### PR TITLE
fix 68: extend fuzz test to more models

### DIFF
--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -59,7 +59,6 @@ testing {
         useJUnitJupiter()
         targets.all {
             testTask {
-                useJUnitPlatform()
                 // We are running a lot of tests 10s of thousands, so they need to run in parallel
                 systemProperties["junit.jupiter.execution.parallel.enabled"] = true
                 systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
@@ -95,13 +94,9 @@ testing {
     }
 }
 
-tasks.test.configure() {
+tasks.test {
     actions.clear()
     dependsOn("integTest", "fuzzTest")
-}
-
-tasks.test {
-    useJUnitPlatform()
 }
 
 jmh {

--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -79,8 +79,6 @@ tasks.withType<Test>().configureEach {
     systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
     // us parallel GC to keep up with high temporary garbage creation, and allow GC to use 40% of CPU if needed
     jvmArgs("-XX:+UseParallelGC", "-XX:GCTimeRatio=90")
-//                jvmArgs("-XX:+UseZGC","-XX:ZAllocationSpikeTolerance=2")
-//                jvmArgs("-XX:+UseG1GC", "-XX:GCTimeRatio=90", "-XX:MaxGCPauseMillis=100")
     // Some also need more memory
     minHeapSize = "512m"
     maxHeapSize = "4096m"

--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -57,36 +57,10 @@ testing {
     @Suppress("UnstableApiUsage")
     suites.getByName<JvmTestSuite>("test") {
         useJUnitJupiter()
-        targets.all {
-            testTask {
-                // We are running a lot of tests 10s of thousands, so they need to run in parallel
-                systemProperties["junit.jupiter.execution.parallel.enabled"] = true
-                systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
-                // us parallel GC to keep up with high temporary garbage creation, and allow GC to use 40% of CPU if needed
-                jvmArgs("-XX:+UseParallelGC", "-XX:GCTimeRatio=90")
-//                jvmArgs("-XX:+UseZGC","-XX:ZAllocationSpikeTolerance=2")
-//                jvmArgs("-XX:+UseG1GC", "-XX:GCTimeRatio=90", "-XX:MaxGCPauseMillis=100")
-                // Some also need more memory
-                minHeapSize = "512m"
-                maxHeapSize = "4096m"
-            }
-        }
-
-        tasks.register<Test>("integTest") {
-            testClassesDirs = sources.output.classesDirs
-            classpath = sources.runtimeClasspath
-
-            shouldRunAfter(tasks.test)
-
-            useJUnitPlatform { excludeTags("FUZZ_TEST") }
-            enableAssertions = true
-        }
 
         tasks.register<Test>("fuzzTest") {
             testClassesDirs = sources.output.classesDirs
             classpath = sources.runtimeClasspath
-
-            shouldRunAfter(tasks.test)
 
             useJUnitPlatform { includeTags("FUZZ_TEST") }
             enableAssertions = false
@@ -95,8 +69,21 @@ testing {
 }
 
 tasks.test {
-    actions.clear()
-    dependsOn("integTest", "fuzzTest")
+    useJUnitPlatform { excludeTags("FUZZ_TEST") }
+    dependsOn("fuzzTest")
+}
+
+tasks.withType<Test>().configureEach {
+    // We are running a lot of tests 10s of thousands, so they need to run in parallel
+    systemProperties["junit.jupiter.execution.parallel.enabled"] = true
+    systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
+    // us parallel GC to keep up with high temporary garbage creation, and allow GC to use 40% of CPU if needed
+    jvmArgs("-XX:+UseParallelGC", "-XX:GCTimeRatio=90")
+//                jvmArgs("-XX:+UseZGC","-XX:ZAllocationSpikeTolerance=2")
+//                jvmArgs("-XX:+UseG1GC", "-XX:GCTimeRatio=90", "-XX:MaxGCPauseMillis=100")
+    // Some also need more memory
+    minHeapSize = "512m"
+    maxHeapSize = "4096m"
 }
 
 jmh {

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -4,7 +4,15 @@ import com.hedera.hapi.node.base.tests.AccountIDTest;
 import com.hedera.hapi.node.base.tests.ContractIDTest;
 import com.hedera.pbj.integration.fuzz.FuzzTest;
 import com.hedera.pbj.integration.fuzz.FuzzTestResult;
-
+import com.hedera.pbj.test.proto.pbj.tests.EverythingTest;
+import com.hedera.pbj.test.proto.pbj.tests.HashevalTest;
+import com.hedera.pbj.test.proto.pbj.tests.InnerEverythingTest;
+import com.hedera.pbj.test.proto.pbj.tests.MessageWithStringTest;
+import com.hedera.pbj.test.proto.pbj.tests.TimestampTest2Test;
+import com.hedera.pbj.test.proto.pbj.tests.TimestampTestSeconds2Test;
+import com.hedera.pbj.test.proto.pbj.tests.TimestampTestSecondsTest;
+import com.hedera.pbj.test.proto.pbj.tests.TimestampTestTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -12,6 +20,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * This is a sample fuzz test just to demonstrate the usage of the FuzzTest class.
@@ -19,13 +28,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * See javadoc for FuzzTest for more details.
  */
 public class SampleFuzzTest {
-    // A percentage threshold for the DESERIALIZATION_FAILED outcomes.
-    private static final double THRESHOLD = 0.5;
+    public static final String FUZZ_TEST = "FUZZ_TEST";
 
-    // This is to be extended to all model classes in the future.
+    // A percentage threshold for the DESERIALIZATION_FAILED outcomes.
+    // Note that we still encounter runs that result in less than 60%
+    // of the desirable outcome. Interestingly, this occurs with small
+    // objects mostly, for example an object with a single field
+    // of type string/byte array. When the string is too long, many a time
+    // the random data gets written into the string bytes w/o affecting
+    // the validity of the object. This may be addressed by increasing
+    // the number of bytes that we modify for a single test run.
+    // However, this may decrease the number of subtle modifications
+    // which we also want to test.
+    // For now, we keep the threshold at 60%.
+    // This will be refactored to gather the statistics across all the
+    // test cases and pass or fail the overall test based on the statistics.
+    private static final double THRESHOLD = 0.6;
+
     private static final List<List<?>> MODEL_TEST_OBJECTS = List.of(
             AccountIDTest.ARGUMENTS,
-            ContractIDTest.ARGUMENTS
+            ContractIDTest.ARGUMENTS,
+            EverythingTest.ARGUMENTS,
+            HashevalTest.ARGUMENTS,
+            InnerEverythingTest.ARGUMENTS,
+            MessageWithStringTest.ARGUMENTS,
+            TimestampTest2Test.ARGUMENTS,
+            TimestampTestSeconds2Test.ARGUMENTS,
+            TimestampTestSecondsTest.ARGUMENTS,
+            TimestampTestTest.ARGUMENTS
     );
 
     private static Stream<?> objectTestCases() {
@@ -33,15 +63,15 @@ public class SampleFuzzTest {
                 .flatMap(List::stream);
     }
 
-    // If this parametrized test proves to be taking too long time to complete,
-    // we may try and convert it to a regular test, and instead run it
-    // in a parallelStream() on the objectTestCases.
-    // However, each individual fuzz test already uses a parallel stream
-    // for its repeated runs. So using an extra, outer parallel stream here
-    // is unlikely to yield too much of a performance boost.
     @ParameterizedTest
     @MethodSource("objectTestCases")
-    void testMethod(Object object) {
+    @Tag(SampleFuzzTest.FUZZ_TEST)
+    void testMethod(Object object) throws Exception {
+        assumeFalse(
+                this.getClass().desiredAssertionStatus(),
+                "Fuzz tests run with assertions disabled only. Use the fuzzTest Gradle target."
+        );
+
         FuzzTestResult<?> fuzzTestResult = FuzzTest.fuzzTest(object, THRESHOLD);
         String resultDescription = fuzzTestResult.format();
         System.out.println(resultDescription);


### PR DESCRIPTION
**Description**:
1. Adding about 8 more test models to run the fuzz test against. The total number of test objects from their `ARGUMENTS` is a little over 300.
2. Splitting the `integTest` and `fuzzTest` Gradle targets to run the fuzz tests with assertions off, and making the regular `test` target depend on both.
3. Minor adjustments to heuristics used in the fuzz test.

Please note that the `THRESHOLD` mechanism will be overhauled in a future PR where I'll replace the individual tests failures with gathering of statistics across all runs, and then deciding if the test as a whole should fail or not. But this is OUTSIDE OF SCOPE of this particular PR.

**Related issue(s)**:

Fixes #68 

**Notes for reviewer**:
1. The output of the test is similar as before but it now tests against more than 300 test objects.
2. The test takes a couple of minutes to run currently. I'll be looking at optimizing it a bit in a future PR.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
