### PR TITLE
fix: 151 Fixed incorrect `readVarLong` behavior in case of prematurely ended stream in `ReadableStreamingData`

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.7.10-SNAPSHOT
+version=0.7.11-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
@@ -138,9 +138,15 @@ public interface ReadableSequentialData extends SequentialData {
         // because, for streams, we cannot determine ahead of time the total number of available bytes, so we must
         // continue to check as we process each byte. This is not efficient for buffers.
         final var len = dst.remaining();
+        long bytesRead = 0;
         for (int i = 0; i < len; i++) {
             if (!hasRemaining()) return i;
-            dst.put(readByte());
+            try {
+                dst.put(readByte());
+                bytesRead++;
+            } catch (EOFException e) {
+                return bytesRead;
+            }
         }
         return len;
     }
@@ -168,9 +174,15 @@ public interface ReadableSequentialData extends SequentialData {
         // because, for streams, we cannot determine ahead of time the total number of available bytes, so we must
         // continue to check as we process each byte. This is not efficient for buffers.
         final var len = dst.remaining();
+        long bytesRead = 0;
         for (int i = 0; i < len; i++) {
             if (!hasRemaining()) return i;
-            dst.writeByte(readByte());
+            try {
+                dst.writeByte(readByte());
+                bytesRead++;
+            } catch (EOFException e) {
+                return bytesRead;
+            }
         }
         return len;
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -242,7 +242,7 @@ public class ReadableStreamingData implements ReadableSequentialData, Closeable 
                 final int b = in.read();
                 if (b < 0) {
                     eof = true;
-                    break;
+                    throw new EOFException();
                 }
                 value |= (long) (b & 0x7F) << (i * 7);
                 if ((b & 0x80) == 0) {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
@@ -1,9 +1,12 @@
 package com.hedera.pbj.runtime.io.stream;
 
 import com.hedera.pbj.runtime.io.DataAccessException;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.ReadableSequentialTestBase;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -137,7 +140,7 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
 
     @Test
     @DisplayName("Bad InputStream empty when read")
-    void inputStreamEmptyRead() {
+    void inputStreamEmptyReadBytes() {
         final var inputStream = new ByteArrayInputStream(new byte[0]) {
             @Override
             public void close() throws IOException {
@@ -151,6 +154,42 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
             final var i = stream.readInt();
         });
         assertEquals(0, stream.readBytes(read));
+    }
+
+    @Test
+    @DisplayName("Bad InputStream empty when read")
+    void inputStreamEmptyReadVarLong() {
+        final var inputStream = new ByteArrayInputStream(new byte[] {
+                (byte) 128, (byte) 129, (byte) 130, (byte) 131});
+
+        final var stream = new ReadableStreamingData(inputStream);
+
+        assertThrows(EOFException.class, () -> stream.readVarLong(false));
+    }
+
+    @Test
+    void incompleteStreamToByteBuffer() {
+        final var inputStream = new ByteArrayInputStream(new byte[] {
+                (byte) 128, (byte) 129, (byte) 130, (byte) 131});
+
+        final var stream = new TestReadeableSequentialData(new ReadableStreamingData(inputStream));
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+
+
+        assertEquals(4, stream.readBytes(buffer), "Unexpected number of bytes read");
+    }
+
+    @Test
+    void incompleteStreamToBufferedData() {
+        final var inputStream = new ByteArrayInputStream(new byte[] {
+                (byte) 128, (byte) 129, (byte) 130, (byte) 131});
+
+        final var stream = new TestReadeableSequentialData(new ReadableStreamingData(inputStream));
+        stream.limit(8);
+        BufferedData buffer = BufferedData.allocate(8);
+
+
+        assertEquals(4, stream.readBytes(buffer), "Unexpected number of bytes read");
     }
 
     @Test
@@ -231,5 +270,43 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
         final Path file = Files.createTempFile(getClass().getSimpleName(), "readFileThatDoesntExist");
         Files.delete(file);
         assertThrows(IOException.class, () -> new ReadableStreamingData(file));
+    }
+
+    private static class TestReadeableSequentialData implements ReadableSequentialData {
+        private ReadableStreamingData readableStreamingData;
+
+        public TestReadeableSequentialData(final ReadableStreamingData readableStreamingData) {
+            this.readableStreamingData = readableStreamingData;
+        }
+
+        @Override
+        public byte readByte() {
+            return readableStreamingData.readByte();
+        }
+
+        @Override
+        public long capacity() {
+            return readableStreamingData.capacity();
+        }
+
+        @Override
+        public long position() {
+            return readableStreamingData.position();
+        }
+
+        @Override
+        public long limit() {
+            return readableStreamingData.limit();
+        }
+
+        @Override
+        public void limit(long limit) {
+            readableStreamingData.limit(limit);
+        }
+
+        @Override
+        public long skip(long count) {
+            return readableStreamingData.skip(count);
+        }
     }
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
@@ -175,7 +175,6 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
         final var stream = new TestReadeableSequentialData(new ReadableStreamingData(inputStream));
         ByteBuffer buffer = ByteBuffer.allocate(8);
 
-
         assertEquals(4, stream.readBytes(buffer), "Unexpected number of bytes read");
     }
 
@@ -187,7 +186,6 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
         final var stream = new TestReadeableSequentialData(new ReadableStreamingData(inputStream));
         stream.limit(8);
         BufferedData buffer = BufferedData.allocate(8);
-
 
         assertEquals(4, stream.readBytes(buffer), "Unexpected number of bytes read");
     }
@@ -263,7 +261,6 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
             Files.delete(dir);
         }
     }
-
 
     @Test
     void readFileThatDoesntExist() throws IOException {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
@@ -269,6 +269,11 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
         assertThrows(IOException.class, () -> new ReadableStreamingData(file));
     }
 
+    /**
+     * The sole purpose of this class is to allow testing of
+     * `{@link ReadableStreamingData#readBytes(ByteBuffer)}` and `{@link ReadableStreamingData#readBytes(BufferedData)}`.
+     * This methods are overriddin in other implementation and not possible to test ortherwise.
+     */
     private static class TestReadeableSequentialData implements ReadableSequentialData {
         private ReadableStreamingData readableStreamingData;
 


### PR DESCRIPTION
Fixes #151 

