### PR TITLE
Replaced `/` with OS-dependent path separator in the importedFileName to make sure that there is a match.

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -314,7 +314,9 @@ public final class LookupHelper {
 					// process imports
 					final Set<String> fileImports = protoFileImports.computeIfAbsent(fullQualifiedFile, key -> new HashSet<>());
 					for (var importStatement : parsedDoc.importStatement()) {
-						final String importedFileName = importStatement.strLit().getText().replaceAll("\"","");
+						final String importedFileName = importStatement.strLit().getText()
+								.replaceAll("\"","")
+								.replaceAll("/", FileSystems.getDefault().getSeparator());
 						// ignore standard google protobuf imports as we do not need them
 						if (importedFileName.startsWith("google/protobuf")) {
 							continue;


### PR DESCRIPTION
Replaced `/` with OS-dependent path separator in the importedFileName to make sure that there is a match. This makes it work on Windows