### PR TITLE
Fix for issue 37

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -535,6 +535,12 @@ public interface RandomAccessData {
      * @throws IndexOutOfBoundsException If the given {@code offset} is negative or not less than {@link #length()}
      */
     default boolean contains(final long offset, @NonNull final RandomAccessData data) {
+        // If the this data is EMPTY, return true if only the
+        // the incoming data is EMPTY too.
+        if (length() == 0) {
+            return data.length() == 0;
+        }
+
         if (offset < 0 || offset >= length()) {
             throw new IndexOutOfBoundsException();
         }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/BytesTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/BytesTest.java
@@ -382,6 +382,13 @@ final class BytesTest {
     }
 
     @Test
+    void matchesPrefixEmpty_issue37() {
+        final var bytes1 = Bytes.wrap(new byte[0]);
+        final var bytes2 = Bytes.wrap(new byte[0]);
+        assertTrue(bytes1.matchesPrefix(bytes2));
+    }
+
+    @Test
     void matchesPrefixBytesTest() {
         RandomAccessData primary = Bytes.wrap(new byte[]{0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09});
         RandomAccessData prefixGood1 = Bytes.wrap(new byte[]{0x01});


### PR DESCRIPTION
If the data is EMPTY, the contains throws OutOfBoundsException. Add a special code to deal with EMPTY buffers.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
