### PR TITLE
fix 68: introduce SingleFuzzTest

### DIFF
--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestException.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestException.java
@@ -1,0 +1,7 @@
+package com.hedera.pbj.integration.fuzz;
+
+public class FuzzTestException extends RuntimeException {
+    public FuzzTestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/SingleFuzzTest.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/SingleFuzzTest.java
@@ -56,7 +56,7 @@ public final class SingleFuzzTest {
             dataBuffer = write(object, codec, size);
         } catch (Exception ex) {
             // The test expects a valid input object, so we don't expect this to happen here
-            throw new RuntimeException("Unable to write the object", ex);
+            throw new FuzzTestException("Unable to write the object", ex);
         }
 
         System.out.println(prefix + "Bytes: " + dataBuffer);

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/SingleFuzzTest.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/SingleFuzzTest.java
@@ -1,0 +1,109 @@
+package com.hedera.pbj.integration.fuzz;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A single fuzz test.
+ * <p>
+ * This class exposes a single public static method that allows a caller to pass
+ * a valid object, a Protobuf codec for this object, as well as a random numbers
+ * generator. The method will then perform a single fuzz test run with the given
+ * data and return a SingleFuzzTestResult describing the outcome of the test run.
+ * <p>
+ * A fuzz testing framework is expected to use this class to execute multiple runs
+ * of the same test (each being random per the given random numbers generator)
+ * until the set of outcomes satisfies the testing framework threshold,
+ * or the framework runs out of the maximum number of attempts, or a timeout
+ * occurs.
+ * <p>
+ * This class is thread-safe and can be called concurrently from multiple threads
+ * as long as the input parameters are immutable or thread-safe.
+ */
+public final class SingleFuzzTest {
+    private final static AtomicInteger TEST_ID_GENERATOR = new AtomicInteger(0);
+
+    private static <T> BufferedData write(final T object, final Codec<T> codec, final int size) throws Exception {
+        final BufferedData dataBuffer = BufferedData.allocate(size);
+        codec.write(object, dataBuffer);
+        return dataBuffer;
+    }
+
+    /**
+     * Perform a fuzz test for a given input object of type T and its codec
+     * using a provided random numbers generator.
+     * <p>
+     * The input object is expected to be valid (i.e. serializable using the given codec),
+     * otherwise an exception is thrown.
+     *<p>
+     * The test run produces debugging output on stdout with a prefix that is unique
+     * to this particular run, allowing one to identify all the debugging output related
+     * to this specific run even if multiple runs are running concurrently.
+     *
+     * @return a SingleFuzzTestResult
+     */
+    public static <T> SingleFuzzTestResult fuzzTest(final T object, final Codec<T> codec, final Random random) {
+        // Generate a unique test ID prefix for this particular run to tag debugging output:
+        final String prefix = SingleFuzzTest.class.getSimpleName() + " " + TEST_ID_GENERATOR.getAndIncrement() + ": ";
+
+        System.out.println(prefix + "Object: " + object);
+        final int size = codec.measureRecord(object);
+        final BufferedData dataBuffer;
+        try {
+            dataBuffer = write(object, codec, size);
+        } catch (Exception ex) {
+            // The test expects a valid input object, so we don't expect this to happen here
+            throw new RuntimeException("Unable to write the object", ex);
+        }
+
+        System.out.println(prefix + "Bytes: " + dataBuffer);
+
+        // Set a random byte to a random value
+        final int randomPosition = random.nextInt(size);
+        final byte randomByte = (byte) random.nextInt(256);
+
+        dataBuffer.position(randomPosition);
+        dataBuffer.writeByte(randomByte);
+
+        System.out.println(prefix + "Fuzz bytes: " + dataBuffer);
+
+        dataBuffer.reset();
+        final T deserializedObject;
+        try {
+            deserializedObject = codec.parse(dataBuffer);
+        } catch (Exception ex) {
+            // Note that the codec may throw the IOException, as well as various nio exceptions
+            // such as the BufferUnderflowException. We're good as long as any exception is thrown.
+            System.out.println(prefix + "Fuzz exception: " + ex.getMessage());
+            return SingleFuzzTestResult.DESERIALIZATION_FAILED;
+        }
+
+        final int deserializedSize = codec.measureRecord(deserializedObject);
+        if (deserializedSize != size) {
+            System.out.println(prefix + "Original size: " + size + " , fuzz size: " + deserializedSize);
+            return SingleFuzzTestResult.DESERIALIZED_SIZE_MISMATCHED;
+        }
+
+
+        final BufferedData reserializedBuffer;
+        try {
+            reserializedBuffer = write(deserializedObject, codec, deserializedSize);
+        } catch (Exception ex) {
+            // Note that the codec may throw the IOException, as well as various nio exceptions
+            // such as the BufferUnderflowException. We're good as long as any exception is thrown.
+            System.out.println(prefix + "Reserialization exception: " + ex.getMessage());
+            return SingleFuzzTestResult.RESERIALIZATION_FAILED;
+        }
+
+        System.out.println(prefix + "Reserialized bytes: " + reserializedBuffer);
+        if (!reserializedBuffer.equals(dataBuffer)) {
+            return SingleFuzzTestResult.RESERIALIZATION_MISMATCHED;
+        }
+
+        return SingleFuzzTestResult.RESERIALIZATION_PASSED;
+    }
+
+}

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/SingleFuzzTestResult.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/SingleFuzzTestResult.java
@@ -1,0 +1,71 @@
+package com.hedera.pbj.integration.fuzz;
+
+/**
+ * An enum describing possible outcomes of a fuzz test run for a Protobuf codec.
+ *
+ * A typical fuzz test performs the following actions:
+ * <ol>
+ * <p> 1. Serializes a valid object into a byte array
+ * <p> 2. Modifies a random element of the byte array randomly
+ * <p> 3. Deserializes the modified byte array. <b>This is where an exception thrown
+ * by the codec is considered to be the best possible outcome of a test run.</b>
+ * <p> 4. Compares the measured size of the deserialized object to the measured size
+ * of the original object. The test ends if they differ.
+ * <p> 5. Reserializes the previously deserialized object into a new byte array.
+ * The test ends if codec throws an exception.
+ * <p> 6. Compares the bytes of the modified array from step #2 and the new array
+ * from step #5. The test ends if the contents differ.
+ * <p> 7. Finally, the test ends unconditionally w/o any conclusion because the
+ * test was unable to make the codec fail.
+ * </ol>
+ */
+public enum SingleFuzzTestResult {
+    /**
+     * codec.parse() threw an exception at step #3.
+     *
+     * This indicates that the codec fails on malformed data
+     * which is exactly what we want it to do.
+     */
+    DESERIALIZATION_FAILED,
+
+    /**
+     * codec.parse() with fuzz bytes returned an object whose measured size
+     * differs from the measured size of the original object at step #4.
+     *
+     * This indicates that the fuzz data appears to be a correct
+     * binary message for an object that may differ from the original input object.
+     * There may or may not be bugs in the codec, but this test run
+     * failed to ultimately reveal any.
+     */
+    DESERIALIZED_SIZE_MISMATCHED,
+
+    /**
+     * codec.write() threw an exception for a previously deserialized object at step #5.
+     *
+     * This means that the deserialized object produced at step #3 is invalid from the serializer
+     * perspective, which means that the deserializer can read malformed data and produce
+     * such malformed objects which may be a potential bug in the deserializer.
+     */
+    RESERIALIZATION_FAILED,
+
+    /**
+     * codec.write() produced bytes different from the fuzz bytes at step #6.
+     *
+     * This means that the deserializer at step #3 may have ignored fuzz data
+     * producing an object that doesn't match its binary representation from step #2.
+     * Alternatively, the serializer at step #5 may have ignored a certain invalid
+     * state of the deserialized object from step #3.
+     * This may be a potential bug in the codec.
+     */
+    RESERIALIZATION_MISMATCHED,
+
+    /**
+     * codec.write() produced bytes identical to the fuzz bytes at step #6.
+     *
+     * This means that the fuzz data resulted in a correct binary message.
+     * It's unclear if there are any bugs, but this test run was unable to
+     * reveal any.
+     */
+    RESERIALIZATION_PASSED;
+
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -1,0 +1,26 @@
+package com.hedera.pbj.intergration.test;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.pbj.integration.fuzz.SingleFuzzTest;
+import com.hedera.pbj.integration.fuzz.SingleFuzzTestResult;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a sample fuzz test just to demonstrate the usage of the SingleFuzzTest class.
+ * It's unable to assert or verify anything because a single fuzz test run may not
+ * produce a desired result.
+ * It will be replaced with a more elaborate fuzz testing framework in the future.
+ * See javadoc for SingleFuzzTest for more details.
+ */
+public class SampleFuzzTest {
+
+    @Test
+    void testMethod() {
+        AccountID accountID = AccountID.newBuilder().accountNum(1).realmNum(2).shardNum(3).build();
+        SingleFuzzTestResult singleFuzzTestResult = SingleFuzzTest.fuzzTest(accountID, AccountID.PROTOBUF, new Random());
+        System.out.println("A fuzz test for " + accountID + " resulted in " + singleFuzzTestResult);
+    }
+
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -7,6 +7,8 @@ import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /**
  * This is a sample fuzz test just to demonstrate the usage of the SingleFuzzTest class.
  * It's unable to assert or verify anything because a single fuzz test run may not
@@ -19,8 +21,15 @@ public class SampleFuzzTest {
     @Test
     void testMethod() {
         AccountID accountID = AccountID.newBuilder().accountNum(1).realmNum(2).shardNum(3).build();
-        SingleFuzzTestResult singleFuzzTestResult = SingleFuzzTest.fuzzTest(accountID, AccountID.PROTOBUF, new Random());
+        SingleFuzzTestResult singleFuzzTestResult = SingleFuzzTest.fuzzTest(
+                accountID,
+                AccountID.PROTOBUF,
+                new Random()
+        );
         System.out.println("A fuzz test for " + accountID + " resulted in " + singleFuzzTestResult);
+
+        // It's a no-op by design currently. See javadoc for details.
+        assertNotNull(singleFuzzTestResult);
     }
 
 }


### PR DESCRIPTION
**Description**:
Introducing the `SingleFuzzTest` class to support fuzz testing.

This is the first in a series of pull requests that will ultimately build a framework to run fuzz testing for pbj.

Here I'm introducing a new utility class that can perform a single randomized run of a fuzz test and return a result value that indicates whether the test was successful or more testing may be needed. See javadocs for more details.

Please note that building the entire fuzz testing framework is outside of scope of this particular PR and will be done in future, separate PRs.

**Related issue(s)**:

Fixes #68 

**Notes for reviewer**:
```
pbj-integration-tests]$ ./gradlew test --info
...
STANDARD_OUT
    SingleFuzzTest 0: Object: AccountID[shardNum=3, realmNum=2, account=OneOf[kind=ACCOUNT_NUM, value=1]]
    SingleFuzzTest 0: Bytes: ByteArrayBufferedData[8,3,16,2,24,1]
    SingleFuzzTest 0: Fuzz bytes: ByteArrayBufferedData[8,3,16,2,223,1]
    SingleFuzzTest 0: Fuzz exception: Cannot understand wire_type of 7
    A fuzz test for AccountID[shardNum=3, realmNum=2, account=OneOf[kind=ACCOUNT_NUM, value=1]] resulted in DESERIALIZATION_FAILED
...
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
