### PR TITLE
fix: properly generate code and pass tests when protobuf message definition is empty

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -522,13 +522,8 @@ public final class ModelGenerator implements Generator {
 			     * Create an empty builder
 			     */
 			    public Builder() {}
-		
-			    /**
-			     * Create a pre-populated builder
-			     * $constructorParamDocs
-			     */
-			    public Builder($constructorParams) {
-			$constructorCode    }
+			    
+			    $prePopulatedBuilder
 		
 			    /**
 			     * Build a new model record with data set on builder
@@ -544,19 +539,34 @@ public final class ModelGenerator implements Generator {
 						"private " + field.javaFieldType() + " " + field.nameCamelFirstLower() +
 								" = " + getDefaultValue(field, msgDef, lookupHelper)
 						).collect(Collectors.joining(";\n    ")))
-				.replace("$constructorParamDocs",fields.stream().map(field ->
-						"\n     * @param "+field.nameCamelFirstLower()+" "+
-								field.comment().replaceAll("\n", "\n     *         "+" ".repeat(field.nameCamelFirstLower().length()))
-						).collect(Collectors.joining(", ")))
-				.replace("$constructorParams",fields.stream().map(field ->
-						field.javaFieldType() + " " + field.nameCamelFirstLower()
-						).collect(Collectors.joining(", ")))
-				.replace("$constructorCode",fields.stream().map(field ->
-						"this.$name = $name;".replace("$name", field.nameCamelFirstLower())
-						).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT * 2))
+				.replace("$prePopulatedBuilder", generatePrePopulatedBuilder(fields))
 				.replace("$javaRecordName",javaRecordName)
 				.replace("$recordParams",fields.stream().map(Field::nameCamelFirstLower).collect(Collectors.joining(", ")))
 				.replace("$builderMethods", String.join("\n", builderMethods))
+				.indent(DEFAULT_INDENT);
+	}
+
+	private static String generatePrePopulatedBuilder(List<Field> fields) {
+		if (fields.isEmpty()) {
+			return "";
+		}
+		return """
+			    /**
+			     * Create a pre-populated builder
+			     * $constructorParamDocs
+			     */
+			    public Builder($constructorParams) {
+			$constructorCode    }"""
+				.replace("$constructorParamDocs",fields.stream().map(field ->
+						"\n     * @param "+field.nameCamelFirstLower()+" "+
+								field.comment().replaceAll("\n", "\n     *         "+" ".repeat(field.nameCamelFirstLower().length()))
+				).collect(Collectors.joining(", ")))
+				.replace("$constructorParams",fields.stream().map(field ->
+						field.javaFieldType() + " " + field.nameCamelFirstLower()
+				).collect(Collectors.joining(", ")))
+				.replace("$constructorCode",fields.stream().map(field ->
+						"this.$name = $name;".replace("$name", field.nameCamelFirstLower())
+				).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT * 2))
 				.indent(DEFAULT_INDENT);
 	}
 

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -121,7 +121,7 @@ public final class TestGenerator implements Generator {
 				%s
 				    ).max().getAsInt();
 				    // create new stream of model objects using lists above as constructor params
-				    ARGUMENTS = IntStream.range(0,maxValues)
+				    ARGUMENTS = (maxValues > 0 ? IntStream.range(0, maxValues) : IntStream.of(0))
 				            .mapToObj(i -> new %s(
 				%s
 				            )).toList();
@@ -143,6 +143,10 @@ public final class TestGenerator implements Generator {
 							.collect(Collectors.joining("\n")).indent(DEFAULT_INDENT),
 					fields.stream()
 							.map(f -> f.nameCamelFirstLower()+"List.size()")
+							.collect(Collectors.collectingAndThen(
+									Collectors.toList(),
+									list -> list.isEmpty() ? Stream.of("0") : list.stream()
+							))
 							.collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 2),
 					modelClassName,
 					fields.stream().map(field -> "%sList.get(Math.min(i, %sList.size()-1))".formatted(

--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -23,9 +23,9 @@ plugins {
 gitRepositories {
     checkoutsDirectory.set(file("./build/repos"))
     include("hapi") {
-        uri.set("https://github.com/nickpoorman/hedera-protobufs.git")
+        uri.set("https://github.com/hashgraph/hedera-protobufs.git")
         // choose tag or branch of HAPI you would like to test with
-        tag.set("block-node")
+        tag.set("main")
         // do not load project from repo
         autoInclude.set(false)
     }

--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -23,9 +23,9 @@ plugins {
 gitRepositories {
     checkoutsDirectory.set(file("./build/repos"))
     include("hapi") {
-        uri.set("https://github.com/hashgraph/hedera-protobufs.git")
+        uri.set("https://github.com/nickpoorman/hedera-protobufs.git")
         // choose tag or branch of HAPI you would like to test with
-        tag.set("main")
+        tag.set("block-node")
         // do not load project from repo
         autoInclude.set(false)
     }


### PR DESCRIPTION
**Description**:
Without this fix, when an empty protobuf definition is supplied, the generator and tests fail.

**Related issue(s)**:

Fixes #130

**Notes for reviewer**:
Add an empty protobuf message to the hedera-protobufs repo, or change settings.gradle.kts to use

        uri.set("https://github.com/nickpoorman/hedera-protobufs.git")
        // choose tag or branch of HAPI you would like to test with
        tag.set("block-node")
and run the build task on pbj-integration-tests.

See it done here: https://github.com/hashgraph/pbj/commit/5091ab928b0c92a6260bd4b5ed8e91ca7d7a836f#diff-33c26aa8d64828ee0a21e949f86378b4702433336009b2a6575795e6416d7d29R26

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
