### PR TITLE
fix 134: replace AutoCloseable with Closeable

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -4,6 +4,7 @@ import com.hedera.pbj.runtime.io.DataAccessException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.BufferUnderflowException;
@@ -15,7 +16,7 @@ import static java.util.Objects.requireNonNull;
  * <p>A {@code ReadableSequentialData} backed by an input stream. If the instance is closed,
  * the underlying {@link InputStream} is closed too.
  */
-public class ReadableStreamingData implements ReadableSequentialData, AutoCloseable {
+public class ReadableStreamingData implements ReadableSequentialData, Closeable {
 
     /** The underlying input stream */
     private final InputStream in;
@@ -36,7 +37,7 @@ public class ReadableStreamingData implements ReadableSequentialData, AutoClosea
     }
 
     // ================================================================================================================
-    // AutoCloseable Methods
+    // Closeable Methods
 
     /** {@inheritDoc} */
     @Override

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.runtime.io.stream;
 import com.hedera.pbj.runtime.io.DataAccessException;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
@@ -13,7 +14,7 @@ import java.util.Objects;
  * <p>A {@code WritableSequentialData} backed by an output stream. If the instance is closed,
  * the underlying {@link OutputStream} is closed too.
  */
-public class WritableStreamingData implements WritableSequentialData, AutoCloseable {
+public class WritableStreamingData implements WritableSequentialData, Closeable {
 
     /** The underlying output stream */
     private final OutputStream out;
@@ -46,7 +47,7 @@ public class WritableStreamingData implements WritableSequentialData, AutoClosea
     }
 
     // ================================================================================================================
-    // AutoCloseable Methods
+    // Closeable Methods
 
     @Override
     public void close() throws IOException {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
@@ -46,7 +46,7 @@ public class WritableStreamingDataTest extends WritableTestBase {
 
     @Test
     @DisplayName("capacity() returns Long.MAX_VALUE by default")
-    void defaultCapacity() throws Exception {
+    void defaultCapacity() throws IOException {
         // Given a sequence
         try (final var seq = sequence()) {
             // When we ask for the capacity, then we get Long.MAX_VALUE
@@ -56,7 +56,7 @@ public class WritableStreamingDataTest extends WritableTestBase {
 
     @Test
     @DisplayName("capacity() returns the capacity specified in the constructor")
-    void specifiedCapacity() throws Exception {
+    void specifiedCapacity() throws IOException {
         // Given a sequence
         try (final var seq = new WritableStreamingData(new ByteArrayOutputStream(), 10)) {
             // When we ask for the capacity, then we get 10


### PR DESCRIPTION
**Description**:
Replacing AutoCloseable with Closeable in ReadableStreamingData and WritableStreamingData classes and updating a unit test for the latter to use IOException instead of plain Exception.

**Related issue(s)**:

Fixes #134

**Notes for reviewer**:
```
pbj-core]$ ./gradlew test
...
BUILD SUCCESSFUL in 10s
```

**Checklist**

- [x ] Documented (Code comments, README, etc.)
- [x ] Tested (unit, integration, etc.)
