### PR TITLE
fix: 67: Compare & Improve General Protobuf performance

### DIFF
--- a/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/ByteBufferGetByte.java
+++ b/pbj-core/pbj-runtime/src/jmh/java/com/hedera/pbj/runtime/io/ByteBufferGetByte.java
@@ -68,14 +68,14 @@ public class ByteBufferGetByte {
     @Benchmark
     public void heapUnsafeGet(final Blackhole blackhole) {
         for (int i = 0; i < size; i++) {
-            blackhole.consume(UnsafeUtils.getByteHeap(heapBuffer, i));
+            blackhole.consume(UnsafeUtils.getHeapBufferByte(heapBuffer, i));
         }
     }
 
     @Benchmark
     public void directUnsafeGet(final Blackhole blackhole) {
         for (int i = 0; i < size; i++) {
-            blackhole.consume(UnsafeUtils.getByteDirect(directBuffer, i));
+            blackhole.consume(UnsafeUtils.getDirectBufferByte(directBuffer, i));
         }
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
@@ -430,7 +430,7 @@ public interface ReadableSequentialData extends SequentialData {
     }
 
     /**
-     * Read a 32bit protobuf varint at current {@link #position()}. An integer var int can be 1 to 5 bytes.
+     * Read a 32bit protobuf varint at current {@link #position()}.
      *
      * @return integer read in var int format
      * @param zigZag use protobuf zigZag varint encoding, optimized for negative numbers
@@ -439,42 +439,11 @@ public interface ReadableSequentialData extends SequentialData {
      * @throws DataAccessException if an I/O error occurs
      */
     default int readVarInt(final boolean zigZag) {
-        long pos = position();
-        long limit = limit();
-        if (limit == pos) {
-            return (int) readVarIntLongSlow(zigZag);
-        }
-        else if (limit - pos < 10) {
-            return (int) readVarIntLongSlow(zigZag);
-        }
-
-        int x;
-        if ((x = readByte()) >= 0) {
-            return  zigZag ? (x >>> 1) ^ -(x & 1) : x;
-        } else if ((x ^= (readByte() << 7)) < 0) {
-            x ^= (~0 << 7);
-        } else if ((x ^= (readByte() << 14)) >= 0) {
-            x ^= (~0 << 7) ^ (~0 << 14);
-        } else if ((x ^= (readByte() << 21)) < 0) {
-            x ^= (~0 << 7) ^ (~0 << 14) ^ (~0 << 21);
-        } else {
-            int y = readByte();
-            x ^= y << 28;
-            x ^= (~0 << 7) ^ (~0 << 14) ^ (~0 << 21) ^ (~0 << 28);
-            if (y < 0
-                    && readByte() < 0
-                    && readByte() < 0
-                    && readByte() < 0
-                    && readByte() < 0
-                    && readByte() < 0) {
-                return (int) readVarIntLongSlow(zigZag);
-            }
-        }
-        return zigZag ? (x >>> 1) ^ -(x & 1) : x;
+        return (int) readVarLong(zigZag);
     }
 
     /**
-     * Read a 64bit protobuf varint at current {@link #position()}. A long var int can be 1 to 10 bytes.
+     * Read a 64bit protobuf varint at current {@link #position()}.
      *
      * @return long read in var int format
      * @param zigZag use protobuf zigZag varint encoding, optimized for negative numbers
@@ -484,81 +453,16 @@ public interface ReadableSequentialData extends SequentialData {
      * @throws DataEncodingException if the variable long cannot be decoded
      */
     default long readVarLong(final boolean zigZag) {
-        long pos = position();
-        long limit = limit();
-        if (limit == pos) {
-            return readVarIntLongSlow(zigZag);
-        }
-        else if (limit - pos < 10) {
-            return readVarIntLongSlow(zigZag);
-        }
+        long value = 0;
 
-        long x;
-        int y;
-        if ((y = readByte()) >= 0) {
-            return zigZag ? (y >>> 1) ^ -(y & 1) : y;
-        } else if ((y ^= (readByte() << 7)) < 0) {
-            x = y ^ (~0 << 7);
-        } else if ((y ^= (readByte() << 14)) >= 0) {
-            x = y ^ ((~0 << 7) ^ (~0 << 14));
-        } else if ((y ^= (readByte() << 21)) < 0) {
-            x = y ^ ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
-        } else if ((x = y ^ ((long) readByte() << 28)) >= 0L) {
-            x ^= (~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28);
-        } else if ((x ^= ((long) readByte() << 35)) < 0L) {
-            x ^= (~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35);
-        } else if ((x ^= ((long) readByte() << 42)) >= 0L) {
-            x ^= (~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42);
-        } else if ((x ^= ((long) readByte() << 49)) < 0L) {
-            x ^=
-                    (~0L << 7)
-                            ^ (~0L << 14)
-                            ^ (~0L << 21)
-                            ^ (~0L << 28)
-                            ^ (~0L << 35)
-                            ^ (~0L << 42)
-                            ^ (~0L << 49);
-        } else {
-            x ^= ((long) readByte() << 56);
-            x ^=
-                    (~0L << 7)
-                            ^ (~0L << 14)
-                            ^ (~0L << 21)
-                            ^ (~0L << 28)
-                            ^ (~0L << 35)
-                            ^ (~0L << 42)
-                            ^ (~0L << 49)
-                            ^ (~0L << 56);
-            if (x < 0L) {
-                if (readByte() < 0L) {
-                    throw new DataEncodingException("Malformed VarLong");
-                }
-            }
-        }
-        return zigZag ? (x >>> 1) ^ -(x & 1) : x;
-    }
-
-    /**
-     * Read a 64bit protobuf varint at current {@link #position()}. A long var int can be 1 to 10 bytes.
-     * This is the slow path function.
-     *
-     * @return long read in var int format
-     * @param zigZag use protobuf zigZag varint encoding, optimized for negative numbers
-     * @throws BufferUnderflowException If the end of the sequence is reached before the final variable byte fragment
-     *                                  is read
-     * @throws DataAccessException if an I/O error occurs
-     * @throws DataEncodingException if the variable long cannot be decoded
-     */
-    default long readVarIntLongSlow(final boolean zigZag) {
-        long result = 0;
-        for (int shift = 0; shift < 64; shift += 7) {
+        for (int i = 0; i < 10; i++) {
             final byte b = readByte();
-            result |= (long) (b & 0x7F) << shift;
-            if ((b & 0x80) == 0) {
-                return zigZag ? (result >>> 1) ^ -(result & 1) : result;
+            value |= (long) (b & 0x7F) << (i * 7);
+            if (b >= 0) {
+                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
             }
         }
-        throw new DataEncodingException("Malformed Varlong");
+        throw new DataEncodingException("Malformed var int");
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/UnsafeUtils.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/UnsafeUtils.java
@@ -49,24 +49,62 @@ public class UnsafeUtils {
     }
 
     /**
-     * Get heap byte buffer element at a given offset. Identical to buf.get(offset), but
-     * slightly faster on some systems. May only be called for Java heap byte buffers
+     * Get byte array element at a given offset. Identical to arr[offset].
      */
-    public static byte getByteHeap(final ByteBuffer buf, final int offset) {
+    public static byte getArrayByte(final byte[] arr, final int offset) {
+        if (arr.length <= offset) {
+            throw new IndexOutOfBoundsException();
+        }
+        return getArrayByteNoChecks(arr, offset);
+    }
+
+    /**
+     * Get byte array element at a given offset. Identical to arr[offset], but faster,
+     * because no array bounds checks are performed.
+     *
+     * <p><b>Use with caution!</b>
+     */
+    public static byte getArrayByteNoChecks(final byte[] arr, final int offset) {
+        return UNSAFE.getByte(arr, BYTE_ARRAY_BASE_OFFSET + offset);
+    }
+
+    /**
+     * Get heap byte buffer element at a given offset. Identical to buf.get(offset). May only
+     * be called for Java heap byte buffers.
+     */
+    public static byte getHeapBufferByte(final ByteBuffer buf, final int offset) {
         if (buf.limit() < offset + 1) {
             throw new BufferUnderflowException();
         }
+        return getHeapBufferByteNoChecks(buf, offset);
+    }
+
+    /**
+     * Get heap byte buffer element at a given offset. Identical to buf.get(offset), but faster,
+     * because no buffer range checks are performed. May only be called for Java heap byte buffers.
+     *
+     * <p><b>Use with caution!</b>
+     */
+    public static byte getHeapBufferByteNoChecks(final ByteBuffer buf, final int offset) {
         return UNSAFE.getByte(buf.array(), BYTE_ARRAY_BASE_OFFSET + offset);
     }
 
     /**
-     * Get direct byte buffer element at a given offset. Identical to buf.get(offset), but
-     * slightly faster on some systems. May only be called for direct byte buffers
+     * Get direct byte buffer element at a given offset. Identical to buf.get(offset). May only
+     * be called for direct byte buffers
      */
-    public static byte getByteDirect(final ByteBuffer buf, final int offset) {
+    public static byte getDirectBufferByte(final ByteBuffer buf, final int offset) {
         if (buf.limit() < offset + 1) {
             throw new BufferUnderflowException();
         }
+        return getDirectBufferByteNoChecks(buf, offset);
+    }
+
+    /**
+     * Get direct byte buffer element at a given offset. Identical to buf.get(offset), but faster,
+     * because no buffer range checks are performed. May only be called for direct byte buffers.
+     */
+    public static byte getDirectBufferByteNoChecks(final ByteBuffer buf, final int offset) {
         final long address = UNSAFE.getLong(buf, DIRECT_BYTEBUFFER_ADDRESS_OFFSET);
         return UNSAFE.getByte(null, address + offset);
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/WritableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/WritableSequentialData.java
@@ -377,7 +377,10 @@ public interface WritableSequentialData extends SequentialData {
     }
 
     /**
-     * Write a 32bit protobuf varint at current {@link #position()}. An integer var int can be 1 to 5 bytes.
+     * Write a 32bit protobuf varint at current {@link #position()}.
+     *
+     * <p>Non-negative integer var int can be 1 to 5 bytes. Negative integer with zigZag=false is
+     * always 10 bytes. Negative integer with zigZag=true can be 1 to 5 bytes.
      *
      * @param value integer to write in var int format
      * @param zigZag use protobuf zigZag varint encoding, optimized for negative numbers

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
@@ -852,26 +852,6 @@ public sealed class BufferedData
      * {@inheritDoc}
      */
     @Override
-    public void writeVarInt(final int value, final boolean zigZag) {
-        long longValue = value;
-        if (zigZag) {
-            longValue = (longValue << 1) ^ (longValue >> 63);
-        }
-        while (true) {
-            if ((longValue & ~0x7F) == 0) {
-                buffer.put((byte) longValue);
-                break;
-            } else {
-                buffer.put((byte) ((longValue & 0x7F) | 0x80));
-                longValue >>>= 7;
-            }
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void writeVarLong(long value, final boolean zigZag) {
         if (zigZag) {
             value = (value << 1) ^ (value >> 63);
@@ -897,7 +877,7 @@ public sealed class BufferedData
 
     protected void validateCanRead(final long offset, final long len) {
         if (offset < 0) {
-            throw new ArrayIndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException();
         }
         if (offset > length() - len) {
             // FUTURE: change to AIOOBE, too

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -2,7 +2,6 @@ package com.hedera.pbj.runtime.io.buffer;
 
 import com.hedera.pbj.runtime.io.DataEncodingException;
 import com.hedera.pbj.runtime.io.SequentialData;
-import com.hedera.pbj.runtime.io.UnsafeUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.nio.BufferUnderflowException;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -1,6 +1,8 @@
 package com.hedera.pbj.runtime.io.buffer;
 
+import com.hedera.pbj.runtime.io.DataEncodingException;
 import com.hedera.pbj.runtime.io.SequentialData;
+import com.hedera.pbj.runtime.io.UnsafeUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.nio.BufferUnderflowException;
@@ -394,7 +396,7 @@ public interface RandomAccessData {
     }
 
     /**
-     * Get a 32bit protobuf varint at the given {@code offset}. An integer var int can be 1 to 5 bytes.
+     * Get a 32bit protobuf varint at the given {@code offset}.
      *
      * @param offset The offset into data to get a varint from.
      * @return integer get in var int format
@@ -403,20 +405,11 @@ public interface RandomAccessData {
      * @throws IndexOutOfBoundsException If the given {@code offset} is negative or not less than {@link #length()}
      */
     default int getVarInt(final long offset, final boolean zigZag) {
-        int result = 0;
-        long index = offset;
-        for (int shift = 0; shift < 32; shift += 7) {
-            final byte b = getByte(index++);
-            result |= (long) (b & 0x7F) << shift;
-            if ((b & 0x80) == 0) {
-                return zigZag ? ((result >>> 1) ^ -(result & 1)) : result;
-            }
-        }
-        throw new RuntimeException("Malformed Varint");
+        return (int) getVarLong(Math.toIntExact(offset), zigZag);
     }
 
     /**
-     * Get a 64bit protobuf varint at given {@code offset}. A long var int can be 1 to 10 bytes.
+     * Get a 64bit protobuf varint at given {@code offset}.
      *
      * @param offset The offset into data to get a varlong from.
      * @return long get in var long format
@@ -425,16 +418,15 @@ public interface RandomAccessData {
      * @throws IndexOutOfBoundsException If the given {@code offset} is negative or not less than {@link #length()}
      */
     default long getVarLong(final long offset, final boolean zigZag) {
-        long result = 0;
-        long index = offset;
-        for (int shift = 0; shift < 64; shift += 7) {
-            final byte b = getByte(index++);
-            result |= (long) (b & 0x7F) << shift;
-            if ((b & 0x80) == 0) {
-                return zigZag ? ((result >>> 1) ^ -(result & 1)) : result;
+        long value = 0;
+        for (int i = 0; i < 10; i++) {
+            final byte b = getByte(offset + i);
+            value |= (long) (b & 0x7F) << (i * 7);
+            if (b >= 0) {
+                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
             }
         }
-        throw new RuntimeException("Malformed Varlong");
+        throw new DataEncodingException("Malformed var int");
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -3,7 +3,6 @@ package com.hedera.pbj.runtime.io.stream;
 import com.hedera.pbj.runtime.io.DataAccessException;
 import com.hedera.pbj.runtime.io.DataEncodingException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.UnsafeUtils;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayInputStream;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -1,7 +1,9 @@
 package com.hedera.pbj.runtime.io.stream;
 
 import com.hedera.pbj.runtime.io.DataAccessException;
+import com.hedera.pbj.runtime.io.DataEncodingException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.UnsafeUtils;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayInputStream;
@@ -224,6 +226,35 @@ public class ReadableStreamingData implements ReadableSequentialData, Closeable 
             eof = true;
         }
         return bytesRead;
+    }
+
+
+    @Override
+    public long readVarLong(final boolean zigZag) {
+        if (!hasRemaining()) {
+            throw new BufferUnderflowException();
+        }
+
+        long value = 0;
+
+        try {
+            int i = 0;
+            for (; i < 10; i++) {
+                final int b = in.read();
+                if (b < 0) {
+                    eof = true;
+                    break;
+                }
+                value |= (long) (b & 0x7F) << (i * 7);
+                if ((b & 0x80) == 0) {
+                    position += i + 1;
+                    return zigZag ? (value >>> 1) ^ -(value & 1) : value;
+                }
+            }
+            throw (i == 10) ? new DataEncodingException("Malformed var int") : new BufferUnderflowException();
+        } catch (final IOException e) {
+            throw new DataAccessException(e);
+        }
     }
 
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/DataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/DataTest.java
@@ -20,7 +20,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 final class DataTest {
 
     static Stream<Byte> bytesTestCases() {
-        return Stream.of(Byte.MIN_VALUE,-100,-66,-7,-1,0,1,9,51,101,Byte.MAX_VALUE).map(Number::byteValue);
+        return Stream.of(
+                Byte.MIN_VALUE,
+                Byte.MIN_VALUE + 1,
+                -100,
+                -66,
+                -7,
+                -1,
+                0,
+                1,
+                9,
+                51,
+                101,
+                Byte.MAX_VALUE - 1,
+                Byte.MAX_VALUE).map(Number::byteValue);
     }
 
     @ParameterizedTest
@@ -54,7 +67,20 @@ final class DataTest {
     }
 
     static Stream<Integer> intsTestCases() {
-        return Stream.of(Integer.MIN_VALUE,-100,-66,-7,-1,0,1,9,51,101,Integer.MAX_VALUE).map(Number::intValue);
+        return Stream.of(
+                Integer.MIN_VALUE,
+                Integer.MIN_VALUE + 1,
+                -100,
+                -66,
+                -7,
+                -1,
+                0,
+                1,
+                9,
+                51,
+                101,
+                Integer.MAX_VALUE - 1,
+                Integer.MAX_VALUE).map(Number::intValue);
     }
 
     @ParameterizedTest
@@ -104,8 +130,34 @@ final class DataTest {
     }
 
     static Stream<Long> longsTestCases() {
-        return Stream.of(Long.MIN_VALUE, Integer.MIN_VALUE-1L,-100,-66,-7,-1,0,1,9,51,101,Integer.MAX_VALUE+1L,Long.MAX_VALUE).map(Number::longValue);
-    }
+        return Stream.of(
+                Long.MIN_VALUE,
+                Long.MIN_VALUE + 1,
+                Integer.MIN_VALUE - 1L,
+                Integer.MIN_VALUE,
+                Integer.MIN_VALUE + 1,
+                -65536,
+                -65535,
+                -65534
+                -100,
+                -66,
+                -7,
+                -1,
+                0,
+                1,
+                9,
+                51,
+                101,
+                1023,
+                1024,
+                1025,
+                Integer.MAX_VALUE - 1L,
+                Integer.MAX_VALUE,
+                Integer.MAX_VALUE + 1L,
+                Long.MAX_VALUE - 1L,
+                Long.MAX_VALUE).map(Number::longValue);
+}
+
     @ParameterizedTest
     @MethodSource("longsTestCases")
     void longTest(Long value) throws IOException {
@@ -176,7 +228,7 @@ final class DataTest {
 
     @ParameterizedTest
     @MethodSource("intsTestCases")
-    void varIntTest(int value) throws IOException {
+    void varIntTest(final int value) throws IOException {
         { // without zigzag
             // write to byte array with DataIO DataOutputStream
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -277,6 +329,39 @@ final class DataTest {
             ReadableStreamingData din = new ReadableStreamingData(bin);
             long readValue2 = din.readVarLong(true);
             assertEquals(value, readValue2);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("longsTestCases")
+    void compatInt32Int64(final long num) {
+        { // write as int
+            final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            final WritableStreamingData dout = new WritableStreamingData(bout);
+            dout.writeVarInt((int) num, false);
+            final byte[] writtenData = bout.toByteArray();
+            ByteArrayInputStream bin = new ByteArrayInputStream(writtenData);
+            ReadableStreamingData din = new ReadableStreamingData(bin);
+            final int readValue1 = din.readVarInt(false);
+            assertEquals((int) num, readValue1);
+            bin = new ByteArrayInputStream(writtenData);
+            din = new ReadableStreamingData(bin);
+            final long readValue2 = din.readVarLong(false);
+            assertEquals((int) num, readValue2);
+        }
+        { // write as long
+            final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            final WritableStreamingData dout = new WritableStreamingData(bout);
+            dout.writeVarLong(num, false);
+            final byte[] writtenData = bout.toByteArray();
+            ByteArrayInputStream bin = new ByteArrayInputStream(writtenData);
+            ReadableStreamingData din = new ReadableStreamingData(bin);
+            final int readValue1 = din.readVarInt(false);
+            assertEquals((int) num, readValue1);
+            bin = new ByteArrayInputStream(writtenData);
+            din = new ReadableStreamingData(bin);
+            final long readValue2 = din.readVarLong(false);
+            assertEquals(num, readValue2);
         }
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/RandomAccessTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/RandomAccessTestBase.java
@@ -15,7 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/VarIntBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/VarIntBench.java
@@ -36,6 +36,7 @@ public class VarIntBench {
 
 	InputStream bais = null;
 	ReadableStreamingData rsd = null;
+
 	InputStream baisNonSync = null;
 	ReadableStreamingData rsdNonSync = null;
 
@@ -243,9 +244,9 @@ public class VarIntBench {
 		throw new MalformedProtobufException("Malformed var int");
 	}
 
-	final static Blackhole blackhole = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
-
 	public static void main(String[] args) throws Exception {
+		final Blackhole blackhole = new Blackhole(
+				"Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
 		final VarIntBench bench = new VarIntBench();
 		bench.dataBufferRead(blackhole);
 		bench.dataBufferGet(blackhole);

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/VarIntBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/VarIntBench.java
@@ -2,10 +2,13 @@ package com.hedera.pbj.intergration.jmh;
 
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
+import com.hedera.pbj.integration.NonSynchronizedByteArrayInputStream;
 import com.hedera.pbj.runtime.MalformedProtobufException;
+import com.hedera.pbj.runtime.io.UnsafeUtils;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import java.io.InputStream;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -31,24 +34,38 @@ public class VarIntBench {
 
 	Bytes bytes = Bytes.EMPTY;
 
-	ByteArrayInputStream bais = null;
+	InputStream bais = null;
 	ReadableStreamingData rsd = null;
+	InputStream baisNonSync = null;
+	ReadableStreamingData rsdNonSync = null;
+
+	private final int[] offsets = new int[1201];
 
 	public VarIntBench() {
 		try {
 			CodedOutputStream cout = CodedOutputStream.newInstance(buffer);
 			Random random = new Random(9387498731984L);
+			int pos = 0;
+			offsets[pos++] = 0;
 			for (int i = 0; i < 600; i++) {
 				cout.writeUInt64NoTag(random.nextLong(0,128));
+				offsets[pos++] = cout.getTotalBytesWritten();
 			}
 			for (int i = 0; i < 150; i++) {
 				cout.writeUInt64NoTag(random.nextLong(128,256));
+				offsets[pos++] = cout.getTotalBytesWritten();
 			}
 			for (int i = 0; i < 150; i++) {
-				cout.writeUInt64NoTag(random.nextLong(256,Integer.MAX_VALUE));
+				cout.writeUInt64NoTag(random.nextLong(256, Integer.MAX_VALUE));
+				offsets[pos++] = cout.getTotalBytesWritten();
 			}
 			for (int i = 0; i < 150; i++) {
-				cout.writeUInt64NoTag(random.nextLong(0,Long.MAX_VALUE));
+				cout.writeUInt64NoTag(random.nextLong(Integer.MIN_VALUE, Integer.MAX_VALUE));
+				offsets[pos++] = cout.getTotalBytesWritten();
+			}
+			for (int i = 0; i < 150; i++) {
+				cout.writeUInt64NoTag(random.nextLong(0, Long.MAX_VALUE));
+				offsets[pos++] = cout.getTotalBytesWritten();
 			}
 			cout.flush();
 			// copy to direct buffer
@@ -61,91 +78,116 @@ public class VarIntBench {
 			bytes = Bytes.wrap(bts);
 			bais = new ByteArrayInputStream(bts.clone());
 			rsd = new ReadableStreamingData(bais);
+			baisNonSync = new NonSynchronizedByteArrayInputStream(bts.clone());
+			rsdNonSync = new ReadableStreamingData(baisNonSync);
 		} catch (IOException e){
 			e.printStackTrace();
 		}
 	}
 
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void dataBuffer(Blackhole blackhole) throws IOException {
+	@OperationsPerInvocation(1200)
+	public void dataBufferRead(Blackhole blackhole) throws IOException {
 		dataBuffer.reset();
-		for (int i = 0; i < 1050; i++) {
-		    int i1 = dataBuffer.readVarInt(false);
-			blackhole.consume(dataBuffer.readVarInt(false));
+		for (int i = 0; i < 1200; i++) {
+			blackhole.consume(dataBuffer.readVarLong(false));
 		}
 	}
+
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void dataBufferDirect(Blackhole blackhole) throws IOException {
+	@OperationsPerInvocation(1200)
+	public void dataBufferGet(Blackhole blackhole) throws IOException {
+		dataBuffer.reset();
+		int offset = 0;
+		for (int i = 0; i < 1200; i++) {
+			blackhole.consume(dataBuffer.getVarLong(offsets[offset++], false));
+		}
+	}
+
+	@Benchmark
+	@OperationsPerInvocation(1200)
+	public void dataBufferDirectRead(Blackhole blackhole) throws IOException {
 		dataBufferDirect.reset();
-		for (int i = 0; i < 1050; i++) {
-			blackhole.consume(dataBufferDirect.readVarInt(false));
-		}
-	}
-
-	long pos = 0;
-
-	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void dataBytes(Blackhole blackhole) throws IOException {
-		for (int i = 0; i < 1050; i++) {
-			blackhole.consume(bytes.getVarInt(pos, false));
-			pos++;
+		for (int i = 0; i < 1200; i++) {
+			blackhole.consume(dataBufferDirect.readVarLong(false));
 		}
 	}
 
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void dataInputStream(Blackhole blackhole) throws IOException {
+	@OperationsPerInvocation(1200)
+	public void dataBytesGet(Blackhole blackhole) throws IOException {
+		int offset = 0;
+		for (int i = 0; i < 1200; i++) {
+			blackhole.consume(bytes.getVarLong(offsets[offset++], false));
+		}
+	}
+
+	@Benchmark
+	@OperationsPerInvocation(1200)
+	public void dataSyncInputStreamRead(Blackhole blackhole) throws IOException {
 		bais.reset();
-		for (int i = 0; i < 1050; i++) {
-			blackhole.consume(rsd.readVarInt(false));
+		for (int i = 0; i < 1200; i++) {
+			blackhole.consume(rsd.readVarLong(false));
 		}
 	}
 
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void richard(Blackhole blackhole) throws MalformedProtobufException {
-		buffer.clear();
-		for (int i = 0; i < 1050; i++) {
-			blackhole.consume(readVarintRichard(buffer));
+	@OperationsPerInvocation(1200)
+	public void dataNonSyncInputStreamRead(Blackhole blackhole) throws IOException {
+		baisNonSync.reset();
+		for (int i = 0; i < 1200; i++) {
+			blackhole.consume(rsdNonSync.readVarLong(false));
 		}
 	}
+
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void google(Blackhole blackhole) throws IOException {
+	@OperationsPerInvocation(1200)
+	public void richardGet(Blackhole blackhole) throws MalformedProtobufException {
+		int offset = 0;
 		buffer.clear();
-		for (int i = 0; i < 1050; i++) {
-			final CodedInputStream codedInputStream = CodedInputStream.newInstance(buffer);
+		for (int i = 0; i < 1200; i++) {
+			blackhole.consume(getVarLongRichard(offsets[offset++], buffer));
+		}
+	}
+
+	@Benchmark
+	@OperationsPerInvocation(1200)
+	public void googleRead(Blackhole blackhole) throws IOException {
+		buffer.clear();
+		final CodedInputStream codedInputStream = CodedInputStream.newInstance(buffer);
+		for (int i = 0; i < 1200; i++) {
 			blackhole.consume(codedInputStream.readRawVarint64());
 		}
 	}
+
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void googleDirect(Blackhole blackhole) throws IOException {
+	@OperationsPerInvocation(1200)
+	public void googleDirecRead(Blackhole blackhole) throws IOException {
 		bufferDirect.clear();
-		for (int i = 0; i < 1050; i++) {
-			final CodedInputStream codedInputStream = CodedInputStream.newInstance(bufferDirect);
+		final CodedInputStream codedInputStream = CodedInputStream.newInstance(bufferDirect);
+		for (int i = 0; i < 1200; i++) {
 			blackhole.consume(codedInputStream.readRawVarint64());
 		}
 	}
+
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void googleSlowPath(Blackhole blackhole) throws MalformedProtobufException {
+	@OperationsPerInvocation(1200)
+	public void googleSlowPathRead(Blackhole blackhole) throws MalformedProtobufException {
 		buffer.clear();
-		for (int i = 0; i < 1050; i++) {
+		for (int i = 0; i < 1200; i++) {
 			blackhole.consume(readRawVarint64SlowPath(buffer));
 		}
 	}
+
 	@Benchmark
-	@OperationsPerInvocation(1050)
-	public void googleSlowPathDirect(Blackhole blackhole) throws MalformedProtobufException {
+	@OperationsPerInvocation(1200)
+	public void googleSlowPathDirectRead(Blackhole blackhole) throws MalformedProtobufException {
 		bufferDirect.clear();
-		for (int i = 0; i < 1050; i++) {
+		for (int i = 0; i < 1200; i++) {
 			blackhole.consume(readRawVarint64SlowPath(bufferDirect));
 		}
 	}
+
 	private static long readRawVarint64SlowPath(ByteBuffer buf) throws MalformedProtobufException {
 		long result = 0;
 		for (int shift = 0; shift < 64; shift += 7) {
@@ -163,7 +205,7 @@ public class VarIntBench {
 	private static final int VARINT_DATA_MASK = 0b0111_1111;
 	private static final int NUM_BITS_PER_VARINT_BYTE = 7;
 
-	public static long readVarintRichard(ByteBuffer buf) throws MalformedProtobufException {
+	public static long getVarLongRichard(int offset, ByteBuffer buf) throws MalformedProtobufException {
 		// Protobuf encodes smaller integers with fewer bytes than larger integers. It takes a full byte
 		// to encode 7 bits of information. So, if all 64 bits of a long are in use (for example, if the
 		// leading bit is 1, or even all bits are 1) then it will take 10 bytes to transmit what would
@@ -177,40 +219,40 @@ public class VarIntBench {
 		// The bytes come least to most significant 7 bits. So the first byte we read represents
 		// the lowest 7 bytes, then the next byte is the next highest 7 bytes, etc.
 
-		// Keeps track of the number of bytes that have been read. If we read 10 in a row all with
-		// the leading continuation bit set, then throw a malformed protobuf exception.
-		int numBytesRead = 0;
 		// The final value.
 		long value = 0;
 		// The amount to shift the bits we read by before AND with the value
-		long shift = 0;
-		// The byte to read from the stream
-		int b;
+		int shift = -NUM_BITS_PER_VARINT_BYTE;
 
-		while ((b = buf.get()) != -1) {
-			// Keep track of the number of bytes read
-			numBytesRead++;
-			// Checks whether the continuation bit is set
-			final boolean continuationBitSet = (b & VARINT_CONTINUATION_MASK) != 0;
-			// Strip off the continuation bit by keeping only the data bits
-			b &= VARINT_DATA_MASK;
-			// Shift the data bits left into position to AND with the value
-			final long toBeAdded = (long) b << shift;
-			value |= toBeAdded;
-			// Increment the shift for the next data bits (if there are more bits)
-			shift += NUM_BITS_PER_VARINT_BYTE;
+		// This method works with heap byte buffers only
+		final byte[] arr = buf.array();
+		final int arrOffset = buf.arrayOffset() + offset;
 
-			if (continuationBitSet) {
-				// msb is set, so there is another byte following this one. If we've just read our 10th byte,
-				// then we have a malformed protobuf stream
-				if (numBytesRead == 10) {
-					throw new MalformedProtobufException("");
-				}
-			} else {
-				break;
+		int i = 0;
+		for (; i < 10; i++) {
+			// Use UnsafeUtil instead of arr[arrOffset + i] to avoid array range checks
+			byte b = UnsafeUtils.getArrayByteNoChecks(arr, arrOffset + i);
+			value |= (long) (b & 0x7F) << (shift += NUM_BITS_PER_VARINT_BYTE);
+
+			if (b >= 0) {
+				return value;
 			}
 		}
-		return value;
+		// If we read 10 in a row all with the leading continuation bit set, then throw a malformed
+		// protobuf exception
+		throw new MalformedProtobufException("Malformed var int");
 	}
 
+	final static Blackhole blackhole = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
+
+	public static void main(String[] args) throws Exception {
+		final VarIntBench bench = new VarIntBench();
+		bench.dataBufferRead(blackhole);
+		bench.dataBufferGet(blackhole);
+		bench.dataBufferDirectRead(blackhole);
+		bench.dataBytesGet(blackhole);
+		bench.dataSyncInputStreamRead(blackhole);
+		bench.dataNonSyncInputStreamRead(blackhole);
+		bench.googleRead(blackhole);
+	}
 }


### PR DESCRIPTION
Fix summary:

* Fixed `VarIntBench` JMH benchmark
* Improved `getVarInt/Long()` and `readVarIntLong()` implementations for all applicable classes
* Added several new unit tests
* Refactored some existing tests, so they are run for more classes
* Renamed a few `UnsafeUtils` methods and added methods without range checks

Fixes: https://github.com/hashgraph/pbj/issues/67
Fixes: https://github.com/hashgraph/pbj/issues/143
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
