### PR TITLE
127: HAPI tests are failing with 0.7.7

### DIFF
--- a/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/BufferedDataGetBytes.java
+++ b/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/BufferedDataGetBytes.java
@@ -25,8 +25,6 @@ public class BufferedDataGetBytes {
     private BufferedData heapData;
     private BufferedData directData;
 
-    private boolean printSum;
-
     @Setup(Level.Trial)
     public void init() {
         heapData = BufferedData.allocate(size);
@@ -37,160 +35,74 @@ public class BufferedDataGetBytes {
         }
     }
 
-    @Setup(Level.Iteration)
-    public void initEach() {
-        printSum = true;
-    }
-
-    private static long sum(final byte[] arr) {
-        long result = 0;
-        for (int i = 0; i < arr.length; i++) {
-            result += arr[i];
-        }
-        return result;
-    }
-
-    private static long sum(final ByteBuffer buf) {
-        long result = 0;
-        for (int i = 0; i < buf.capacity(); i++) {
-            result += buf.get(i);
-        }
-        return result;
-    }
-
-    private static long sum(final Bytes bytes) {
-        long result = 0;
-        for (int i = 0; i < bytes.length(); i++) {
-            result += bytes.getByte(i);
-        }
-        return result;
-    }
-
     @Benchmark
     public void heapToByteArray(final Blackhole blackhole) {
         final byte[] dst = new byte[window];
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             heapData.getBytes(i, dst);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void heapToHeapByteBuffer(final Blackhole blackhole) {
         final ByteBuffer dst = ByteBuffer.allocate(window);
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             heapData.getBytes(i, dst);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void heapToDirectByteBuffer(final Blackhole blackhole) {
         final ByteBuffer dst = ByteBuffer.allocateDirect(window);
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             heapData.getBytes(i, dst);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void heapToBytes(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             final Bytes bytes = heapData.getBytes(i, window);
-//            sum += sum(bytes);
             blackhole.consume(bytes);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void directToByteArray(final Blackhole blackhole) {
         final byte[] dst = new byte[window];
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             directData.getBytes(i, dst);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void directToHeapByteBuffer(final Blackhole blackhole) {
         final ByteBuffer dst = ByteBuffer.allocate(window);
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             directData.getBytes(i, dst);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void directToDirectByteBuffer(final Blackhole blackhole) {
         final ByteBuffer dst = ByteBuffer.allocateDirect(window);
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             directData.getBytes(i, dst);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void directToBytes(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             final Bytes bytes = directData.getBytes(i, window);
-//            sum += sum(bytes);
             blackhole.consume(bytes);
         }
-        if (printSum) {
-//            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
-
 
 }

--- a/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/ByteBufferGetByte.java
+++ b/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/ByteBufferGetByte.java
@@ -20,8 +20,6 @@ public class ByteBufferGetByte {
     private ByteBuffer heapBuffer;
     private ByteBuffer directBuffer;
 
-    private boolean printSum;
-
     @Setup(Level.Trial)
     public void init() {
         heapBuffer = ByteBuffer.allocate(size);
@@ -32,11 +30,6 @@ public class ByteBufferGetByte {
         }
     }
 
-    @Setup(Level.Iteration)
-    public void initEach() {
-        printSum = true;
-    }
-
     @Setup(Level.Invocation)
     public void initEachInvocation() {
         heapBuffer.clear();
@@ -45,87 +38,45 @@ public class ByteBufferGetByte {
 
     @Benchmark
     public void heapArrayGet(final Blackhole blackhole) {
-        long sum = 0;
         final byte[] array = heapBuffer.array();
         for (int i = 0; i < size; i++) {
-//            sum += array[i];
             blackhole.consume(array[i]);
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void heapBufferGet(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size; i++) {
-//            sum += heapBuffer.get(i);
             blackhole.consume(heapBuffer.get(i));
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void heapBufferRead(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size; i++) {
-//            sum += heapBuffer.get();
             blackhole.consume(heapBuffer.get());
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void directBufferGet(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size; i++) {
-//            sum += directBuffer.get(i);
             blackhole.consume(directBuffer.get(i));
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void heapUnsafeGet(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size; i++) {
-//            sum += UnsafeUtils.getByteHeap(heapBuffer, i);
             blackhole.consume(UnsafeUtils.getByteHeap(heapBuffer, i));
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void directUnsafeGet(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size; i++) {
-//            sum += UnsafeUtils.getByteDirect(directBuffer, i);
             blackhole.consume(UnsafeUtils.getByteDirect(directBuffer, i));
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
 }

--- a/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/ByteBufferGetBytes.java
+++ b/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/ByteBufferGetBytes.java
@@ -23,8 +23,6 @@ public class ByteBufferGetBytes {
     private ByteBuffer heapBuffer;
     private ByteBuffer directBuffer;
 
-    private boolean printSum;
-
     @Setup(Level.Trial)
     public void init() {
         heapBuffer = ByteBuffer.allocate(size);
@@ -35,129 +33,66 @@ public class ByteBufferGetBytes {
         }
     }
 
-    @Setup(Level.Iteration)
-    public void initEach() {
-        printSum = true;
-    }
-
-    private static long sum(final byte[] arr) {
-        long result = 0;
-        for (int i = 0; i < arr.length; i++) {
-            result += arr[i];
-        }
-        return result;
-    }
-
-    private static long sum(final ByteBuffer buf) {
-        long result = 0;
-        for (int i = 0; i < buf.capacity(); i++) {
-            result += buf.get(i);
-        }
-        return result;
-    }
-
     // Heap buffer -> byte[] using System.arraycopy()
     @Benchmark
     public void arrayCopy(final Blackhole blackhole) {
         final byte[] dst = new byte[window];
         final byte[] src = heapBuffer.array();
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             System.arraycopy(src, i, dst, 0, window);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     // Heap buffer -> byte[] using ByteBuffer.get()
     @Benchmark
     public void heapBufferGet(final Blackhole blackhole) {
         final byte[] dst = new byte[window];
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             heapBuffer.position(i);
             heapBuffer.get(dst, 0, window);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     // Direct buffer -> byte[] using ByteBuffer.get()
     @Benchmark
     public void directBufferGet(final Blackhole blackhole) {
         final byte[] dst = new byte[window];
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             directBuffer.position(i);
             directBuffer.get(dst, 0, window);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     // Heap buffer -> byte[] using Unsafe
     @Benchmark
     public void unsafeHeapGet(final Blackhole blackhole) {
         final byte[] dst = new byte[window];
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             UnsafeUtils.getHeapBufferToArray(heapBuffer, i, dst, 0, window);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     // Direct buffer -> byte[] using Unsafe
     @Benchmark
     public void unsafeDirectBytes(final Blackhole blackhole) {
         final byte[] dst = new byte[window];
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             UnsafeUtils.getDirectBufferToArray(directBuffer, i, dst, 0, window);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     // Direct buffer -> direct buffer using Unsafe
     @Benchmark
     public void unsafeDirectBuffer(final Blackhole blackhole) {
         final ByteBuffer dst = ByteBuffer.allocateDirect(window);
-        long sum = 0;
         for (int i = 0; i < size - window; i++) {
             UnsafeUtils.getDirectBufferToDirectBuffer(directBuffer, i, dst, 0, window);
-//            sum += sum(dst);
             blackhole.consume(dst);
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 }

--- a/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/BytesGetLong.java
+++ b/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/BytesGetLong.java
@@ -20,11 +20,8 @@ public class BytesGetLong {
 
     private byte[] array;
 
-    private boolean printSum;
-
     @Setup(Level.Trial)
     public void init() {
-        System.out.println("Initializing array, size = " + size);
         array = new byte[size];
         final Random r = new Random(size);
         for (int i = 0; i < size; i++) {
@@ -32,36 +29,19 @@ public class BytesGetLong {
         }
     }
 
-    @Setup(Level.Iteration)
-    public void initEach() {
-        printSum = true;
-    }
-
     @Benchmark
     public void testBytesGetLong(final Blackhole blackhole) {
-        long sum = 0;
         final Bytes bytes = Bytes.wrap(array);
         for (int i = 0; i < size + 1 - Long.BYTES; i++) {
-            sum += bytes.getLong(i);
+            blackhole.consume(bytes.getLong(i));
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
     @Benchmark
     public void testUnsafeGetLong(final Blackhole blackhole) {
-        long sum = 0;
         for (int i = 0; i < size + 1 - Long.BYTES; i++) {
-            sum += UnsafeUtils.getLong(array, i);
+            blackhole.consume(UnsafeUtils.getLong(array, i));
         }
-        if (printSum) {
-            System.out.println("sum = " + sum);
-            printSum = false;
-        }
-        blackhole.consume(sum);
     }
 
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/UnsafeUtils.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/UnsafeUtils.java
@@ -49,17 +49,6 @@ public class UnsafeUtils {
     }
 
     /**
-     * Get byte array element at a given offset. Identical to arr[offset], but slightly
-     * faster on some systems
-     */
-    public static byte getByte(final byte[] arr, final int offset) {
-        if (arr.length < offset + 1) {
-            throw new BufferUnderflowException();
-        }
-        return UNSAFE.getByte(arr, BYTE_ARRAY_BASE_OFFSET + offset);
-    }
-
-    /**
      * Get heap byte buffer element at a given offset. Identical to buf.get(offset), but
      * slightly faster on some systems. May only be called for Java heap byte buffers
      */

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -506,8 +506,8 @@ public interface RandomAccessData {
         }
 
         // Check each byte one at a time until we find a mismatch or, we get to the end, and all bytes match.
-        for (long i = offset; i < bytes.length; i++) {
-            if (bytes[Math.toIntExact(i)] != getByte(i)) {
+        for (int i = 0; i < bytes.length; i++) {
+            if (bytes[i] != getByte(offset + i)) {
                 return false;
             }
         }


### PR DESCRIPTION
Fix summary:

* Fixed `Bytes.getInt()`, `Bytes.getLong()`, `Bytes.contains()`, and `Bytes.asUtf8String()` methods, when `start` field of the Bytes object is not zero
* Fixed `RandomAccessData.contains()` method to check bytes up to `offset + bytes.length` rather than to just `bytes.length`
* Improved `Bytes.validateOffset()` method, so it now rejects offsets greater or equal to length (was: greater than length)

Testing:

* New unit tests are added for the fixed methods (getInt(), getLong(), contains())
* These new tests are applicable both to `Bytes` and `BufferedData` (and all its subclasses)

Fixes: https://github.com/hashgraph/pbj/issues/127
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
