### PR TITLE
90: BufferedData slices are still broken

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
@@ -178,7 +178,7 @@ public interface ReadableSequentialData extends SequentialData {
     /**
      * Read {@code length} bytes from this sequence, returning them as a {@link Bytes} buffer of
      * the read data. The returned bytes will be immutable. The {@link #position()} of this sequence will be
-     * incremented by {@code maxLength} bytes.
+     * incremented by {@code length} bytes.
      *
      * <p>Bytes are read from the sequence one at a time. If there are not {@code length} bytes remaining in this
      * sequence, then a {@link BufferUnderflowException} will be thrown. The {@link #position()} will be

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedSequentialData.java
@@ -20,7 +20,8 @@ public interface BufferedSequentialData extends SequentialData, RandomAccessData
 
     /**
      * Set the {@link #limit()} to the current {@link #position()} and the {@link #position()} to the origin. This is
-     * useful when you have just finished writing into a buffer and want to flip it to be ready to read back from.
+     * useful when you have just finished writing into a buffer and want to flip it to be ready to read back from, or
+     * vice versa.
      */
     void flip();
 


### PR DESCRIPTION
A follow-up fix for https://github.com/hashgraph/pbj/issues/83. In complex `BufferedData` methods like `readVarInt()` or `readVarLong()`, which are more than just propagate to the underlying buffer, reading takes array offset (for sliced buffers) into consideration after the fix above. However, when position is updated to skip the bytes read, the offset is still ignored. This PR changes that.

A couple new unit tests are provided.

Fixes: https://github.com/hashgraph/pbj/issues/90
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
