### PR TITLE
fix 68: use ModelTest.ARGUMENTS and extend SampleFuzzTest to ContractID

### DIFF
--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTest.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTest.java
@@ -2,6 +2,7 @@ package com.hedera.pbj.integration.fuzz;
 
 import com.hedera.pbj.runtime.Codec;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Function;
@@ -29,7 +30,10 @@ public class FuzzTest {
      * for the most desirable DESERIALIZATION_FAILED outcome to determine
      * if the test passed or not.
      */
-    public static <T> FuzzTestResult<T> fuzzTest(final T object, final Codec<T> codec, final double threshold) {
+    public static <T> FuzzTestResult<T> fuzzTest(final T object, final double threshold) {
+        final long startNanoTime = System.nanoTime();
+
+        final Codec<T> codec = getCodec(object);
         final Random random = new Random();
         final int repeatCount = estimateRepeatCount(object, codec);
 
@@ -43,7 +47,9 @@ public class FuzzTest {
         return new FuzzTestResult<>(
                 object,
                 statsMap.getOrDefault(SingleFuzzTestResult.DESERIALIZATION_FAILED, 0.) >= threshold,
-                statsMap
+                statsMap,
+                repeatCount,
+                System.nanoTime() - startNanoTime
         );
     }
 
@@ -62,5 +68,14 @@ public class FuzzTest {
                         Map.Entry::getKey,
                         entry -> entry.getValue().doubleValue() / (double) repeatCount)
                 );
+    }
+
+    private static <T> Codec<T> getCodec(final T object) {
+        try {
+            Field codecField = object.getClass().getField("PROTOBUF");
+            return (Codec<T>) codecField.get(null);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new FuzzTestException("Failed to get a codec from the static PROTOBUF field", e);
+        }
     }
 }

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestException.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestException.java
@@ -4,4 +4,8 @@ public class FuzzTestException extends RuntimeException {
     public FuzzTestException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public FuzzTestException(String message) {
+        super(message);
+    }
 }

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestResult.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzTestResult.java
@@ -2,6 +2,7 @@ package com.hedera.pbj.integration.fuzz;
 
 import java.text.NumberFormat;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -14,7 +15,9 @@ import java.util.stream.Collectors;
 public record FuzzTestResult<T>(
         T object,
         boolean passed,
-        Map<SingleFuzzTestResult, Double> percentageMap
+        Map<SingleFuzzTestResult, Double> percentageMap,
+        int repeatCount,
+        long nanoDuration
 ) {
     private static final NumberFormat PERCENTAGE_FORMAT = NumberFormat.getPercentInstance();
 
@@ -22,8 +25,11 @@ public record FuzzTestResult<T>(
      * Format the FuzzTestResult object for printing/logging.
      */
     public String format() {
-        return "A fuzz test " + (passed ? "PASSED" : "FAILED") + " for "
-                + object + " with:" + System.lineSeparator()
+        return "A fuzz test " + (passed ? "PASSED" : "FAILED")
+                + " with " + repeatCount + " runs took "
+                + TimeUnit.MILLISECONDS.convert(nanoDuration, TimeUnit.NANOSECONDS) + " ms"
+                + " for " + object
+                + " with:" + System.lineSeparator()
                 + formatResultsStats();
     }
 

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -1,10 +1,15 @@
 package com.hedera.pbj.intergration.test;
 
-import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.tests.AccountIDTest;
+import com.hedera.hapi.node.base.tests.ContractIDTest;
 import com.hedera.pbj.integration.fuzz.FuzzTest;
 import com.hedera.pbj.integration.fuzz.FuzzTestResult;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,19 +19,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * See javadoc for FuzzTest for more details.
  */
 public class SampleFuzzTest {
+    // A percentage threshold for the DESERIALIZATION_FAILED outcomes.
+    private static final double THRESHOLD = 0.5;
 
-    @Test
-    void testMethod() {
-        AccountID accountID = AccountID.newBuilder().accountNum(1).realmNum(2).shardNum(3).build();
+    // This is to be extended to all model classes in the future.
+    private static final List<List<?>> MODEL_TEST_OBJECTS = List.of(
+            AccountIDTest.ARGUMENTS,
+            ContractIDTest.ARGUMENTS
+    );
 
-        // A percentage threshold for the DESERIALIZATION_FAILED outcomes.
-        final double THRESHOLD = 0.5;
-
-        FuzzTestResult<AccountID> fuzzTestResult = FuzzTest.fuzzTest(accountID, AccountID.PROTOBUF, THRESHOLD);
-
-        System.out.println(fuzzTestResult.format());
-
-        assertTrue(fuzzTestResult.passed());
+    private static Stream<?> objectTestCases() {
+        return MODEL_TEST_OBJECTS.stream()
+                .flatMap(List::stream);
     }
 
+    // If this parametrized test proves to be taking too long time to complete,
+    // we may try and convert it to a regular test, and instead run it
+    // in a parallelStream() on the objectTestCases.
+    // However, each individual fuzz test already uses a parallel stream
+    // for its repeated runs. So using an extra, outer parallel stream here
+    // is unlikely to yield too much of a performance boost.
+    @ParameterizedTest
+    @MethodSource("objectTestCases")
+    void testMethod(Object object) {
+        FuzzTestResult<?> fuzzTestResult = FuzzTest.fuzzTest(object, THRESHOLD);
+        String resultDescription = fuzzTestResult.format();
+        System.out.println(resultDescription);
+        assertTrue(fuzzTestResult.passed(), resultDescription);
+    }
 }


### PR DESCRIPTION
**Description**:

This is a re-send of https://github.com/hashgraph/pbj/pull/146 because that branch got broken.

1. Using the already existing ModelTest.ARGUMENTS lists to fetch sample model objects for fuzz testing.
2. Modifying the SingleFuzzTest to inflict more damage to the message payload, so as to increase the probability of the codec failing. W/o this change the threshold of 50% wasn't always enough.
3. Extend the SampleFuzzTest to support both the old AccountID and the new ContractID models.
4. Minor changes in other related places.

Please note that it is still OUT OF SCOPE of this PR to extend support to all the models supported by pbj. There's already a lot of code in this single change that I'd like to push separately.

We'll be adding support for testing all the models in future, separate PRs.

**Related issue(s)**:

Fixes #68 

**Notes for reviewer**:
```
pbj-integration-tests]$ ./gradlew test --info
...
A fuzz test PASSED with 220 runs took 32 ms for AccountID[shardNum=0, realmNum=0, account=OneOf[kind=ACCOUNT_NUM, value=-21]] with:
DESERIALIZATION_FAILED: 82%
DESERIALIZED_SIZE_MISMATCHED: 12%
RESERIALIZATION_MISMATCHED: 0%
RESERIALIZATION_PASSED: 6%
A fuzz test PASSED with 440 runs took 41 ms for AccountID[shardNum=9223372036854775807, realmNum=9223372036854775807, account=OneOf[kind=ALIAS, value=]] with:
DESERIALIZATION_FAILED: 88%
DESERIALIZED_SIZE_MISMATCHED: 9%
RESERIALIZATION_PASSED: 3%
A fuzz test PASSED with 120 runs took 28 ms for AccountID[shardNum=42, realmNum=42, account=OneOf[kind=ACCOUNT_NUM, value=21]] with:
DESERIALIZATION_FAILED: 56%
DESERIALIZED_SIZE_MISMATCHED: 32%
RESERIALIZATION_PASSED: 12%
A fuzz test PASSED with 440 runs took 42 ms for AccountID[shardNum=9223372036854775807, realmNum=9223372036854775807, account=OneOf[kind=ACCOUNT_NUM, value=42]] with:
DESERIALIZATION_FAILED: 90%
DESERIALIZED_SIZE_MISMATCHED: 7%
RESERIALIZATION_PASSED: 2%
A fuzz test PASSED with 120 runs took 31 ms for AccountID[shardNum=21, realmNum=21, account=OneOf[kind=ACCOUNT_NUM, value=0]] with:
DESERIALIZATION_FAILED: 68%
DESERIALIZED_SIZE_MISMATCHED: 22%
RESERIALIZATION_PASSED: 11%
A fuzz test PASSED with 440 runs took 46 ms for AccountID[shardNum=-9223372036854775808, realmNum=-9223372036854775808, account=OneOf[kind=UNSET, value=null]] with:
DESERIALIZATION_FAILED: 80%
DESERIALIZED_SIZE_MISMATCHED: 17%
RESERIALIZATION_MISMATCHED: 0%
RESERIALIZATION_PASSED: 3%
A fuzz test PASSED with 600 runs took 50 ms for AccountID[shardNum=9223372036854775807, realmNum=9223372036854775807, account=OneOf[kind=ACCOUNT_NUM, value=9223372036854775807]] with:
DESERIALIZATION_FAILED: 91%
DESERIALIZED_SIZE_MISMATCHED: 6%
RESERIALIZATION_PASSED: 2%
A fuzz test PASSED with 660 runs took 50 ms for AccountID[shardNum=-21, realmNum=-21, account=OneOf[kind=ACCOUNT_NUM, value=-42]] with:
DESERIALIZATION_FAILED: 93%
DESERIALIZED_SIZE_MISMATCHED: 5%
RESERIALIZATION_PASSED: 2%
A fuzz test PASSED with 660 runs took 51 ms for AccountID[shardNum=-42, realmNum=-42, account=OneOf[kind=ACCOUNT_NUM, value=-9223372036854775808]] with:
DESERIALIZATION_FAILED: 91%
DESERIALIZED_SIZE_MISMATCHED: 5%
RESERIALIZATION_MISMATCHED: 0%
RESERIALIZATION_PASSED: 3%
A fuzz test PASSED with 440 runs took 54 ms for ContractID[shardNum=9223372036854775807, realmNum=9223372036854775807, contract=OneOf[kind=EVM_ADDRESS, value=]] with:
DESERIALIZATION_FAILED: 91%
DESERIALIZED_SIZE_MISMATCHED: 7%
RESERIALIZATION_PASSED: 2%
A fuzz test PASSED with 120 runs took 4 ms for ContractID[shardNum=42, realmNum=42, contract=OneOf[kind=CONTRACT_NUM, value=21]] with:
DESERIALIZATION_FAILED: 63%
DESERIALIZED_SIZE_MISMATCHED: 29%
RESERIALIZATION_PASSED: 8%
A fuzz test PASSED with 120 runs took 5 ms for ContractID[shardNum=21, realmNum=21, contract=OneOf[kind=CONTRACT_NUM, value=0]] with:
DESERIALIZATION_FAILED: 62%
DESERIALIZED_SIZE_MISMATCHED: 28%
RESERIALIZATION_PASSED: 9%
A fuzz test PASSED with 220 runs took 3 ms for ContractID[shardNum=0, realmNum=0, contract=OneOf[kind=CONTRACT_NUM, value=-21]] with:
DESERIALIZATION_FAILED: 78%
DESERIALIZED_SIZE_MISMATCHED: 15%
RESERIALIZATION_PASSED: 7%
A fuzz test PASSED with 460 runs took 12 ms for AccountID[shardNum=9223372036854775807, realmNum=9223372036854775807, account=OneOf[kind=ALIAS, value=01]] with:
DESERIALIZATION_FAILED: 88%
DESERIALIZED_SIZE_MISMATCHED: 8%
RESERIALIZATION_PASSED: 4%
A fuzz test PASSED with 600 runs took 11 ms for ContractID[shardNum=9223372036854775807, realmNum=9223372036854775807, contract=OneOf[kind=CONTRACT_NUM, value=9223372036854775807]] with:
DESERIALIZATION_FAILED: 90%
DESERIALIZED_SIZE_MISMATCHED: 6%
RESERIALIZATION_PASSED: 4%
A fuzz test PASSED with 660 runs took 24 ms for ContractID[shardNum=-42, realmNum=-42, contract=OneOf[kind=CONTRACT_NUM, value=-9223372036854775808]] with:
DESERIALIZATION_FAILED: 91%
DESERIALIZED_SIZE_MISMATCHED: 6%
RESERIALIZATION_MISMATCHED: 0%
RESERIALIZATION_PASSED: 3%
A fuzz test PASSED with 440 runs took 31 ms for ContractID[shardNum=9223372036854775807, realmNum=9223372036854775807, contract=OneOf[kind=CONTRACT_NUM, value=42]] with:
DESERIALIZATION_FAILED: 91%
DESERIALIZED_SIZE_MISMATCHED: 6%
RESERIALIZATION_PASSED: 3%
A fuzz test PASSED with 460 runs took 29 ms for ContractID[shardNum=9223372036854775807, realmNum=9223372036854775807, contract=OneOf[kind=EVM_ADDRESS, value=01]] with:
DESERIALIZATION_FAILED: 88%
DESERIALIZED_SIZE_MISMATCHED: 8%
RESERIALIZATION_PASSED: 3%
A fuzz test PASSED with 660 runs took 33 ms for ContractID[shardNum=-21, realmNum=-21, contract=OneOf[kind=CONTRACT_NUM, value=-42]] with:
DESERIALIZATION_FAILED: 93%
DESERIALIZED_SIZE_MISMATCHED: 5%
RESERIALIZATION_MISMATCHED: 0%
RESERIALIZATION_PASSED: 2%
A fuzz test PASSED with 440 runs took 30 ms for ContractID[shardNum=-9223372036854775808, realmNum=-9223372036854775808, contract=OneOf[kind=UNSET, value=null]] with:
DESERIALIZATION_FAILED: 80%
DESERIALIZED_SIZE_MISMATCHED: 17%
RESERIALIZATION_MISMATCHED: 0%
RESERIALIZATION_PASSED: 3%
A fuzz test PASSED with 560 runs took 26 ms for ContractID[shardNum=9223372036854775807, realmNum=9223372036854775807, contract=OneOf[kind=EVM_ADDRESS, value=010203ff807f]] with:
DESERIALIZATION_FAILED: 90%
DESERIALIZED_SIZE_MISMATCHED: 5%
RESERIALIZATION_PASSED: 4%
A fuzz test PASSED with 560 runs took 41 ms for AccountID[shardNum=9223372036854775807, realmNum=9223372036854775807, account=OneOf[kind=ALIAS, value=010203ff807f]] with:
DESERIALIZATION_FAILED: 87%
DESERIALIZED_SIZE_MISMATCHED: 8%
RESERIALIZATION_PASSED: 5%
...
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)