### PR TITLE
Fix issue 87.

### DIFF
--- a/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
+++ b/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
@@ -23,6 +23,7 @@ proto
       | topLevelDef
       | emptyStatement_
       | optionComment
+      | DOC_COMMENT
     )*
   ;
 
@@ -344,7 +345,7 @@ fragment HEX_DIGIT: [0-9A-Fa-f];
 
 // comments
 WS  :   [ \t\r\n\u000C]+ -> skip;
-OPTION_LINE_COMMENT: '//' WS? '<<<' .* '>>>' ~[\r\n]*;
+OPTION_LINE_COMMENT: '//' WS? '<<<' .*? '>>>' ~[\r\n]*;
 LINE_COMMENT: '//' ~[\r\n]* -> skip;
 DOC_COMMENT: '/**' .*? '*/';
 COMMENT: '/*' .*? '*/' -> skip;

--- a/pbj-integration-tests/src/main/proto/timestampTest.proto
+++ b/pbj-integration-tests/src/main/proto/timestampTest.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package proto;
 
+/** Test issue 87 */
+/** Test issue 87 */
+
 /*-
  * ‌
  * Hedera Network Services Protobuf


### PR DESCRIPTION
Couple of fixes to the grammar.

Made a couple of changes in the grammar to fix issues. Allowed DOC_COMMENTS on top level of the file.

The issue here was not an error, but a warning. The runtime was still working properly.

Fixes #87 

