### PR TITLE
Replaced `/` with OS-dependent path separator

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -193,7 +193,7 @@ public final class Common {
 	 * @return File object for java file
 	 */
 	public static File getJavaFile(File srcDir, String javaPackage, String className) {
-		File packagePath = new File(srcDir.getPath() + File.separatorChar + javaPackage.replaceAll("\\.",File.separator));
+		File packagePath = new File(srcDir.getPath() + File.separatorChar + javaPackage.replaceAll("\\.","\\" + File.separator));
 		//noinspection ResultOfMethodCallIgnored
 		packagePath.mkdirs();
 		return new File(packagePath,className+".java");

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -10,6 +10,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -319,7 +320,7 @@ public final class LookupHelper {
 						}
 						// now scan all src files to find import as there can be many src directories
 						List<File> matchingSrcFiles = StreamSupport.stream(allSrcFiles.spliterator(), false)
-								.filter(srcFile -> srcFile.getAbsolutePath().endsWith("/" + importedFileName))
+								.filter(srcFile -> srcFile.getAbsolutePath().endsWith(FileSystems.getDefault().getSeparator() + importedFileName))
 								.toList();
 						if (matchingSrcFiles.size() == 1) {
 							fileImports.add(matchingSrcFiles.get(0).getAbsolutePath());
@@ -457,6 +458,7 @@ public final class LookupHelper {
 				}
 			}
 		}
+
 		// insert into maps
 		final var fullQualifiedEnumName = getFullyQualifiedProtoNameForMsgOrEnum(enumDef);
 		pbjPackageMap.put(fullQualifiedEnumName, enumPbjPackage);


### PR DESCRIPTION
**Description**:

Due to the fact that the compiler expect a path separator to be `/`,  PBJ gradle task fails on Windows. 
