### PR TITLE
Reverted removal of `id("com.hedera.pbj.aggregate-reports")`

### DIFF
--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
     id("com.hedera.pbj.repositories")
+    id("com.hedera.pbj.aggregate-reports")
     id("com.hedera.pbj.spotless-conventions")
     id("com.hedera.pbj.spotless-kotlin-conventions")
     id("com.autonomousapps.dependency-analysis")


### PR DESCRIPTION
Reverted removal of `id("com.hedera.pbj.aggregate-reports")`

Related to #109 
