### PR TITLE
fix: sign when publishing to central / metadata for all publications

### DIFF
--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     id("com.hedera.pbj.spotless-conventions")
     id("com.hedera.pbj.spotless-java-conventions")
     id("com.hedera.pbj.spotless-kotlin-conventions")
+    id("com.hedera.pbj.maven-publish")
 }
 
 group = "com.hedera.pbj"

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.maven-publish.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.maven-publish.gradle.kts
@@ -60,46 +60,10 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            name = "sonatype"
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_PASSWORD")
-            }
-        }
-        maven {
-            name = "sonatypeSnapshot"
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_PASSWORD")
-            }
-        }
-    }
 }
 
 signing { useGpgCmd() }
 
 tasks.withType<Sign> {
     onlyIf { providers.gradleProperty("publishSigningEnabled").getOrElse("false").toBoolean() }
-}
-
-tasks.register("release-maven-central") {
-    group = "release"
-    dependsOn(
-        tasks.withType<PublishToMavenRepository>().matching {
-            it.name.endsWith("ToSonatypeRepository")
-        }
-    )
-}
-
-tasks.register("release-maven-central-snapshot") {
-    group = "release"
-    dependsOn(
-        tasks.withType<PublishToMavenRepository>().matching {
-            it.name.endsWith("ToSonatypeSnapshotRepository")
-        }
-    )
 }


### PR DESCRIPTION
While the signing for Gradle plugins published to the Plugin Portal is automatically done (through `com.gradle.plugin-publish`), it needs to be explicitly defined for publishing to "normal" maven repositories like central.

This PR adds this back (was accidentally removed in #92).

This PR also partially reverts #113 so that all publishing configuration that should be used for **both** Plugin Portal and Maven Central is kept in `com.hedera.pbj.maven-publish.gradle.kts` and used by all projects. This concerns the informal metadata for POM files and the general signing setup.
