### PR TITLE
fix 68: introduce FuzzTest

### DIFF
--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTest.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTest.java
@@ -1,0 +1,66 @@
+package com.hedera.pbj.integration.fuzz;
+
+import com.hedera.pbj.runtime.Codec;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * A fuzz test runner for a single object/codec.
+ * <p>
+ * This class exposes a single public static method that runs a comprehensive fuzz test
+ * for a given object and its codec. Note that the codec must be valid for the given
+ * object (see the SingleFuzzTest javadoc for more details.)
+ * <p>
+ * Ultimately, the result of the test is a map that describes how often a particular
+ * SingleFuzzTest outcome occurred in percentages. The provided threshold specifies
+ * the percentage of the DESERIALIZATION_FAILED outcome for the test to be considered
+ * as passed.
+ * <p>
+ * The method returns a FuzzTestResult record that describes the results in full.
+ */
+public class FuzzTest {
+
+    /**
+     * Run a fuzz test for a given object and codec, and use the provided threshold
+     * for the most desirable DESERIALIZATION_FAILED outcome to determine
+     * if the test passed or not.
+     */
+    public static <T> FuzzTestResult<T> fuzzTest(final T object, final Codec<T> codec, final double threshold) {
+        final Random random = new Random();
+        final int repeatCount = estimateRepeatCount(object, codec);
+
+        final Map<SingleFuzzTestResult, Long> resultCounts = IntStream.range(0, repeatCount)
+                .parallel()
+                .mapToObj(n -> SingleFuzzTest.fuzzTest(object, codec, random))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        final Map<SingleFuzzTestResult, Double> statsMap = computePercentageMap(resultCounts, repeatCount);
+
+        return new FuzzTestResult<>(
+                object,
+                statsMap.getOrDefault(SingleFuzzTestResult.DESERIALIZATION_FAILED, 0.) >= threshold,
+                statsMap
+        );
+    }
+
+    private static <T> int estimateRepeatCount(final T object, final Codec<T> codec) {
+        final int size = codec.measureRecord(object);
+        // This is purely a heuristic that seems to produce good results.
+        // We may want to limit this value from above for extra large objects.
+        return size * 20;
+    }
+
+    private static Map<SingleFuzzTestResult, Double> computePercentageMap(
+            final Map<SingleFuzzTestResult, Long> resultCounts,
+            final int repeatCount) {
+        return resultCounts.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().doubleValue() / (double) repeatCount)
+                );
+    }
+}

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestResult.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestResult.java
@@ -1,0 +1,36 @@
+package com.hedera.pbj.integration.fuzz;
+
+import java.text.NumberFormat;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A record that describes the result of running a fuzz test.
+ * @param object an object for which this test was run.
+ * @param passed indicates if the test passed or not. See the FuzzTest class for the definition.
+ * @param percentageMap a map with percentage statistics of occurred outcomes.
+ * @param <T> the type of the object for which the test was run
+ */
+public record FuzzTestResult<T>(
+        T object,
+        boolean passed,
+        Map<SingleFuzzTestResult, Double> percentageMap
+) {
+    private static final NumberFormat PERCENTAGE_FORMAT = NumberFormat.getPercentInstance();
+
+    /**
+     * Format the FuzzTestResult object for printing/logging.
+     */
+    public String format() {
+        return "A fuzz test " + (passed ? "PASSED" : "FAILED") + " for "
+                + object + " with:" + System.lineSeparator()
+                + formatResultsStats();
+    }
+
+    private String formatResultsStats() {
+        return percentageMap.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> entry.getKey().name() + ": " + PERCENTAGE_FORMAT.format(entry.getValue()))
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -1,35 +1,32 @@
 package com.hedera.pbj.intergration.test;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.pbj.integration.fuzz.SingleFuzzTest;
-import com.hedera.pbj.integration.fuzz.SingleFuzzTestResult;
-import java.util.Random;
+import com.hedera.pbj.integration.fuzz.FuzzTest;
+import com.hedera.pbj.integration.fuzz.FuzzTestResult;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * This is a sample fuzz test just to demonstrate the usage of the SingleFuzzTest class.
- * It's unable to assert or verify anything because a single fuzz test run may not
- * produce a desired result.
+ * This is a sample fuzz test just to demonstrate the usage of the FuzzTest class.
  * It will be replaced with a more elaborate fuzz testing framework in the future.
- * See javadoc for SingleFuzzTest for more details.
+ * See javadoc for FuzzTest for more details.
  */
 public class SampleFuzzTest {
 
     @Test
     void testMethod() {
         AccountID accountID = AccountID.newBuilder().accountNum(1).realmNum(2).shardNum(3).build();
-        SingleFuzzTestResult singleFuzzTestResult = SingleFuzzTest.fuzzTest(
-                accountID,
-                AccountID.PROTOBUF,
-                new Random()
-        );
-        System.out.println("A fuzz test for " + accountID + " resulted in " + singleFuzzTestResult);
 
-        // It's a no-op by design currently. See javadoc for details.
-        assertNotNull(singleFuzzTestResult);
+        // A percentage threshold for the DESERIALIZATION_FAILED outcomes.
+        final double THRESHOLD = 0.5;
+
+        FuzzTestResult<AccountID> fuzzTestResult = FuzzTest.fuzzTest(accountID, AccountID.PROTOBUF, THRESHOLD);
+
+        System.out.println(fuzzTestResult.format());
+
+        assertTrue(fuzzTestResult.passed());
     }
 
 }


### PR DESCRIPTION
**Description**:
Introducing a FuzzTest class that allows one to run a comprehensive fuzz test for a given object and its codec. The class uses the `SingleFuzzTest.fuzzTest` to run the actual tests and then collects all the results in a statistics map with keys being the SingleFuzzTestResult enum constants, and values describing the percentage of that particular outcome occurring during the test.

A provided threshold is used to measure the `SingleFuzzTestResult.DESERIALIZATION_FAILED` outcome specifically as it's the most desired outcome of all.

The SampleFuzzTest.java has been modified to use the FuzzTest, and it finally can assert something real and useful.

In future PR the SampleFuzzTest will be replaced with something that would be testing all the object models that pbj currently supports.

**Related issue(s)**:

Fixes #68 

**Notes for reviewer**:
```
pbj-integration-tests]$ ./gradlew test --info
...
A fuzz test PASSED for AccountID[shardNum=3, realmNum=2, account=OneOf[kind=ACCOUNT_NUM, value=1]] with:
DESERIALIZATION_FAILED: 60%
DESERIALIZED_SIZE_MISMATCHED: 14%
RESERIALIZATION_PASSED: 26%
...
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
