### PR TITLE
fix: 27: ReadableStreamingData should implement bulk read methods

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
@@ -12,7 +12,6 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Objects;
 
 /**
  * A buffer backed by a {@link ByteBuffer} that is a {@link BufferedSequentialData} (and therefore contains
@@ -756,56 +755,6 @@ public sealed class BufferedData
             buf.writeTo(buffer);
         } else {
             WritableSequentialData.super.writeBytes(src);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int writeBytes(@NonNull final InputStream src, final int maxLength) {
-        if (!buffer.hasArray()) {
-            return WritableSequentialData.super.writeBytes(src, maxLength);
-        }
-
-        // Check for a bad length or a null src
-        Objects.requireNonNull(src);
-        if (maxLength < 0) {
-            throw new IllegalArgumentException("The length must be >= 0");
-        }
-
-        // If the length is zero, then we have nothing to read
-        if (maxLength == 0) {
-            return 0;
-        }
-
-        // Since we have an inner array, we can just read from the input stream into that
-        // array over and over until either we read all the bytes we need to, or we hit
-        // the end of the stream, or we have read all that we can.
-        final var array = buffer.array();
-
-        // We are going to read from the input stream up to either "len" or the number of bytes
-        // remaining in this buffer, whichever is lesser.
-        final long numBytesToRead = Math.min(maxLength, remaining());
-        if (numBytesToRead == 0) {
-            return 0;
-        }
-
-        try {
-            int totalBytesRead = 0;
-            while (totalBytesRead < numBytesToRead) {
-                int numBytesRead = src.read(array, buffer.position() + buffer.arrayOffset(), (int) numBytesToRead - totalBytesRead);
-                if (numBytesRead == -1) {
-                    return totalBytesRead;
-                }
-
-                buffer.position(buffer.position() + numBytesRead);
-                totalBytesRead += numBytesRead;
-            }
-
-            return totalBytesRead;
-        } catch (IOException e) {
-            throw new DataAccessException(e);
         }
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
@@ -193,6 +193,7 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
     public void writeBytes(@NonNull final ByteBuffer src) {
         if (!src.hasArray()) {
             WritableSequentialData.super.writeBytes(src);
+            return;
         }
 
         if (remaining() < src.remaining()) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
@@ -3,12 +3,10 @@ package com.hedera.pbj.runtime.io.stream;
 import com.hedera.pbj.runtime.io.DataAccessException;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.FilterOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /**
@@ -83,7 +81,7 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
 
     /** {@inheritDoc} */
     @Override
-    public void limit(long limit) {
+    public void limit(final long limit) {
         // Any attempt to set the limit must be clamped between position on the low end and capacity on the high end.
         this.limit = Math.min(capacity(), Math.max(position, limit));
     }
@@ -136,7 +134,7 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
      * {@inheritDoc}
      */
     @Override
-    public void writeByte(byte b) {
+    public void writeByte(final byte b) {
         if (position >= limit) {
             throw new BufferOverflowException();
         }
@@ -153,7 +151,7 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
      * {@inheritDoc}
      */
     @Override
-    public void writeBytes(@NonNull byte[] src, int offset, int length) {
+    public void writeBytes(@NonNull final byte[] src, final int offset, final int length) {
         if (length < 0) {
             throw new IllegalArgumentException("length must be >= 0");
         }
@@ -169,7 +167,7 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
         try {
             out.write(src, offset, length);
             position += length;
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new DataAccessException(e);
         }
     }
@@ -178,7 +176,7 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
      * {@inheritDoc}
      */
     @Override
-    public void writeBytes(@NonNull byte[] src) {
+    public void writeBytes(@NonNull final byte[] src) {
         if (src.length > remaining()) {
             throw new BufferOverflowException();
         }
@@ -186,7 +184,34 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
         try {
             out.write(src);
             position += src.length;
-        } catch (IOException e) {
+        } catch (final IOException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    @Override
+    public void writeBytes(@NonNull final ByteBuffer src) {
+        if (!src.hasArray()) {
+            WritableSequentialData.super.writeBytes(src);
+        }
+
+        if (remaining() < src.remaining()) {
+            throw new BufferOverflowException();
+        }
+
+        final long len = src.remaining();
+        if (len == 0) {
+            // Nothing to do
+            return;
+        }
+
+        final byte[] srcArr = src.array();
+        final int srcPos = src.position();
+        try {
+            out.write(srcArr, srcPos, Math.toIntExact(len));
+            position += len;
+            src.position(Math.toIntExact(srcPos + len));
+        } catch (final IOException e) {
             throw new DataAccessException(e);
         }
     }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
@@ -3,7 +3,8 @@ package com.hedera.pbj.runtime.io;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.BufferUnderflowException;
 
-final class ReadableSequentialDataTest extends ReadableTestBase {
+final class ReadableSequentialDataTest extends ReadableSequentialTestBase {
+
     @NonNull
     @Override
     protected ReadableSequentialData emptySequence() {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
@@ -1,0 +1,207 @@
+package com.hedera.pbj.runtime.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public abstract class ReadableSequentialTestBase extends ReadableTestBase {
+
+    @NonNull
+    @Override
+    protected abstract ReadableSequentialData emptySequence();
+
+    @NonNull
+    @Override
+    protected abstract ReadableSequentialData fullyUsedSequence();
+
+    @Override
+    @NonNull
+    protected abstract ReadableSequentialData sequence(@NonNull byte [] arr);
+
+    @Test
+    @DisplayName("Stream with no data")
+    void noDataTest() throws Exception {
+        final var stream = emptySequence();
+        try {
+            assertThat(stream.remaining()).isZero();
+            assertThat(stream.hasRemaining()).isFalse();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Stream with data")
+    void someDataTest() throws Exception {
+        final var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8));
+        try {
+            assertThat(stream.hasRemaining()).isTrue();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Read some bytes")
+    void readSomeBytesTest() throws Exception {
+        final var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8));
+        try {
+            final var bytes = new byte[4];
+            final long bytesRead = stream.readBytes(bytes);
+            assertThat(bytesRead).isEqualTo(bytes.length);
+            assertThat(stream.position()).isEqualTo(4);
+            assertThat(bytes).containsExactly('W', 'h', 'a', 't');
+            assertThat(stream.hasRemaining()).isTrue();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Read some bytes, skip some bytes, read some more bytes")
+    void readSomeSkipSomeTest() throws Exception {
+        final var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8));
+        try {
+            final var bytes = new byte[5];
+            stream.readBytes(bytes, 0, 4);
+            assertThat(stream.position()).isEqualTo(4);
+            assertThat(bytes).containsExactly('W', 'h', 'a', 't', 0);
+            assertThat(stream.skip(3)).isEqualTo(3);
+            assertThat(stream.position()).isEqualTo(7);
+            stream.readBytes(bytes);
+            assertThat(stream.position()).isEqualTo(12);
+            assertThat(bytes).containsExactly('d', 'r', 'e', 'a', 'm');
+            assertThat(stream.hasRemaining()).isTrue();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Skip some bytes, read some bytes")
+    void skipSomeReadSomeTest() throws Exception {
+        final var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8));
+        try {
+            assertThat(stream.skip(7)).isEqualTo(7);
+            final var bytes = new byte[5];
+            stream.readBytes(bytes);
+            assertThat(stream.position()).isEqualTo(12);
+            assertThat(bytes).containsExactly('d', 'r', 'e', 'a', 'm');
+            assertThat(stream.hasRemaining()).isTrue();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Read up to some limit on the stream which is less than its total length")
+    void readToLimit() throws Exception {
+        final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
+        try {
+            stream.limit(6);
+            final var bytes = new byte[6];
+            stream.readBytes(bytes);
+            assertThat(stream.position()).isEqualTo(6);
+            assertThat(bytes).containsExactly('0', '1', '2', '3', '4', '5');
+            assertThat(stream.hasRemaining()).isFalse();
+            assertThat(stream.remaining()).isZero();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Read past the data - EOF")
+    void readPastEnd() throws Exception {
+        final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
+        try {
+            stream.limit(12);
+            final var bytes = new byte[12];
+            final var read = stream.readBytes(bytes);
+            assertEquals(10, read);
+            assertThat(stream.position()).isEqualTo(10);
+            assertThat(bytes).containsExactly('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 0, 0);
+            assertThat(stream.hasRemaining()).isFalse();
+            assertThat(stream.remaining()).isZero();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Read up to some limit and then extend the limit")
+    void readToLimitAndExtend() throws Exception {
+        final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
+        try {
+            final var bytes = new byte[6];
+            stream.limit(6);
+            stream.readBytes(bytes);
+            assertThat(stream.hasRemaining()).isFalse();
+            assertThat(stream.remaining()).isZero();
+
+            stream.limit(10);
+            stream.readBytes(bytes, 0, 4);
+            assertThat(stream.position()).isEqualTo(10);
+            assertThat(bytes).containsExactly('6', '7', '8', '9', '4', '5');
+            assertThat(stream.hasRemaining()).isFalse();
+            assertThat(stream.remaining()).isZero();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Limit snaps to position if set to less than position")
+    void limitNotBeforePosition() throws Exception {
+        final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
+        try {
+            final var bytes = new byte[5];
+            stream.readBytes(bytes);
+            assertThat(stream.hasRemaining()).isTrue();
+            assertThat(stream.limit()).isEqualTo(10);
+            assertThat(stream.position()).isEqualTo(5);
+            stream.limit(2);
+            assertThat(stream.position()).isEqualTo(5);
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Skipping more bytes than are available")
+    void skipMoreThanAvailable() throws Exception {
+        final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
+        try {
+            assertThat(stream.skip(20)).isEqualTo(10);
+            assertThat(stream.hasRemaining()).isFalse();
+            assertThat(stream.remaining()).isZero();
+        } finally {
+            if (stream instanceof AutoCloseable closeable) {
+                closeable.close();
+            }
+        }
+    }
+
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableSequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableSequentialDataTest.java
@@ -4,7 +4,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.BufferOverflowException;
 import java.util.Arrays;
 
-public class WritableSequentialDataTest extends WritableTestBase {
+final class WritableSequentialDataTest extends WritableTestBase {
+
     @NonNull
     @Override
     protected WritableSequentialData sequence() {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
@@ -523,6 +523,21 @@ public abstract class WritableTestBase extends SequentialTestBase {
         }
 
         @Test
+        @DisplayName("Writing bytes from a direct ByteBuffer")
+        void writeSrcDirectByteBufferWithOffset() {
+            final var seq = sequence();
+            final int LEN = 10;
+            seq.limit(LEN);
+            final var src = ByteBuffer.allocateDirect(LEN);
+            src.put(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+            src.flip();
+            final var pos = seq.position();
+            seq.writeBytes(src);
+            assertThat(extractWrittenBytes(seq)).isEqualTo(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+            assertThat(seq.position()).isEqualTo(pos + 10);
+        }
+
+        @Test
         @DisplayName("Writing bytes from a src BufferedData where the src is the same length as the sequence limit")
         void writeSrcBufferedData() {
             final var seq = sequence();

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.ReadableSequentialTestBase;
 import com.hedera.pbj.runtime.io.ReadableTestBase;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.WritableTestBase;
@@ -185,7 +186,7 @@ abstract class BufferedDataTestBase {
     }
 
     @Nested
-    final class ReadableSequentialDataTest extends ReadableTestBase {
+    final class ReadableSequentialDataTest extends ReadableSequentialTestBase {
 
         @NonNull
         @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
@@ -1,7 +1,7 @@
 package com.hedera.pbj.runtime.io.stream;
 
 import com.hedera.pbj.runtime.io.DataAccessException;
-import com.hedera.pbj.runtime.io.ReadableTestBase;
+import com.hedera.pbj.runtime.io.ReadableSequentialTestBase;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,14 +10,13 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-final class ReadableStreamingDataTest extends ReadableTestBase {
+final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
 
     @NonNull
     @Override
@@ -43,150 +42,6 @@ final class ReadableStreamingDataTest extends ReadableTestBase {
         final var stream = new ReadableStreamingData(new ByteArrayInputStream(arr));
         stream.limit(arr.length);
         return stream;
-    }
-
-    @Test
-    @DisplayName("Stream with no data")
-    void noDataTest() {
-        try (var stream = emptySequence()) {
-            assertThat(stream.remaining()).isZero();
-            assertThat(stream.hasRemaining()).isFalse();
-        }
-    }
-
-    @Test
-    @DisplayName("Stream with data")
-    void someDataTest() {
-        try (var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8))) {
-            assertThat(stream.hasRemaining()).isTrue();
-        }
-    }
-
-    @Test
-    @DisplayName("Read some bytes")
-    void readSomeBytesTest() {
-        try (var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8))) {
-            final var bytes = new byte[4];
-            stream.readBytes(bytes);
-            assertThat(stream.position()).isEqualTo(4);
-            assertThat(bytes).containsExactly('W', 'h', 'a', 't');
-            assertThat(stream.hasRemaining()).isTrue();
-        }
-    }
-
-    @Test
-    @DisplayName("Read some bytes, skip some bytes, read some more bytes")
-    void readSomeSkipSomeTest() {
-        try (var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8))) {
-            final var bytes = new byte[5];
-            stream.readBytes(bytes, 0, 4);
-            assertThat(stream.position()).isEqualTo(4);
-            assertThat(bytes).containsExactly('W', 'h', 'a', 't', 0);
-            assertThat(stream.skip(3)).isEqualTo(3);
-            assertThat(stream.position()).isEqualTo(7);
-            stream.readBytes(bytes);
-            assertThat(stream.position()).isEqualTo(12);
-            assertThat(bytes).containsExactly('d', 'r', 'e', 'a', 'm');
-            assertThat(stream.hasRemaining()).isTrue();
-        }
-    }
-
-    @Test
-    @DisplayName("Skip some bytes, read some bytes")
-    void skipSomeReadSomeTest() {
-        try (var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8))) {
-            assertThat(stream.skip(7)).isEqualTo(7);
-            final var bytes = new byte[5];
-            stream.readBytes(bytes);
-            assertThat(stream.position()).isEqualTo(12);
-            assertThat(bytes).containsExactly('d', 'r', 'e', 'a', 'm');
-            assertThat(stream.hasRemaining()).isTrue();
-        }
-    }
-
-    @Test
-    @DisplayName("Read up to some limit on the stream which is less than its total length")
-    void readToLimit() {
-        try (var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8))) {
-            stream.limit(6);
-            final var bytes = new byte[6];
-            stream.readBytes(bytes);
-            assertThat(stream.position()).isEqualTo(6);
-            assertThat(bytes).containsExactly('0', '1', '2', '3', '4', '5');
-            assertThat(stream.hasRemaining()).isFalse();
-            assertThat(stream.remaining()).isZero();
-        }
-    }
-
-    @Test
-    @DisplayName("Read past the data - EOF")
-    void readPastEnd() {
-        try (var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8))) {
-            stream.limit(12);
-            final var bytes = new byte[12];
-            final var read = stream.readBytes(bytes);
-            assertEquals(10, read);
-            assertThat(stream.position()).isEqualTo(10);
-            assertThat(bytes).containsExactly('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 0, 0);
-            assertThat(stream.hasRemaining()).isFalse();
-            assertThat(stream.remaining()).isZero();
-        }
-    }
-
-    @Test
-    @DisplayName("Read up to some limit and then extend the limit")
-    void readToLimitAndExtend() {
-        try (var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8))) {
-            final var bytes = new byte[6];
-            stream.limit(6);
-            stream.readBytes(bytes);
-            assertThat(stream.hasRemaining()).isFalse();
-            assertThat(stream.remaining()).isZero();
-
-            stream.limit(10);
-            stream.readBytes(bytes, 0, 4);
-            assertThat(stream.position()).isEqualTo(10);
-            assertThat(bytes).containsExactly('6', '7', '8', '9', '4', '5');
-            assertThat(stream.hasRemaining()).isFalse();
-            assertThat(stream.remaining()).isZero();
-        }
-    }
-
-    @Test
-    @DisplayName("Limit is not changed when we get to the end of the stream")
-    void limitNotChanged() {
-        // The semantics are now that the stream doesn't know if it has reached the end until you
-        // try to read past the end, at which point you get a BufferUnderflowException.
-        try (var stream = new ReadableStreamingData(new ByteArrayInputStream(new byte[] {1, 2, 3}))) {
-            final var bytes = new byte[3];
-            stream.readBytes(bytes);
-            assertThat(stream.hasRemaining()).isTrue();
-            assertThat(stream.limit()).isEqualTo(Long.MAX_VALUE);
-        }
-    }
-
-    @Test
-    @DisplayName("Limit snaps to position if set to less than position")
-    void limitNotBeforePosition() {
-        try (var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8))) {
-            final var bytes = new byte[5];
-            stream.readBytes(bytes);
-            assertThat(stream.hasRemaining()).isTrue();
-            assertThat(stream.limit()).isEqualTo(10);
-            assertThat(stream.position()).isEqualTo(5);
-            stream.limit(2);
-            assertThat(stream.position()).isEqualTo(5);
-        }
-    }
-
-    @Test
-    @DisplayName("Skipping more bytes than are available")
-    void skipMoreThanAvailable() {
-        try (var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8))) {
-            assertThat(stream.skip(20)).isEqualTo(10);
-            assertThat(stream.hasRemaining()).isFalse();
-            assertThat(stream.remaining()).isZero();
-        }
     }
 
     @Test
@@ -223,7 +78,7 @@ final class ReadableStreamingDataTest extends ReadableTestBase {
 
     @Test
     @DisplayName("Bad InputStream will fail on skip")
-    void inputStreamFailsDuringSkip() throws IOException {
+    void inputStreamFailsDuringSkip() {
         final var byteStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7 });
         final var inputStream = new BufferedInputStream(byteStream) {
             @Override
@@ -310,4 +165,19 @@ final class ReadableStreamingDataTest extends ReadableTestBase {
         assertThat(bytes1).containsExactly(1, 2, 3, 4, 5);
         assertThat(bytes2).containsExactly(6, 7, 8, 9, 10);
     }
+
+    @Test
+    @DisplayName("Limit is not changed when we get to the end of the stream")
+    void limitNotChanged() {
+        final var byteStream = new ByteArrayInputStream(new byte[] {1, 2, 3});
+        // The semantics are now that the stream doesn't know if it has reached the end until you
+        // try to read past the end, at which point you get a BufferUnderflowException.
+        try (final var stream = new ReadableStreamingData(byteStream)) {
+            final var bytes = new byte[3];
+            stream.readBytes(bytes);
+            assertThat(stream.hasRemaining()).isTrue();
+            assertThat(stream.limit()).isEqualTo(Long.MAX_VALUE);
+        }
+    }
+
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
@@ -1,18 +1,15 @@
 package com.hedera.pbj.runtime.io.stream;
 
 import com.hedera.pbj.runtime.io.DataAccessException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.WritableTestBase;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -22,9 +19,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class WritableStreamingDataTest extends WritableTestBase {
+
     private ByteArrayOutputStream out;
 
     @NonNull


### PR DESCRIPTION
Fix summary:

* `readBytes()` methods are implemented in `ReadableStreamingData` in a more efficient way than inherited from `ReadableSequentialData`
* Unit tests are refactored, so some tests previously run for `ReadableStreamingData` only now are also used for other implementations of `ReadableSequentialData` (e.g. `BufferedData`)

Fixes: https://github.com/hashgraph/pbj/issues/27
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
