### PR TITLE
Make readBytes honor the contract of the Java libraries.

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.runtime.io;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.buffer.RandomAccessData;
+import com.hedera.pbj.runtime.io.stream.EOFException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -98,9 +99,15 @@ public interface ReadableSequentialData extends SequentialData {
         // continue to check as we process each byte. This is not efficient for buffers.
         final var length = Math.min(maxLength, remaining());
         final var maxIndex = offset + length;
+        long bytesRead = 0;
         for (int i = offset; i < maxIndex; i++) {
             if (!hasRemaining()) return (long) i - offset;
-            dst[i] = readByte();
+            try {
+                dst[i] = readByte();
+                bytesRead++;
+            } catch (EOFException e) {
+                return bytesRead;
+            }
         }
         return length;
     }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
@@ -10,9 +10,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final class ReadableStreamingDataTest extends ReadableTestBase {
@@ -111,6 +113,21 @@ final class ReadableStreamingDataTest extends ReadableTestBase {
             stream.readBytes(bytes);
             assertThat(stream.position()).isEqualTo(6);
             assertThat(bytes).containsExactly('0', '1', '2', '3', '4', '5');
+            assertThat(stream.hasRemaining()).isFalse();
+            assertThat(stream.remaining()).isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("Read past the data - EOF")
+    void readPastEnd() {
+        try (var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8))) {
+            stream.limit(12);
+            final var bytes = new byte[12];
+            final var read = stream.readBytes(bytes);
+            assertEquals(10, read);
+            assertThat(stream.position()).isEqualTo(10);
+            assertThat(bytes).containsExactly('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 0, 0);
             assertThat(stream.hasRemaining()).isFalse();
             assertThat(stream.remaining()).isZero();
         }
@@ -272,8 +289,9 @@ final class ReadableStreamingDataTest extends ReadableTestBase {
         byte[] read = new byte[5];
         final var stream = new ReadableStreamingData(inputStream);
         assertThrows(EOFException.class, () -> {
-            stream.readBytes(read);
+            final var i = stream.readInt();
         });
+        assertEquals(0, stream.readBytes(read));
     }
 
     @Test


### PR DESCRIPTION
In case of EOF readBytes() doesn't throw anymore, but returns the bytes read.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
