### PR TITLE
Fix off-by-one on ReadableStreamingData due to preloading of a byte

### DIFF
--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
@@ -271,4 +271,21 @@ final class ReadableStreamingDataTest extends ReadableTestBase {
         stream.close();
         assertThat(stream.hasRemaining()).isFalse();
     }
+
+    @Test
+    @DisplayName("Reusing an input stream on two ReadableStreamingData does not lose any data")
+    void reuseStream() {
+        final var byteStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+
+        final var bytes1 = new byte[5];
+        final var stream1 = new ReadableStreamingData(byteStream);
+        stream1.readBytes(bytes1);
+
+        final var bytes2 = new byte[5];
+        final var stream2 = new ReadableStreamingData(byteStream);
+        stream2.readBytes(bytes2);
+
+        assertThat(bytes1).containsExactly(1, 2, 3, 4, 5);
+        assertThat(bytes2).containsExactly(6, 7, 8, 9, 10);
+    }
 }


### PR DESCRIPTION
Fix off-by-one error caused by `ReadableStreamingData` preloading a byte. If you use an input stream, and pass it to a `ReadableStreamingData`, and then read with the streaming data, and then create a new `ReadableStreamingData` with the same stream, the second one will be missing one byte. The fix is to require the InputStream passed to `ReadableStreamingData` to support `markSupported`. If it does, then we can make this work. Not sure on performance. Might need another pass later.