### PR TITLE
59: Improve Bytes Performance

### DIFF
--- a/pbj-core/pbj-runtime/build.gradle.kts
+++ b/pbj-core/pbj-runtime/build.gradle.kts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-plugins { id("com.hedera.pbj.runtime") }
+plugins {
+    id("com.hedera.pbj.runtime")
+    id("me.champeau.jmh").version("0.7.1")
+}
 
 testModuleInfo {
     requires("org.junit.jupiter.api")

--- a/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/BytesGetLong.java
+++ b/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/BytesGetLong.java
@@ -1,0 +1,67 @@
+package com.hedera.pbj.runtime.io;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Random;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class BytesGetLong {
+
+    @Param({"10000"})
+    public int size = 10000;
+
+    private byte[] array;
+
+    private boolean printSum;
+
+    @Setup(Level.Trial)
+    public void init() {
+        System.out.println("Initializing array, size = " + size);
+        array = new byte[size];
+        final Random r = new Random(size);
+        for (int i = 0; i < size; i++) {
+            array[i] = (byte) r.nextInt(127);
+        }
+    }
+
+    @Setup(Level.Iteration)
+    public void initEach() {
+        printSum = true;
+    }
+
+    @Benchmark
+    public void testBytesGetLong(final Blackhole blackhole) {
+        long sum = 0;
+        final Bytes bytes = Bytes.wrap(array);
+        for (int i = 0; i < size + 1 - Long.BYTES; i++) {
+            sum += bytes.getLong(i);
+        }
+        if (printSum) {
+            System.out.println("sum = " + sum);
+            printSum = false;
+        }
+        blackhole.consume(sum);
+    }
+
+    @Benchmark
+    public void testUnsafeGetLong(final Blackhole blackhole) {
+        long sum = 0;
+        for (int i = 0; i < size + 1 - Long.BYTES; i++) {
+            sum += UnsafeUtils.getLong(array, i);
+        }
+        if (printSum) {
+            System.out.println("sum = " + sum);
+            printSum = false;
+        }
+        blackhole.consume(sum);
+    }
+
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/UnsafeUtils.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/UnsafeUtils.java
@@ -1,0 +1,69 @@
+package com.hedera.pbj.runtime.io;
+
+import java.lang.reflect.Field;
+import java.nio.Buffer;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import sun.misc.Unsafe;
+
+/**
+ * A set of utility methods on top of sun.misc.Unsafe
+ */
+public class UnsafeUtils {
+
+    private static final Unsafe UNSAFE;
+
+    private static final boolean NEED_CHANGE_BYTE_ORDER;
+
+    private static final int BYTE_ARRAY_BASE_OFFSET;
+
+    static {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            UNSAFE = (Unsafe) f.get(null);
+            NEED_CHANGE_BYTE_ORDER = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+            BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+            throw new InternalError(e);
+        }
+    }
+
+    private UnsafeUtils() {
+    }
+
+    /**
+     * Reads an integer from the given array starting at the given offset. Array bytes are
+     * interpreted in BIG_ENDIAN order.
+     *
+     * @param arr The byte array
+     * @param offset The offset to read an integer at
+     * @return The integer number
+     * @throws java.nio.BufferOverflowException If array length is less than offset + integer bytes
+     */
+    public static int getInt(final byte[] arr, final int offset) {
+        if (arr.length < offset + Integer.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        final int value = UNSAFE.getInt(arr, BYTE_ARRAY_BASE_OFFSET + offset);
+        return NEED_CHANGE_BYTE_ORDER ? Integer.reverseBytes(value) : value;
+    }
+
+    /**
+     * Reads a long from the given array starting at the given offset. Array bytes are
+     * interpreted in BIG_ENDIAN order.
+     *
+     * @param arr The byte array
+     * @param offset The offset to read a long at
+     * @return The long number
+     * @throws java.nio.BufferOverflowException If array length is less than offset + long bytes
+     */
+    public static long getLong(final byte[] arr, final int offset) {
+        if (arr.length < offset + Long.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        final long value = UNSAFE.getLong(arr, BYTE_ARRAY_BASE_OFFSET + offset);
+        return NEED_CHANGE_BYTE_ORDER ? Long.reverseBytes(value) : value;
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -2,6 +2,7 @@ package com.hedera.pbj.runtime.io.buffer;
 
 import com.hedera.pbj.runtime.io.DataAccessException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.UnsafeUtils;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -11,7 +12,9 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HexFormat;
 
@@ -167,6 +170,26 @@ public final class Bytes implements RandomAccessData {
 
     // ================================================================================================================
     // Object Methods
+
+    @Override
+    public int getInt(final long offset) {
+        return UnsafeUtils.getInt(buffer, Math.toIntExact(offset));
+    }
+
+    @Override
+    public int getInt(final long offset, @NonNull final ByteOrder byteOrder) {
+        return byteOrder == ByteOrder.BIG_ENDIAN ? getInt(offset) : Integer.reverseBytes(getInt(offset));
+    }
+
+    @Override
+    public long getLong(final long offset) {
+        return UnsafeUtils.getLong(buffer, Math.toIntExact(offset));
+    }
+
+    @Override
+    public long getLong(final long offset, @NonNull final ByteOrder byteOrder) {
+        return byteOrder == ByteOrder.BIG_ENDIAN ? getLong(offset) : Long.reverseBytes(getLong(offset));
+    }
 
     /**
      * Duplicate this {@link Bytes} by making a copy of the underlying byte array and returning a new {@link Bytes}
@@ -474,7 +497,7 @@ public final class Bytes implements RandomAccessData {
     /** {@inheritDoc} */
     @NonNull
     @Override
-    public Bytes getBytes(long offset, long length) {
+    public Bytes getBytes(final long offset, final long length) {
         validateOffset(offset);
 
         if (length > this.length - offset) {
@@ -490,11 +513,34 @@ public final class Bytes implements RandomAccessData {
         return new Bytes(buffer, Math.toIntExact(start + offset), Math.toIntExact(length));
     }
 
+    /** {@inheritDoc} */
+    @NonNull
+    @Override
+    public String asUtf8String(long offset, long len) {
+        if (offset < 0 || offset + len > length()) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (len == 0) {
+            return "";
+        }
+        return new String(buffer, Math.toIntExact(offset), length, StandardCharsets.UTF_8);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(long offset, @NonNull byte[] bytes) {
+        validateOffset(offset);
+        final int len = bytes.length;
+        if (offset + len > length()) {
+            return false;
+        }
+        return Arrays.equals(buffer, Math.toIntExact(offset), Math.toIntExact(offset + len), bytes, 0, len);
+    }
 
     /** {@inheritDoc} */
     @NonNull
     @Override
-    public Bytes slice(long offset, long length) {
+    public Bytes slice(final long offset, final long length) {
         return getBytes(offset, length);
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -455,15 +455,10 @@ public interface RandomAccessData {
      * @param offset the offset into the buffer to start reading bytes from
      * @param len the number of bytes to read
      * @return data converted to string
-     * @throws BufferUnderflowException if {@code len} is greater than {@link #length()} - {@code offset}.
      * @throws IndexOutOfBoundsException If the given {@code offset} is negative or not less than {@link #length()}
      */
     @NonNull
     default String asUtf8String(final long offset, final long len) {
-        if (len > length() - offset) {
-            throw new BufferUnderflowException();
-        }
-
         if (offset < 0 || offset + len > length()) {
             throw new IndexOutOfBoundsException();
         }

--- a/pbj-core/pbj-runtime/src/main/java/module-info.java
+++ b/pbj-core/pbj-runtime/src/main/java/module-info.java
@@ -1,6 +1,9 @@
 /** Runtime module of code needed by PBJ generated code at runtime. */
 module com.hedera.pbj.runtime {
+
+    requires jdk.unsupported;
     requires transitive org.antlr.antlr4.runtime;
+
     requires static com.github.spotbugs.annotations;
 
     exports com.hedera.pbj.runtime;

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/BytesTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/BytesTest.java
@@ -21,7 +21,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 final class BytesTest {
@@ -681,10 +683,19 @@ final class BytesTest {
         Bytes b1 = Bytes.wrap(new byte[]{0, 0, (byte)0xFF});
         assertEquals("0000ff", b1.toString());
     }
+
     @Test
     @DisplayName("Changed toString2")
     void changedToString2() {
         Bytes b1 = Bytes.wrap(new byte[]{(byte)0x0f, 0, (byte)0x0a});
         assertEquals("0f000a", b1.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "a", "ab", "abc", "abc123", "✅" })
+    @DisplayName("Overridden asUtf8String")
+    void asUtf8StringTest(final String value) {
+        final Bytes bytes = Bytes.wrap(value.getBytes(StandardCharsets.UTF_8));
+        assertThat(bytes.asUtf8String()).isEqualTo(value);
     }
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/UnsafeUtilsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/UnsafeUtilsTest.java
@@ -1,0 +1,64 @@
+package com.hedera.pbj.runtime.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class UnsafeUtilsTest {
+
+    // RandomAccessData.getInt()
+    private static int getInt(final byte[] arr, final int offset) {
+        final byte b1 = arr[offset];
+        final byte b2 = arr[offset + 1];
+        final byte b3 = arr[offset + 2];
+        final byte b4 = arr[offset + 3];
+        return ((b1 & 0xFF) << 24) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 8) | (b4 & 0xFF);
+    }
+
+    // RandomAccessData.getLong()
+    private static long getLong(final byte[] arr, final int offset) {
+        final byte b1 = arr[offset];
+        final byte b2 = arr[offset + 1];
+        final byte b3 = arr[offset + 2];
+        final byte b4 = arr[offset + 3];
+        final byte b5 = arr[offset + 4];
+        final byte b6 = arr[offset + 5];
+        final byte b7 = arr[offset + 6];
+        final byte b8 = arr[offset + 7];
+        return (((long)b1 << 56) +
+                ((long)(b2 & 255) << 48) +
+                ((long)(b3 & 255) << 40) +
+                ((long)(b4 & 255) << 32) +
+                ((long)(b5 & 255) << 24) +
+                ((b6 & 255) << 16) +
+                ((b7 & 255) <<  8) +
+                (b8 & 255));
+    }
+
+    // Tests that UnsafeUtils.getInt() and RandomAccessData.getInt() produce the same results
+    @Test
+    void getIntTest() {
+        final int SIZE = 1000;
+        final byte[] src = new byte[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            src[i] = (byte) (i % 111);
+        }
+        for (int i = 0; i < SIZE + 1 - Integer.BYTES; i++) {
+            assertEquals(getInt(src, i), UnsafeUtils.getInt(src, i));
+        }
+    }
+
+    // Tests that UnsafeUtils.getLong() and RandomAccessData.getLong() produce the same results
+    @Test
+    void getLongTest() {
+        final int SIZE = 1000;
+        final byte[] src = new byte[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            src[i] = (byte) (i % 111);
+        }
+        for (int i = 0; i < SIZE + 1 - Long.BYTES; i++) {
+            assertEquals(getLong(src, i), UnsafeUtils.getLong(src, i));
+        }
+    }
+    
+}


### PR DESCRIPTION
Fix summary:
* UnsafeUtils class is added to provide a set of classes on top of sun.misc.Unsafe
* Bytes.getInt() and getLong() are implemented using UnsafeUtils
* A few other Bytes methods are overridden to provide more efficient implementation than what's in RandomAccessData: contains(), asUtf8String()

Testing:
* Unit tests for UnsafeUtils.getInt() and getLong() are added
* Unit tests for overridden Bytes methods are added
* A JMH benchmark for the old and the new getInt() and getLong() implementations is provided

Fixes: https://github.com/hashgraph/pbj/issues/59
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
