### PR TITLE
fix: configuration issues preventing proper publishing of Maven Central and Gradle plugin artifacts

### DIFF
--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
@@ -25,7 +25,6 @@ plugins {
     id("com.hedera.pbj.spotless-conventions")
     id("com.hedera.pbj.spotless-java-conventions")
     id("com.hedera.pbj.spotless-kotlin-conventions")
-    id("com.hedera.pbj.maven-publish")
 }
 
 group = "com.hedera.pbj"

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
@@ -25,3 +25,10 @@ tasks.generateGrammarSource {
 
 // Do not generate Java Doc for generated antlr grammar
 tasks.withType<Javadoc> { excludes.add("com/hedera/pbj/compiler/impl/grammar/**") }
+
+tasks.register("release-maven-central") {
+    group = "release"
+    dependsOn(tasks.named("publishPlugins"))
+}
+
+tasks.register("release-maven-central-snapshot") { group = "release" }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.runtime.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.runtime.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("java-library")
     id("com.hedera.pbj.conventions")
     id("com.google.protobuf") // protobuf plugin is only used for tests
+    id("com.hedera.pbj.maven-publish")
 }
 
 tasks.generateGrammarSource {


### PR DESCRIPTION
## Description

This pull request changes the following:

- Fixes Gradle plugin portal publishing
- Fixes Maven Central publishes

### Related Issues

- Related to #92 
- Closes #112 