### PR TITLE
fix: 110: ReadableStreamingData limit is not set if it's wrapped over a file stream

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -47,6 +47,9 @@ public class ReadableStreamingData implements ReadableSequentialData, AutoClosea
      * @throws IOException if an I/O error occurs
      */
     public ReadableStreamingData(@NonNull final Path file) throws IOException {
+        if (!Files.isRegularFile(file) || !Files.isReadable(file)) {
+            throw new IOException("Cannot read file: " + file);
+        }
         this.in = Files.newInputStream(file, StandardOpenOption.READ);
         this.limit = Files.size(file);
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -4,10 +4,14 @@ import com.hedera.pbj.runtime.io.DataAccessException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,12 +31,34 @@ public class ReadableStreamingData implements ReadableSequentialData, AutoClosea
     private boolean eof = false;
 
     /**
-     * Creates a {@code FilterInputStream} that implements {@code DataInput} API.
+     * Creates a new streaming data object on top of a given input stream.
      *
      * @param in the underlying input stream, can not be null
      */
     public ReadableStreamingData(@NonNull final InputStream in) {
         this.in = requireNonNull(in);
+    }
+
+    /**
+     * Opens a new input stream to read a given file and creates a new streaming data object on top
+     * of this stream.
+     *
+     * @param file the file, can not be null
+     * @throws IOException if an I/O error occurs
+     */
+    public ReadableStreamingData(@NonNull final Path file) throws IOException {
+        this.in = Files.newInputStream(file, StandardOpenOption.READ);
+        this.limit = Files.size(file);
+    }
+
+    /**
+     * Creates a new streaming data object on top of a given byte array.
+     *
+     * @param bytes the byte array, can not be null
+     */
+    public ReadableStreamingData(@NonNull final byte[] bytes) {
+        this.in = new ByteArrayInputStream(bytes);
+        this.limit = bytes.length;
     }
 
     // ================================================================================================================


### PR DESCRIPTION
Fix summary:

* A new constructor is added to `ReadableStreamingData` to create a streaming object for a file path. It opens a new file input stream and sets the limit to the size of the file
* A new constructor is added to the same class to create a streaming object from a byte array. It creates a ByteArrayInputStream, the limit is set to byte array length

Testing:

* New unit tests are added to cover both new constructors and check the limits

Fixes: https://github.com/hashgraph/pbj/issues/110
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
