### PR TITLE
feat: Added support of compareTo

### DIFF
--- a/pbj-core/gradle/wrapper/gradle-wrapper.properties
+++ b/pbj-core/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pbj-core/pbj-compiler/build.gradle.kts
+++ b/pbj-core/pbj-compiler/build.gradle.kts
@@ -23,7 +23,11 @@ mainModuleInfo {
     requires("org.antlr.antlr4.runtime")
 }
 
-testModuleInfo { requires("org.junit.jupiter.api") }
+testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requires("org.mockito")
+    requires("org.mockito.junit.jupiter")
+}
 
 gradlePlugin {
     plugins {

--- a/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
+++ b/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
@@ -189,7 +189,7 @@ enumValueOption
 // message
 
 messageDef
-  : docComment MESSAGE messageName messageBody
+  : docComment ( optionComment )? MESSAGE messageName messageBody
   ;
 
 messageBody

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
@@ -74,7 +74,7 @@ public abstract class PbjCompilerTask extends SourceTask {
         for (final File protoFile : getSource()) {
             if (protoFile.exists()
                     && protoFile.isFile()
-                    && protoFile.getName().endsWith(".proto")) {
+                    && protoFile.getName().endsWith(LookupHelper.PROTO_EXTENSIION)) {
                 final ContextualLookupHelper contextualLookupHelper =
                         new ContextualLookupHelper(lookupHelper, protoFile);
                 try (var input = new FileInputStream(protoFile)) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
@@ -67,31 +67,45 @@ public abstract class PbjCompilerTask extends SourceTask {
     public void perform() throws Exception {
         // Clean output directories
         getFileOperations().delete(getJavaMainOutputDirectory(), getJavaTestOutputDirectory());
+        compileFilesIn(getSource(),
+                getJavaMainOutputDirectory().get().getAsFile(),
+                getJavaTestOutputDirectory().get().getAsFile());
+    }
 
+    /**
+     * Compile all the proto files in the given source directories
+     * @param sourceFiles The source files to compile
+     * @param mainOutputDir The main output directory
+     * @param testOutputDir The test output directory
+     */
+
+    public static void compileFilesIn(Iterable<File> sourceFiles,
+                                       File mainOutputDir,
+                                       File testOutputDir) throws Exception {
         // first we do a scan of files to build lookup tables for imports, packages etc.
-        final LookupHelper lookupHelper = new LookupHelper(getSource());
+        final LookupHelper lookupHelper = new LookupHelper(sourceFiles);
         // for each proto src directory generate code
-        for (final File protoFile : getSource()) {
+        for (final File protoFile : sourceFiles) {
             if (protoFile.exists()
                     && protoFile.isFile()
                     && protoFile.getName().endsWith(LookupHelper.PROTO_EXTENSIION)) {
                 final ContextualLookupHelper contextualLookupHelper =
                         new ContextualLookupHelper(lookupHelper, protoFile);
-                try (var input = new FileInputStream(protoFile)) {
+                try (final var input = new FileInputStream(protoFile)) {
                     final var lexer = new Protobuf3Lexer(CharStreams.fromStream(input));
                     final var parser = new Protobuf3Parser(new CommonTokenStream(lexer));
                     final Protobuf3Parser.ProtoContext parsedDoc = parser.proto();
-                    for (var topLevelDef : parsedDoc.topLevelDef()) {
+                    for (final var topLevelDef : parsedDoc.topLevelDef()) {
                         final Protobuf3Parser.MessageDefContext msgDef = topLevelDef.messageDef();
                         if (msgDef != null) {
                             // run all generators for message
-                            for (var generatorClass : Generator.GENERATORS) {
+                            for (final var generatorClass : Generator.GENERATORS) {
                                 final var generator =
                                         generatorClass.getDeclaredConstructor().newInstance();
                                 generator.generate(
                                         msgDef,
-                                        getJavaMainOutputDirectory().get().getAsFile(),
-                                        getJavaTestOutputDirectory().get().getAsFile(),
+                                        mainOutputDir,
+                                        testOutputDir,
                                         contextualLookupHelper);
                             }
                         }
@@ -100,7 +114,7 @@ public abstract class PbjCompilerTask extends SourceTask {
                             // run just enum generators for enum
                             EnumGenerator.generateEnumFile(
                                     enumDef,
-                                    getJavaMainOutputDirectory().get().getAsFile(),
+                                    mainOutputDir,
                                     contextualLookupHelper);
                         }
                     }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -644,7 +644,7 @@ public final class Common {
 						return;
 					}
 				}
-				throw new IllegalArgumentException(("Field %s.%s specified in `pbj.comparable` option has is supposed to implement " +
+				throw new IllegalArgumentException(("Field %s.%s specified in `pbj.comparable` option must implement " +
 						"`Comparable` interface but it doesn't.").formatted(className, field.nameCamelFirstLower()));
 			} catch (IOException e) {
 				throw new RuntimeException(e);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -2,8 +2,12 @@ package com.hedera.pbj.compiler.impl;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jetbrains.annotations.NotNull;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -183,7 +187,7 @@ public final class Common {
 	 * @return The generated code for getting the hashCode value.
 	 */
 	public static String getFieldsHashCode(final List<Field> fields, String generatedCodeSoFar) {
-		for(Field f : fields) {
+		for (Field f : fields) {
 			if (f.parent() != null) {
 				final OneOfField oneOfField = f.parent();
 				generatedCodeSoFar += getFieldsHashCode(oneOfField.fields(), generatedCodeSoFar);
@@ -347,7 +351,7 @@ public final class Common {
 	 * @return The generated code for getting the object equality
 	 */
 	public static String getFieldsEqualsStatements(final List<Field> fields, String generatedCodeSoFar) {
-		for(Field f : fields) {
+		for (Field f : fields) {
 			if (f.parent() != null) {
 				final OneOfField oneOfField = f.parent();
 				generatedCodeSoFar += getFieldsEqualsStatements(oneOfField.fields(), generatedCodeSoFar);
@@ -504,111 +508,153 @@ public final class Common {
 
 	/**
 	 * Generate the compareTo method content for the provided fields
-	 * @param fields The fields of this object.
-	 * @param generatedCodeSoFar the generated code so far (non-empty in case of nested objects)
+	 *
+	 * @param fields                The fields of this object.
+	 * @param generatedCodeSoFar    the generated code so far (non-empty in case of nested objects)
+	 * @param destinationSrcDir a directory where the previously generated code is saved
 	 * @return The generated code for compareTo method body
 	 */
-	public static String getFieldsCompareToStatements(final List<Field> fields, String generatedCodeSoFar) {
-		for(Field f : fields) {
-			if (f.parent() != null) {
-				final OneOfField oneOfField = f.parent();
-				generatedCodeSoFar += getFieldsCompareToStatements(oneOfField.fields(), generatedCodeSoFar);
-			}
-
+	public static String getFieldsCompareToStatements(final List<Field> fields, String generatedCodeSoFar, File destinationSrcDir) {
+		for (Field f : fields) {
 			if (f.optionalValueType()) {
 				generatedCodeSoFar += getPrimitiveWrapperCompareToGeneration(f);
-			}
-			else if (f.repeated()) {
-				// intentionally skipping repeated fields
+			} else if (f.repeated()) {
+				throw new UnsupportedOperationException("Repeated fields are not supported in compareTo method");
 			} else {
-				f.nameCamelFirstLower();
 				if (f.type() == Field.FieldType.FIXED32 ||
 						f.type() == Field.FieldType.INT32 ||
 						f.type() == Field.FieldType.SFIXED32 ||
-						f.type() == Field.FieldType.SINT32 ||
-						f.type() == Field.FieldType.UINT32) {
+						f.type() == Field.FieldType.SINT32) {
 					generatedCodeSoFar +=
 							"""
-                            result = Integer.compare($fieldName, thatObj.$fieldName);
-                            if (result != 0) {
-                                return result;
-                            }
-                            """.replace("$fieldName", f.nameCamelFirstLower());
+							result = Integer.compare($fieldName, thatObj.$fieldName);
+							if (result != 0) {
+							    return result;
+							}
+							""".replace("$fieldName", f.nameCamelFirstLower());
+				} else if (f.type() == Field.FieldType.UINT32) {
+						generatedCodeSoFar +=
+       						"""
+							result = Integer.compareUnsigned($fieldName, thatObj.$fieldName);
+							if (result != 0) {
+							    return result;
+							}
+							""".replace("$fieldName", f.nameCamelFirstLower());
+
 				} else if (f.type() == Field.FieldType.FIXED64 ||
 						f.type() == Field.FieldType.INT64 ||
 						f.type() == Field.FieldType.SFIXED64 ||
-						f.type() == Field.FieldType.SINT64 ||
-						f.type() == Field.FieldType.UINT64) {
+						f.type() == Field.FieldType.SINT64) {
 					generatedCodeSoFar +=
 							"""
-                            result = Long.compare($fieldName, thatObj.$fieldName);
-                            if (result != 0) {
-                                return result;
-                            }
-                            """.replace("$fieldName", f.nameCamelFirstLower());
+							result = Long.compare($fieldName, thatObj.$fieldName);
+							if (result != 0) {
+							    return result;
+							}
+							""".replace("$fieldName", f.nameCamelFirstLower());
+				} else if (f.type() == Field.FieldType.UINT64) {
+					generatedCodeSoFar +=
+							"""
+							result = Long.compareUnsigned($fieldName, thatObj.$fieldName);
+							if (result != 0) {
+							    return result;
+							}
+							""".replace("$fieldName", f.nameCamelFirstLower());
 				} else if (f.type() == Field.FieldType.BOOL) {
 					generatedCodeSoFar +=
 							"""
-                            result = Boolean.compare($fieldName, thatObj.$fieldName);
-                            if (result != 0) {
-                                return result;
-                            }
-                             """.replace("$fieldName", f.nameCamelFirstLower());
+							result = Boolean.compare($fieldName, thatObj.$fieldName);
+							if (result != 0) {
+							    return result;
+							}
+							""".replace("$fieldName", f.nameCamelFirstLower());
 				} else if (f.type() == Field.FieldType.FLOAT) {
 					generatedCodeSoFar +=
 							"""
-                            result = Float.compare($fieldName, thatObj.$fieldName);
-                            if (result != 0) {
-                                return result;
-                            }
-                             """.replace("$fieldName", f.nameCamelFirstLower());
+							result = Float.compare($fieldName, thatObj.$fieldName);
+							if (result != 0) {
+							    return result;
+							}
+							""".replace("$fieldName", f.nameCamelFirstLower());
 				} else if (f.type() == Field.FieldType.DOUBLE) {
 					generatedCodeSoFar +=
 							"""
-                            result = Double.compare($fieldName, thatObj.$fieldName);
-                            if (result != 0) {
-                                return result;
-                            }
-                             """.replace("$fieldName", f.nameCamelFirstLower());
-				} else if(f.type() == Field.FieldType.BYTES) {
-					generatedCodeSoFar +=
-							"""
-							// byte-to-byte comparison is most likely impractical, so we just compare the length
-							if ($fieldName == null && thatObj.$fieldName != null) {
-								return -1;
-							} else if ($fieldName != null && thatObj.$fieldName == null) {
-								return 1;
-							} else if ($fieldName != null) {
-								result = (int) ($fieldName.length() - thatObj.$fieldName.length());
-							}
-							if(result != 0) {
-								return result;
+							result = Double.compare($fieldName, thatObj.$fieldName);
+							if (result != 0) {
+							     return result;
 							}
 							""".replace("$fieldName", f.nameCamelFirstLower());
 				} else if (f.type() == Field.FieldType.STRING ||
-						f.type() == Field.FieldType.ENUM ||
-						f.parent() == null /* Process a sub-message */) {
-					generatedCodeSoFar += (
+						f.type() == Field.FieldType.ENUM) {
+					generatedCodeSoFar += generateCompareToForObject(f);
+				} else if (f.type() == Field.FieldType.BYTES) {
+					generatedCodeSoFar +=
 							"""
-                            if ($fieldName == null && thatObj.$fieldName != null) {
-                                return -1;
-                            }
-                            if ($fieldName != null &&  thatObj.$fieldName == null) {
-                                return 1;
-                            }
-                            if ($fieldName != null) {
-                                result = $fieldName.compareTo(thatObj.$fieldName);
-                            }
-                            if(result != 0) {
-                                return result;
-                            }
-                            """).replace("$fieldName", f.nameCamelFirstLower());
-				}  else {
-					throw new IllegalArgumentException("Unexpected field type for getting HashCode - " + f.type().toString());
+							result = $fieldName.compareTo(thatObj.$fieldName);
+							if (result != 0) {
+								return result;
+							}
+							 """.replace("$fieldName", f.nameCamelFirstLower());
+				} else if (f.type() == Field.FieldType.MESSAGE || f.type() == Field.FieldType.ONE_OF) {
+					verifyComparable(f, destinationSrcDir);
+					generatedCodeSoFar += generateCompareToForObject(f);
+				}else {
+					throw new IllegalArgumentException("Unexpected field type for getting CompareTo - " + f.type().toString());
 				}
 			}
 		}
 		return generatedCodeSoFar.indent(DEFAULT_INDENT * 2);
+	}
+
+	@NotNull
+	private static String generateCompareToForObject(Field f) {
+		return """
+				if ($fieldName == null && thatObj.$fieldName != null) {
+				    return -1;
+				}
+				if ($fieldName != null && thatObj.$fieldName == null) {
+				    return 1;
+				}
+				if ($fieldName != null) {
+				    result = $fieldName.compareTo(thatObj.$fieldName);
+				}
+				if (result != 0) {
+				    return result;
+				}
+				""".replace("$fieldName", f.nameCamelFirstLower());
+	}
+
+	/**
+	 * Verify that the field is comparable.
+	 * @param field The field to verify.
+	 * @param destinationSrcDir The directory where the previously generated code is saved.
+	 */
+	private static void verifyComparable(final Field field, File destinationSrcDir) {
+		if (field instanceof final SingleField singleField) {
+			if (singleField.type() != Field.FieldType.MESSAGE) {
+				// everything else except message and bytes is comparable for sure
+				return;
+			}
+			// let's check if the message implements Comparable
+			final String className = singleField.javaFieldType();
+			final File javaFile = getJavaFile(destinationSrcDir, singleField.messageTypeModelPackage(), className);
+			try (BufferedReader reader = new BufferedReader(new FileReader(javaFile))) {
+				String line;
+				while ((line = reader.readLine()) != null) {
+					if (line.contains("implements Comparable")) {
+						return;
+					}
+				}
+				throw new IllegalArgumentException(("Field %s.%s specified in `pbj.comparable` option has is supposed to implement " +
+						"`Comparable` interface but it doesn't.").formatted(className, field.nameCamelFirstLower()));
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+        } if (field instanceof final OneOfField oneOfField) {
+			oneOfField.fields().forEach(v -> verifyComparable(v, destinationSrcDir));
+		} else {
+			throw new UnsupportedOperationException("Unexpected field type - " + field.getClass());
+		}
 	}
 
 	/**
@@ -626,7 +672,7 @@ public final class Common {
                     } else if ($fieldName != null) {
                         result = $compareStatement;
                     }
-                    if(result != 0) {
+                    if (result != 0) {
                         return result;
                     }
                     """;

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -2,7 +2,6 @@ package com.hedera.pbj.compiler.impl;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -606,7 +605,7 @@ public final class Common {
 		return generatedCodeSoFar.indent(DEFAULT_INDENT * 2);
 	}
 
-	@NotNull
+	@NonNull
 	private static String generateCompareToForObject(Field f) {
 		return """
 				if ($fieldName == null && thatObj.$fieldName != null) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -32,9 +33,10 @@ public final class Common {
 	public static final int TYPE_LENGTH_DELIMITED = 2;
 	/** Wire format code for fixed 32bit number */
 	public static final int TYPE_FIXED32 = 5;
+    private static final Pattern COMPARABLE_PATTERN = Pattern.compile("class\\s+\\w+\\s+implements\\s+Comparable");
 
 
-	/**
+    /**
 	 * Makes a tag value given a field number and wire type.
 	 *
 	 * @param wireType the wire type part of tag
@@ -584,16 +586,9 @@ public final class Common {
 							}
 							""".replace("$fieldName", f.nameCamelFirstLower());
 				} else if (f.type() == Field.FieldType.STRING ||
+						f.type() == Field.FieldType.BYTES ||
 						f.type() == Field.FieldType.ENUM) {
 					generatedCodeSoFar += generateCompareToForObject(f);
-				} else if (f.type() == Field.FieldType.BYTES) {
-					generatedCodeSoFar +=
-							"""
-							result = $fieldName.compareTo(thatObj.$fieldName);
-							if (result != 0) {
-								return result;
-							}
-							 """.replace("$fieldName", f.nameCamelFirstLower());
 				} else if (f.type() == Field.FieldType.MESSAGE || f.type() == Field.FieldType.ONE_OF) {
 					verifyComparable(f, destinationSrcDir);
 					generatedCodeSoFar += generateCompareToForObject(f);
@@ -640,7 +635,7 @@ public final class Common {
 			try (BufferedReader reader = new BufferedReader(new FileReader(javaFile))) {
 				String line;
 				while ((line = reader.readLine()) != null) {
-					if (line.contains("implements Comparable")) {
+					if (COMPARABLE_PATTERN.matcher(line).matches()) {
 						return;
 					}
 				}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -597,7 +597,7 @@ public final class Common {
 				} else if (f.type() == Field.FieldType.MESSAGE || f.type() == Field.FieldType.ONE_OF) {
 					verifyComparable(f, destinationSrcDir);
 					generatedCodeSoFar += generateCompareToForObject(f);
-				}else {
+				} else {
 					throw new IllegalArgumentException("Unexpected field type for getting CompareTo - " + f.type().toString());
 				}
 			}
@@ -677,31 +677,16 @@ public final class Common {
                     """;
 
 
-		final String compareStatement;
-		switch (f.messageType()) {
-			case "StringValue" ->
-					compareStatement =
-							"$fieldName.compareTo(thatObj.$fieldName)";
-			case "BoolValue" ->
-					compareStatement =
-							"java.lang.Boolean.compare($fieldName, thatObj.$fieldName)";
-			case "Int32Value", "UInt32Value" ->
-					compareStatement =
-							"java.lang.Integer.compare($fieldName, thatObj.$fieldName)";
-			case "Int64Value", "UInt64Value" ->
-					compareStatement =
-							"java.lang.Long.compare($fieldName, thatObj.$fieldName)";
-			case "FloatValue" ->
-					compareStatement =
-							"java.lang.Float.compare($fieldName, thatObj.$fieldName)";
-			case "DoubleValue" ->
-					compareStatement =
-							"java.lang.Double.compare($fieldName, thatObj.$fieldName)";
-			case "BytesValue" ->
-					compareStatement =
-							"(int)($fieldName.length() - thatObj.$fieldName.length())";
+		final String compareStatement = switch (f.messageType()) {
+			case "StringValue" -> "$fieldName.compareTo(thatObj.$fieldName)";
+			case "BoolValue" -> "java.lang.Boolean.compare($fieldName, thatObj.$fieldName)";
+			case "Int32Value", "UInt32Value" -> "java.lang.Integer.compare($fieldName, thatObj.$fieldName)";
+			case "Int64Value", "UInt64Value" -> "java.lang.Long.compare($fieldName, thatObj.$fieldName)";
+			case "FloatValue" -> "java.lang.Float.compare($fieldName, thatObj.$fieldName)";
+			case "DoubleValue" -> "java.lang.Double.compare($fieldName, thatObj.$fieldName)";
+			case "BytesValue" -> "(int)($fieldName.length() - thatObj.$fieldName.length())";
 			default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
-		}
+		};
 
 		return template
 				.replace("$compareStatement", compareStatement)

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -33,7 +33,7 @@ public final class Common {
 	public static final int TYPE_LENGTH_DELIMITED = 2;
 	/** Wire format code for fixed 32bit number */
 	public static final int TYPE_FIXED32 = 5;
-    private static final Pattern COMPARABLE_PATTERN = Pattern.compile("class\\s+\\w+\\s+implements\\s+Comparable");
+    private static final Pattern COMPARABLE_PATTERN = Pattern.compile("[)] implements Comparable<\\w+> [{]");
 
 
     /**
@@ -673,14 +673,15 @@ public final class Common {
 
 
 		final String compareStatement = switch (f.messageType()) {
-			case "StringValue" -> "$fieldName.compareTo(thatObj.$fieldName)";
+			case "StringValue", "BytesValue" -> "$fieldName.compareTo(thatObj.$fieldName)";
 			case "BoolValue" -> "java.lang.Boolean.compare($fieldName, thatObj.$fieldName)";
-			case "Int32Value", "UInt32Value" -> "java.lang.Integer.compare($fieldName, thatObj.$fieldName)";
-			case "Int64Value", "UInt64Value" -> "java.lang.Long.compare($fieldName, thatObj.$fieldName)";
+			case "Int32Value" -> "java.lang.Integer.compare($fieldName, thatObj.$fieldName)";
+			case "UInt32Value" -> "java.lang.Integer.compareUnsigned($fieldName, thatObj.$fieldName)";
+			case "Int64Value" -> "java.lang.Long.compare($fieldName, thatObj.$fieldName)";
+			case "UInt64Value" -> "java.lang.Long.compareUnsigned($fieldName, thatObj.$fieldName)";
 			case "FloatValue" -> "java.lang.Float.compare($fieldName, thatObj.$fieldName)";
 			case "DoubleValue" -> "java.lang.Double.compare($fieldName, thatObj.$fieldName)";
-			case "BytesValue" -> "(int)($fieldName.length() - thatObj.$fieldName.length())";
-			default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
+            default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
 		};
 
 		return template

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.compiler.impl;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.*;
 
 import java.io.File;
+import java.util.Set;
 
 /**
  * Wrapper around LookupHelper adding the context of which protobuf source file the lookup is happening within. This
@@ -44,8 +45,17 @@ public class ContextualLookupHelper {
      * @param message The msgDef to get fully qualified class name for
      * @return fully qualified class name
      */
-    public String getFullyQualifiedMessageClassname(FileType fileType, MessageDefContext message) {
+    public String getFullyQualifiedMessageClassname(final FileType fileType, final MessageDefContext message) {
         return lookupHelper.getFullyQualifiedClass(srcProtoFileContext, fileType, message);
+    }
+
+    /**
+     * Get the set of fields that are comparable for a given message.
+     * @param message The message to get comparable fields for
+     * @return set of field names that are comparable
+     */
+    public Set<String> getComparableFields(final MessageDefContext message) {
+        return lookupHelper.getComparableFields(message);
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
@@ -3,7 +3,7 @@ package com.hedera.pbj.compiler.impl;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.*;
 
 import java.io.File;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Wrapper around LookupHelper adding the context of which protobuf source file the lookup is happening within. This
@@ -54,7 +54,7 @@ public class ContextualLookupHelper {
      * @param message The message to get comparable fields for
      * @return set of field names that are comparable
      */
-    public Set<String> getComparableFields(final MessageDefContext message) {
+    public List<String> getComparableFields(final MessageDefContext message) {
         return lookupHelper.getComparableFields(message);
     }
 

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -21,22 +21,31 @@ import static java.util.regex.Matcher.quoteReplacement;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Lexer;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
-import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.*;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.EnumDefContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageDefContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageElementContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageTypeContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.TopLevelDefContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
 
 /**
  * Class that manages packages and enum names that are used more than one place in code generation

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -16,6 +16,7 @@
 
 package com.hedera.pbj.compiler.impl;
 
+import static java.util.Collections.emptySet;
 import static java.util.regex.Matcher.quoteReplacement;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Lexer;
@@ -29,7 +30,10 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -48,8 +52,14 @@ public final class LookupHelper {
     private static final String PBJ_MESSAGE_PACKAGE_OPTION_NAME = "pbj.message_java_package";
     /** The option name for PBJ package at msgDef level */
     private static final String PBJ_ENUM_PACKAGE_OPTION_NAME = "pbj.enum_java_package";
+
+    private static final String PBJ_COMPARABLE_OPTION_NAME = "pbj.comparable";
+
     /** The option name for protoc java package at file level */
     private static final String PROTOC_JAVA_PACKAGE_OPTION_NAME = "java_package";
+
+    /** Extension for protobuf files */
+    public static final String PROTO_EXTENSIION = ".proto";
 
     /**
      * Map from fully qualified msgDef name to fully qualified pbj java package, not including java
@@ -65,6 +75,9 @@ public final class LookupHelper {
 
     /** Map from proto file path to list of other proto files it imports */
     private final Map<String, Set<String>> protoFileImports = new HashMap<>();
+
+    /** Map from fully qualified msgDef name to set of field names that are comparable */
+    private final Map<String, Set<String>> comparableFieldsByMsg = new HashMap<>();
 
     /**
      * Map from file path to map of message/enum name to fully qualified message/enum name. This
@@ -85,7 +98,7 @@ public final class LookupHelper {
      *
      * @param allSrcFiles collection of all proto src files
      */
-    public LookupHelper(Iterable<File> allSrcFiles) {
+    public LookupHelper(final Iterable<File> allSrcFiles) {
         build(allSrcFiles);
     }
 
@@ -141,7 +154,7 @@ public final class LookupHelper {
                 return nameFoundInLocalFile;
             }
             // message type is not from local file so check imported files
-            for (var importedProtoFilePath : protoFileImports.get(protoSrcFile.getAbsolutePath())) {
+            for (final var importedProtoFilePath : protoFileImports.get(protoSrcFile.getAbsolutePath())) {
                 final var messageMap = msgAndEnumByFile.get(importedProtoFilePath);
                 if (messageMap == null) {
                     throw new PbjCompilerException(
@@ -166,7 +179,7 @@ public final class LookupHelper {
                                             .get(protoSrcFile.getAbsolutePath())
                                             .toArray()));
         } else if (context instanceof MessageDefContext || context instanceof EnumDefContext) {
-            Map<String, String> fileMap = msgAndEnumByFile.get(protoSrcFile.getAbsolutePath());
+            final Map<String, String> fileMap = msgAndEnumByFile.get(protoSrcFile.getAbsolutePath());
             if (fileMap == null) {
                 throw new PbjCompilerException(
                         "Failed to find messageMapLocal for proto file [" + protoSrcFile + "]");
@@ -226,6 +239,7 @@ public final class LookupHelper {
      * @param context Parser Context, a message or enum
      * @return java package to put model class in
      */
+    @Nullable
     String getPackage(
             final File protoSrcFile, final FileType fileType, final ParserRuleContext context) {
         if (context instanceof MessageDefContext
@@ -235,7 +249,7 @@ public final class LookupHelper {
             if (qualifiedProtoName.startsWith("google.protobuf")) {
                 return null;
             } else if (fileType == FileType.PROTOC) {
-                String protocPackage = protocPackageMap.get(qualifiedProtoName);
+                final String protocPackage = protocPackageMap.get(qualifiedProtoName);
                 if (protocPackage == null) {
                     throw new PbjCompilerException(
                             "Not found protoc package for message or enum ["
@@ -246,7 +260,7 @@ public final class LookupHelper {
                 }
                 return protocPackage;
             } else {
-                String basePackage = pbjPackageMap.get(qualifiedProtoName);
+                final String basePackage = pbjPackageMap.get(qualifiedProtoName);
                 if (basePackage == null) {
                     throw new PbjCompilerException(
                             "Not found pbj package for message or enum ["
@@ -294,7 +308,7 @@ public final class LookupHelper {
             final String parentClasses;
             if (fileType == FileType.PROTOC
                     && context.getParent() instanceof MessageElementContext) {
-                StringBuilder sb = new StringBuilder();
+                final StringBuilder sb = new StringBuilder();
                 ParserRuleContext parent = context.getParent();
                 while (!(parent instanceof TopLevelDefContext)) {
                     if (parent instanceof MessageDefContext) {
@@ -320,7 +334,7 @@ public final class LookupHelper {
      * @param fullyQualifiedMessageOrEnumName to check if enum
      * @return true if known as an enum, recorded by addEnum()
      */
-    private boolean isEnum(String fullyQualifiedMessageOrEnumName) {
+    private boolean isEnum(final String fullyQualifiedMessageOrEnumName) {
         return enumNames.contains(fullyQualifiedMessageOrEnumName);
     }
 
@@ -330,7 +344,7 @@ public final class LookupHelper {
      * @param messageType field message type to check if enum
      * @return true if known as an enum, recorded by addEnum()
      */
-    boolean isEnum(File protoSrcFile, MessageTypeContext messageType) {
+    boolean isEnum(final File protoSrcFile, final MessageTypeContext messageType) {
         return isEnum(getFullyQualifiedProtoName(protoSrcFile, messageType));
     }
 
@@ -344,23 +358,23 @@ public final class LookupHelper {
      *
      * @param allSrcFiles collection of all proto src files
      */
-    private void build(Iterable<File> allSrcFiles) {
-        for (File file : allSrcFiles) {
+    private void build(final Iterable<File> allSrcFiles) {
+        for (final File file : allSrcFiles) {
             final Path filePath = file.toPath();
             final String fullQualifiedFile = file.getAbsolutePath();
-            if (file.exists() && file.isFile() && file.getName().endsWith(".proto")) {
-                try (var input = new FileInputStream(file)) {
+            if (file.exists() && file.isFile() && file.getName().endsWith(PROTO_EXTENSIION)) {
+                try (final var input = new FileInputStream(file)) {
                     // parse file
                     final var lexer = new Protobuf3Lexer(CharStreams.fromStream(input));
                     final var parser = new Protobuf3Parser(new CommonTokenStream(lexer));
-                    Protobuf3Parser.ProtoContext parsedDoc = parser.proto();
+                    final Protobuf3Parser.ProtoContext parsedDoc = parser.proto();
                     // create entry in map for file
                     msgAndEnumByFile.computeIfAbsent(fullQualifiedFile, fqf -> new HashMap<>());
                     // look for PBJ package option
                     String pbjJavaPackage = null;
                     String protocJavaPackage = null;
                     // check for custom option
-                    for (var option : parsedDoc.optionStatement()) {
+                    for (final var option : parsedDoc.optionStatement()) {
                         switch (option.optionName().getText().replaceAll("[()]", "")) {
                             case PBJ_PACKAGE_OPTION_NAME -> pbjJavaPackage =
                                     option.constant().getText().replaceAll("\"", "");
@@ -369,7 +383,7 @@ public final class LookupHelper {
                         }
                     }
                     // check for special comment option
-                    for (var optionComment : parsedDoc.optionComment()) {
+                    for (final var optionComment : parsedDoc.optionComment()) {
                         final var matcher = OPTION_COMMENT.matcher(optionComment.getText());
                         if (matcher.find()) {
                             final String optionName = matcher.group(1);
@@ -405,7 +419,7 @@ public final class LookupHelper {
                     final Set<String> fileImports =
                             protoFileImports.computeIfAbsent(
                                     fullQualifiedFile, key -> new HashSet<>());
-                    for (var importStatement : parsedDoc.importStatement()) {
+                    for (final var importStatement : parsedDoc.importStatement()) {
                         final String importedFileName =
                                 normalizeFileName(importStatement.strLit().getText());
                         // ignore standard google protobuf imports as we do not need them
@@ -415,7 +429,7 @@ public final class LookupHelper {
                         }
                         // now scan all src files to find import as there can be many src
                         // directories
-                        List<File> matchingSrcFiles =
+                        final List<File> matchingSrcFiles =
                                 StreamSupport.stream(allSrcFiles.spliterator(), false)
                                         .filter(
                                                 srcFile ->
@@ -448,7 +462,7 @@ public final class LookupHelper {
                     // process message and enum defs
                     final String fileLevelJavaPackage =
                             (pbjJavaPackage != null) ? pbjJavaPackage : protocJavaPackage;
-                    for (var item : parsedDoc.topLevelDef()) {
+                    for (final var item : parsedDoc.topLevelDef()) {
                         if (item.messageDef() != null)
                             buildMessage(
                                     fullQualifiedFile,
@@ -462,7 +476,7 @@ public final class LookupHelper {
                                     protocJavaPackage,
                                     item.enumDef());
                     }
-                } catch (IOException e) {
+                } catch (final IOException e) {
                     throw new RuntimeException(e);
                 }
             }
@@ -472,7 +486,7 @@ public final class LookupHelper {
     }
 
     @NonNull
-    static String normalizeFileName(String fileName) {
+    static String normalizeFileName(final String fileName) {
         return fileName.replaceAll("\"", "")
                 .replaceAll("/", quoteReplacement(FileSystems.getDefault().getSeparator()));
     }
@@ -481,29 +495,29 @@ public final class LookupHelper {
     private void printDebug() {
         System.out.println(
                 "== Package Map =================================================================");
-        for (var entry : pbjPackageMap.entrySet()) {
+        for (final var entry : pbjPackageMap.entrySet()) {
             System.out.println("entry = " + entry.getKey() + " = " + entry.getValue());
         }
         System.out.println(
                 "== Enum Names =================================================================");
-        for (var enumName : enumNames) {
+        for (final var enumName : enumNames) {
             System.out.println("enumName = " + enumName);
         }
         System.out.println(
                 "== Proto File Imports"
                         + " =================================================================");
-        for (var entry : protoFileImports.entrySet()) {
+        for (final var entry : protoFileImports.entrySet()) {
             System.out.println("FILE - " + entry.getKey());
-            for (var imp : entry.getValue()) {
+            for (final var imp : entry.getValue()) {
                 System.out.println("    IMPORT - " + imp);
             }
         }
         System.out.println(
                 "== Message Imports"
                         + " =================================================================");
-        for (var entry : msgAndEnumByFile.entrySet()) {
+        for (final var entry : msgAndEnumByFile.entrySet()) {
             System.out.println("FILE - " + entry.getKey());
-            for (var entry2 : entry.getValue().entrySet()) {
+            for (final var entry2 : entry.getValue().entrySet()) {
                 System.out.println("    " + entry2.getKey() + " -> " + entry2.getValue());
             }
         }
@@ -529,6 +543,9 @@ public final class LookupHelper {
         final var msgName = msgDef.messageName().getText();
         // check for msgDef/enum level pbj package level override option
         String messagePbjPackage = fileLevelPbjJavaPackage;
+
+        final String fullyQualifiedMessage = getFullyQualifiedProtoNameForMsgOrEnum(msgDef);
+        comparableFieldsByMsg.computeIfAbsent(fullyQualifiedMessage, v -> extractComparableFields(msgDef));
         for (final var element : msgDef.messageBody().messageElement()) {
             final var option = element.optionStatement();
             if (option != null) {
@@ -549,7 +566,6 @@ public final class LookupHelper {
                 }
             }
         }
-        final String fullyQualifiedMessage = getFullyQualifiedProtoNameForMsgOrEnum(msgDef);
         // insert into maps
         pbjPackageMap.put(fullyQualifiedMessage, messagePbjPackage);
         protocPackageMap.put(fullyQualifiedMessage, fileLevelProtocJavaPackage);
@@ -558,7 +574,7 @@ public final class LookupHelper {
                 .put(msgName, fullyQualifiedMessage);
 
         // handle child messages and enums
-        for (var item : msgDef.messageBody().messageElement()) {
+        for (final var item : msgDef.messageBody().messageElement()) {
             if (item.messageDef() != null) {
                 buildMessage(
                         fullQualifiedFile,
@@ -574,6 +590,35 @@ public final class LookupHelper {
                         item.enumDef());
             }
         }
+    }
+
+    /**
+     * Extract the set of fields that are comparable for a given message.
+     * @param msgDef The message defenition to get comparable fields for
+     * @return set of field names that are comparable
+     */
+    static Set<String> extractComparableFields(final MessageDefContext msgDef) {
+        if(msgDef.optionComment() == null || msgDef.optionComment().getText() == null) {
+            return emptySet();
+        }
+        final var matcher = OPTION_COMMENT.matcher(msgDef.optionComment().getText());
+        if (matcher.find()) {
+            final String optionName = matcher.group(1);
+            final String optionValue = matcher.group(2);
+            if(optionName.equals(PBJ_COMPARABLE_OPTION_NAME)) {
+                final Set<String> fieldNames = msgDef.messageBody().messageElement().stream().map(v -> v.field().fieldName().getText()).collect(Collectors.toSet());
+                return Arrays.stream(optionValue.split(","))
+                        .map(String::trim)
+                        .peek(v -> {
+                            if(!fieldNames.contains(v)) {
+                                throw new IllegalArgumentException(
+                                        "Field '%s' specified in %s option is not found.".formatted(v, PBJ_COMPARABLE_OPTION_NAME));
+                            }
+                        })
+                        .collect(Collectors.toSet());
+            }
+        }
+        return emptySet();
     }
 
     /**
@@ -657,5 +702,14 @@ public final class LookupHelper {
             thisName = getFullyQualifiedProtoNameForMsgOrEnum(ruleContext.getParent());
         }
         return Common.removingLeadingDot(thisName);
+    }
+
+    /**
+     * Get the set of fields that are comparable for a given message.
+     * @param message The message to get comparable fields for
+     * @return set of field names that are comparable
+     */
+    Set<String> getComparableFields(MessageDefContext message) {
+        return comparableFieldsByMsg.get(getFullyQualifiedProtoNameForMsgOrEnum(message));
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
@@ -36,7 +36,7 @@ public record OneOfField(
 			false,
 			getDeprecatedOption(oneOfContext.optionStatement())
 		);
-		for(var field: oneOfContext.oneofField()) {
+		for (var field: oneOfContext.oneofField()) {
 			fields.add(new SingleField(field, this, lookupHelper));
 		}
 	}
@@ -88,7 +88,7 @@ public record OneOfField(
 	public void addAllNeededImports(final Set<String> imports, boolean modelImports,
 									boolean codecImports, final boolean testImports) {
 		imports.add("com.hedera.pbj.runtime");
-		for(var field:fields) {
+		for (var field:fields) {
 			field.addAllNeededImports(imports, modelImports, codecImports, testImports);
 		}
 	}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
@@ -16,9 +16,9 @@ public record OneOfField(
 		String comment,
 		List<Field> fields,
 		boolean repeated,
-		boolean deprecated
+		boolean deprecated,
+		boolean comparable
 ) implements Field {
-
 	/**
 	 * Create a OneOf field from parser context
 	 *
@@ -34,11 +34,20 @@ public record OneOfField(
 					oneOfContext.docComment()),
 			new ArrayList<>(oneOfContext.oneofField().size()),
 			false,
-			getDeprecatedOption(oneOfContext.optionStatement())
+			getDeprecatedOption(oneOfContext.optionStatement()),
+			isComparable(oneOfContext, lookupHelper)
 		);
 		for (var field: oneOfContext.oneofField()) {
 			fields.add(new SingleField(field, this, lookupHelper));
 		}
+	}
+
+	private static boolean isComparable(Protobuf3Parser.OneofContext oneOfContext, ContextualLookupHelper lookupHelper) {
+		final boolean comparable;
+		final List<String> comparableFields = lookupHelper.getComparableFields(((Protobuf3Parser.MessageDefContext)
+				oneOfContext.getParent().getParent().getParent()));
+		comparable = comparableFields.contains(oneOfContext.oneofName().getText());
+		return comparable;
 	}
 
 	/**
@@ -70,7 +79,11 @@ public record OneOfField(
 	 */
 	@Override
 	public String javaFieldType() {
-		return "OneOf<"+getEnumClassRef()+">";
+		return "%s<%s>".formatted(className(), getEnumClassRef());
+	}
+
+	public String className() {
+		return comparable ? "ComparableOneOf" : "OneOf";
 	}
 
 	/**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -242,14 +242,16 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 		final String fieldNameToSet = parent != null ? parent.name() : name;
 		if (optionalValueType()) {
 			if (parent != null) { // one of
-				return "case %d -> this.%s = new OneOf<>(%s.%sOneOfType.%s, input);"
-						.formatted(fieldNumber, fieldNameToSet, parent.parentMessageName(), Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name));
+				return "case %d -> this.%s = new %s<>(%s.%sOneOfType.%s, input);"
+						.formatted(fieldNumber, fieldNameToSet, parent.className(), parent.parentMessageName(),
+								Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name));
 			} else {
 				return "case %d -> this.%s = input;".formatted(fieldNumber, fieldNameToSet);
 			}
 		} else if (type == FieldType.MESSAGE) {
 			final String valueToSet = parent != null ?
-					"new OneOf<>($parentMessageName.$parentNameOneOfType.$parentName, %modelClass.PROTOBUF.parse(input))"
+					"new $className<>($parentMessageName.$parentNameOneOfType.$parentName, %modelClass.PROTOBUF.parse(input))"
+							.replace("$className", parent.className())
 							.replace("$parentMessageName", parent.parentMessageName())
 							.replace("$parentName", Common.snakeToCamel(parent.name(), true))
 							.replace("$parseCode", parseCode())
@@ -277,7 +279,8 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 			}
 		} else if (repeated && (type == FieldType.STRING || type == FieldType.BYTES)) {
 			final String valueToSet = parent != null ?
-					"new OneOf<>(%s.%sOneOfType.%s,input)".formatted(parent.parentMessageName(), Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
+					"new %s<>(%s.%sOneOfType.%s,input)".formatted(parent.className(), parent.parentMessageName(),
+							Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
 					"input";
 			return """
 				case %d -> {
@@ -290,7 +293,8 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 
 		} else {
 			final String valueToSet = parent != null ?
-					"new OneOf<>(%s.%sOneOfType.%s,input)".formatted(parent.parentMessageName(), Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
+					"new %s<>(%s.%sOneOfType.%s,input)".formatted(parent.className(), parent.parentMessageName(),
+							Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
 					"input";
 			return "case %d -> this.%s = %s;".formatted(fieldNumber, fieldNameToSet,valueToSet);
 		}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
@@ -42,7 +42,7 @@ public final class EnumGenerator {
 		String deprecated = "";
 		final Map<Integer, EnumValue> enumValues = new HashMap<>();
 		int maxIndex = 0;
-		for(var item: enumDef.enumBody().enumElement()) {
+		for (var item: enumDef.enumBody().enumElement()) {
 			if (item.enumField() != null && item.enumField().ident() != null) {
 				final var enumValueName = item.enumField().ident().getText();
 				final var enumNumber = Integer.parseInt(item.enumField().intLit().getText());

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -398,8 +398,9 @@ public final class ModelGenerator implements Generator {
 							// handle special case where protobuf does not have destination between a OneOf with optional
 							// value of empty vs an unset OneOf.
 							if ($fieldName.kind() == $fieldUpperNameOneOfType.$subFieldNameUpper && $fieldName.value() == null) {
-								$fieldName = new OneOf<>($fieldUpperNameOneOfType.UNSET, null);
+								$fieldName = new $className<>($fieldUpperNameOneOfType.UNSET, null);
 							}"""
+							.replace("$className", oof.className())
 							.replace("$fieldName", f.nameCamelFirstLower())
 							.replace("$fieldUpperName", f.nameCamelFirstUpper())
 							.replace("$subFieldNameUpper", camelToUpperSnake(subField.name()))
@@ -627,8 +628,8 @@ public final class ModelGenerator implements Generator {
 		final String prefix, postfix, fieldToSet;
 		final OneOfField parentOneOfField = field.parent();
 		if (parentOneOfField != null) {
-			final String oneOfEnumValue = parentOneOfField.getEnumClassRef()+"."+camelToUpperSnake(field.name());
-			prefix = " new OneOf<>("+oneOfEnumValue+",";
+			final String oneOfEnumValue = parentOneOfField.getEnumClassRef() + "." + camelToUpperSnake(field.name());
+			prefix = " new %s<>(".formatted(parentOneOfField.className()) + oneOfEnumValue + ",";
 			postfix = ")";
 			fieldToSet = parentOneOfField.nameCamelFirstLower();
 		} else {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -17,6 +17,9 @@ import com.hedera.pbj.compiler.impl.FileType;
 import com.hedera.pbj.compiler.impl.OneOfField;
 import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageDefContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.antlr.v4.runtime.misc.NotNull;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -55,9 +58,10 @@ public final class ModelGenerator implements Generator {
 	 *
 	 * <p>Generates a new model object, as a Java Record type.
 	 */
-	public void generate(final Protobuf3Parser.MessageDefContext msgDef,
-						 final File destinationSrcDir,
-						 File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
+	public void generate(final MessageDefContext msgDef,
+                         final File destinationSrcDir,
+                         final File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
+
 
 		// The javaRecordName will be something like "AccountID".
 		final var javaRecordName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
@@ -88,140 +92,15 @@ public final class ModelGenerator implements Generator {
 		imports.add("edu.umd.cs.findbugs.annotations");
 
 		// Iterate over all the items in the protobuf schema
-		for(var item: msgDef.messageBody().messageElement()) {
+		for(final var item: msgDef.messageBody().messageElement()) {
 			if (item.messageDef() != null) { // process sub messages
 				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
 			} else if (item.oneof() != null) { // process one ofs
-				final var oneOfField = new OneOfField(item.oneof(), javaRecordName, lookupHelper);
-				final var enumName = oneOfField.nameCamelFirstUpper() + "OneOfType";
-				final int maxIndex = oneOfField.fields().get(oneOfField.fields().size() - 1).fieldNumber();
-				final Map<Integer, EnumValue> enumValues = new HashMap<>();
-				for (final var field : oneOfField.fields()) {
-					final String javaFieldType = javaPrimitiveToObjectType(field.javaFieldType());
-					final String enumComment = cleanDocStr(field.comment())
-						.replaceAll("[\t\s]*/\\*\\*","") // remove doc start indenting
-						.replaceAll("\n[\t\s]+\\*","\n") // remove doc indenting
-						.replaceAll("/\\*\\*","") //  remove doc start
-						.replaceAll("\\*\\*/",""); //  remove doc end
-					enumValues.put(field.fieldNumber(), new EnumValue(field.name(), field.deprecated(), enumComment));
-					// generate getters for one ofs
-					oneofGetters.add("""
-							/**
-							 * Direct typed getter for one of field $fieldName.
-							 *
-							 * @return one of value or null if one of is not set or a different one of value
-							 */
-							public @Nullable $javaFieldType $fieldName() {
-								return $oneOfField.kind() == $enumName.$enumValue ? ($javaFieldType)$oneOfField.value() : null;
-							}
-							
-							/**
-							 * Convenience method to check if the $oneOfField has a one-of with type $enumValue
-							 *
-							 * @return true of the one of kind is $enumValue
-							 */
-							public boolean has$fieldNameUpperFirst() {
-							    return $oneOfField.kind() == $enumName.$enumValue;
-							}
-							
-							/**
-							 * Gets the value for $fieldName if it has a value, or else returns the default
-							 * value for the type.
-							 *
-							 * @param defaultValue the default value to return if $fieldName is null
-							 * @return the value for $fieldName if it has a value, or else returns the default value
-							 */
-							public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
-							    return has$fieldNameUpperFirst() ? $fieldName() : defaultValue;
-							}
-							
-							/**
-							 * Gets the value for $fieldName if it was set, or throws a NullPointerException if it was not set.
-							 *
-							 * @return the value for $fieldName if it has a value
-							 * @throws NullPointerException if $fieldName is null
-							 */
-							public @NonNull $javaFieldType $fieldNameOrThrow() {
-							    return requireNonNull($fieldName(), "Field $fieldName is null");
-							}
-							"""
-							.replace("$fieldNameUpperFirst",field.nameCamelFirstUpper())
-							.replace("$fieldName",field.nameCamelFirstLower())
-							.replace("$javaFieldType",javaFieldType)
-							.replace("$oneOfField",oneOfField.nameCamelFirstLower())
-							.replace("$enumName",enumName)
-							.replace("$enumValue",camelToUpperSnake(field.name()))
-							.indent(DEFAULT_INDENT)
-					);
-					if (field.type() == Field.FieldType.MESSAGE) {
-						field.addAllNeededImports(imports, true, false, false);
-					}
-				}
-				final String enumComment = """
-									/**
-									 * Enum for the type of "%s" oneof value
-									 */""".formatted(oneOfField.name());
-				final String enumString = createEnum(enumComment ,"",enumName,maxIndex,enumValues, true)
-						.indent(DEFAULT_INDENT * 2);
-				oneofEnums.add(enumString);
-				fields.add(oneOfField);
-				imports.add("com.hedera.pbj.runtime");
+				oneofGetters.addAll(generateCodeForOneOf(lookupHelper, item, javaRecordName, imports, oneofEnums, fields));
 			} else if (item.mapField() != null) { // process map fields
 				System.err.println("Encountered a mapField that was not handled in " + javaRecordName);
 			} else if (item.field() != null && item.field().fieldName() != null) {
-				final SingleField field = new SingleField(item.field(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, false, false);
-				if (field.type() == FieldType.MESSAGE) {
-					hasMethods.add("""
-							/**
-							 * Convenience method to check if the $fieldName has a value
-							 *
-							 * @return true of the $fieldName has a value
-							 */
-							public boolean has$fieldNameUpperFirst() {
-							    return $fieldName != null;
-							}
-							
-							/**
-							 * Gets the value for $fieldName if it has a value, or else returns the default
-							 * value for the type.
-							 *
-							 * @param defaultValue the default value to return if $fieldName is null
-							 * @return the value for $fieldName if it has a value, or else returns the default value
-							 */
-							public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
-							    return has$fieldNameUpperFirst() ? $fieldName : defaultValue;
-							}
-							
-							/**
-							 * Gets the value for $fieldName if it has a value, or else throws an NPE.
-							 * value for the type.
-							 *
-							 * @return the value for $fieldName if it has a value
-							 * @throws NullPointerException if $fieldName is null
-							 */
-							public @NonNull $javaFieldType $fieldNameOrThrow() {
-							    return requireNonNull($fieldName, "Field $fieldName is null");
-							}
-							
-							/**
-							 * Executes the supplied {@link Consumer} if, and only if, the $fieldName has a value
-							 *
-							 * @param ifPresent the {@link Consumer} to execute
-							 */
-							public void if$fieldNameUpperFirst(@NonNull final Consumer<$javaFieldType> ifPresent) {
-							    if (has$fieldNameUpperFirst()) {
-							        ifPresent.accept($fieldName);
-							    }
-							}
-							"""
-							.replace("$fieldNameUpperFirst", field.nameCamelFirstUpper())
-							.replace("$javaFieldType", field.javaFieldType())
-							.replace("$fieldName", field.nameCamelFirstLower())
-							.indent(DEFAULT_INDENT)
-					);
-				}
+				generateCodeForField(lookupHelper, item, fields, imports, hasMethods);
 			} else if (item.optionStatement() != null){
 				if ("deprecated".equals(item.optionStatement().optionName().getText())) {
 					deprecated = "@Deprecated ";
@@ -235,11 +114,10 @@ public final class ModelGenerator implements Generator {
 
 		// process field java doc and insert into record java doc
 		if (!fields.isEmpty()) {
-			String recordJavaDoc = !javaDocComment.isEmpty() ?
-					javaDocComment.replaceAll("\n\s*\\*/","") :
-					"/**\n * "+javaRecordName;
+			String recordJavaDoc = javaDocComment.isEmpty() ? "/**\n * " + javaRecordName :
+					javaDocComment.replaceAll("\n\s*\\*/", "");
 			recordJavaDoc += "\n *";
-			for(var field: fields) {
+			for(final var field: fields) {
 				recordJavaDoc += "\n * @param "+field.nameCamelFirstLower()+" "+
 							field.comment()
 								.replaceAll("\n", "\n *         "+" ".repeat(field.nameCamelFirstLower().length()));
@@ -253,50 +131,187 @@ public final class ModelGenerator implements Generator {
 
 		// static codec and default instance
 		bodyContent +=
-       			"""
-                /** Protobuf codec for reading and writing in protobuf format */
-                public static final Codec<$modelClass> PROTOBUF = new $qualifiedCodecClass();
-                /** JSON codec for reading and writing in JSON format */
-                public static final JsonCodec<$modelClass> JSON = new $qualifiedJsonCodecClass();
-				
-                /** Default instance with all fields set to default values */
-                public static final $modelClass DEFAULT = newBuilder().build();
-                """
-				.replace("$modelClass",javaRecordName)
-				.replace("$qualifiedCodecClass",lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef))
-				.replace("$qualifiedJsonCodecClass",lookupHelper.getFullyQualifiedMessageClassname(FileType.JSON_CODEC, msgDef))
-				.indent(DEFAULT_INDENT);
+				generateCodecFields(msgDef, lookupHelper, javaRecordName);
 
 		// constructor
 		if (fields.stream().anyMatch(f -> f instanceof OneOfField || f.optionalValueType())) {
-			bodyContent += """
-     
-					/**
-					 * Override the default constructor adding input validation
-					 * %s
-					 */
-					public %s {
-					%s
-					}
-					"""
-					.formatted(
-						fields.stream().map(field -> "\n * @param "+field.nameCamelFirstLower()+" "+
-								field.comment()
-								.replaceAll("\n", "\n *         "+" ".repeat(field.nameCamelFirstLower().length()))
-						).collect(Collectors.joining()),
-						javaRecordName,
-						fields.stream()
-								.filter(f -> f instanceof OneOfField)
-								.map(ModelGenerator::generateConstructorCode)
-								.collect(Collectors.joining("\n"))
-					)
-					.indent(DEFAULT_INDENT);
+			bodyContent += generateConstructor(fields, javaRecordName);
 		}
 
+		bodyContent += generateHashCode(fields);
+
+		bodyContent += generateEquals(fields, javaRecordName);
+
+		bodyContent += generateCompareTo(filterComparableFields(msgDef, lookupHelper, fields), javaRecordName);
+
+		// Has methods
+		bodyContent += String.join("\n", hasMethods);
+		bodyContent += "\n";
+
+		// oneof getters
+		bodyContent += String.join("\n    ", oneofGetters);
+		bodyContent += "\n";
+
+		// builder copy & new builder methods
+		bodyContent = genrateBuilderFactoryMethods(bodyContent, fields);
+
+		// generate builder
+		bodyContent += generateBuilder(msgDef, fields, lookupHelper);
+		bodyContent += "\n";
+
+		// oneof enums
+		bodyContent += String.join("\n    ", oneofEnums);
+
+		// === Build file
+		try (final FileWriter javaWriter = new FileWriter(javaFile)) {
+			javaWriter.write(
+					generateClass(modelPackage, imports, javaDocComment, deprecated, javaRecordName, fields, bodyContent)
+			);
+		}
+	}
+
+	/**
+	 * Generating method that assembles all the previously generated pieces together
+	 * @param modelPackage the model package to use for the code generation
+	 * @param imports the imports to use for the code generation
+	 * @param javaDocComment the java doc comment to use for the code generation
+	 * @param deprecated the deprecated annotation to add
+	 * @param javaRecordName the name of the class
+	 * @param fields the fields to use for the code generation
+	 * @param bodyContent the body content to use for the code generation
+	 * @return the generated code
+	 */
+	@NotNull
+	private static String generateClass(final String modelPackage,
+										final Set<String> imports,
+										final String javaDocComment,
+										final String deprecated,
+										final String javaRecordName,
+										final List<Field> fields,
+										final String bodyContent) {
+		return """
+				package $package;
+				$imports
+				import com.hedera.pbj.runtime.Codec;
+				import java.util.function.Consumer;
+				import java.lang.Comparable;
+				import edu.umd.cs.findbugs.annotations.Nullable;
+				import static java.util.Objects.requireNonNull;
+									
+				$javaDocComment$deprecated
+				public record $javaRecordName(
+				$fields) implements Comparable<$javaRecordName> {
+				$bodyContent}
+				"""
+				.replace("$package", modelPackage)
+				.replace("$imports", imports.isEmpty() ? "" : imports.stream().collect(Collectors.joining(".*;\nimport ", "\nimport ", ".*;\n")))
+				.replace("$javaDocComment", javaDocComment)
+				.replace("$deprecated", deprecated)
+				.replace("$javaRecordName", javaRecordName)
+				.replace("$fields", fields.stream().map(field ->
+						(field.type() == FieldType.MESSAGE ? "@Nullable " : "")
+								+ field.javaFieldType() + " " + field.nameCamelFirstLower()
+				).collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT))
+				.replace("$bodyContent", bodyContent);
+	}
+
+
+	/**
+	 * Filter the fields to only include those that are comparable
+	 * @param msgDef The message definition
+	 * @param lookupHelper The lookup helper
+	 * @param fields The fields to filter
+	 * @return the filtered fields
+	 */
+	@NonNull
+	private static List<Field> filterComparableFields(final MessageDefContext msgDef,
+													  final ContextualLookupHelper lookupHelper,
+													  final List<Field> fields) {
+		final Set<String> comparableFields = lookupHelper.getComparableFields(msgDef);
+		if(comparableFields.isEmpty()) {
+			// consider all fields in compareTo by defalut
+			return fields;
+		}
+		return fields.stream().filter(f -> comparableFields.contains(f.nameCamelFirstLower())).collect(Collectors.toList());
+	}
+
+	/**
+	 * Generates the compareTo method
+	 * @param fields the fields to use for the code generation
+	 * @param javaRecordName the name of the class
+	 * @return the generated code
+	 */
+	@NonNull
+	private static String generateCompareTo(final List<Field> fields, final String javaRecordName) {
+		String bodyContent =
+			"""
+			/**
+			* Implemenetation of Comparable interface
+			*/
+			@Override
+			public int compareTo($javaRecordName thatObj) {
+				if (thatObj == null) {
+					return 1;
+				}
+				int result = 0;
+			""".replace("$javaRecordName", javaRecordName).indent(DEFAULT_INDENT);
+
+		bodyContent += Common.getFieldsCompareToStatements(fields, "");
+
+		bodyContent +=
+			"""
+				return result;
+			}
+			""".indent(DEFAULT_INDENT);
+		return bodyContent;
+	}
+
+	/**
+	 * Generates the equals method
+	 * @param fields the fields to use for the code generation
+	 * @param javaRecordName the name of the class
+	 * @return the generated code
+	 */
+	@NonNull
+	private static String generateEquals(final List<Field> fields, final String javaRecordName) {
+		String equalsStatements = "";
+		// Generate a call to private method that iterates through fields
+		// and calculates the hashcode.
+		equalsStatements = Common.getFieldsEqualsStatements(fields, equalsStatements);
+
+		String bodyContent =
+		"""
+		/**
+		* Override the default equals method for
+		*/
+		@Override
+		public boolean equals(Object that) {
+		    if (that == null || this.getClass() != that.getClass()) {
+		        return false;
+		    }
+		    $javaRecordName thatObj = ($javaRecordName)that;
+		""".replace("$javaRecordName", javaRecordName).indent(DEFAULT_INDENT);
+
+		bodyContent += equalsStatements.indent(DEFAULT_INDENT);
+		bodyContent +=
+		"""
+		    return true;
+		}
+		""".indent(DEFAULT_INDENT);
+		return bodyContent;
+	}
+
+	/**
+	 * Generates the hashCode method
+	 * @param fields the fields to use for the code generation
+	 * @return the generated code
+	 */
+	@NonNull
+	private static String generateHashCode(final List<Field> fields) {
 		// Generate a call to private method that iterates through fields and calculates the hashcode
 		final String statements = getFieldsHashCode(fields, "");
 
-		bodyContent +=
+		String bodyContent =
 			"""
 			/**
 			* Override the default hashCode method for
@@ -317,41 +332,258 @@ public final class ModelGenerator implements Generator {
 			}
 			""".replace("$hashCodeManipulation", HASH_CODE_MANIPULATION)
 				.indent(DEFAULT_INDENT);
+		return bodyContent;
+	}
 
-		String equalsStatements = "";
-		// Generate a call to private method that iterates through fields
-		// and calculates the hashcode.
-		equalsStatements = Common.getFieldsEqualsStatements(fields, equalsStatements);
+	/**
+	 * Generates constructor code for the class
+	 * @param fields the fields to use for the code generation
+	 * @param javaRecordName the name of the class
+	 * @return the generated code
+	 */
+	@NonNull
+	private static String generateConstructor(final List<Field> fields, final String javaRecordName) {
+		return """
+				     
+				/**
+				 * Override the default constructor adding input validation
+				 * %s
+				 */
+				public %s {
+				%s
+				}
+				"""
+				.formatted(
+						fields.stream().map(field -> "\n * @param " + field.nameCamelFirstLower() + " " +
+								field.comment()
+										.replaceAll("\n", "\n *         " + " ".repeat(field.nameCamelFirstLower().length()))
+						).collect(Collectors.joining()),
+						javaRecordName,
+						fields.stream()
+								.filter(f -> f instanceof OneOfField)
+								.map(ModelGenerator::generateConstructorCodeForField)
+								.collect(Collectors.joining("\n"))
+				)
+				.indent(DEFAULT_INDENT);
+	}
 
-		bodyContent +=
-		"""
-		/**
-		* Override the default equals method for
-		*/
-		@Override
-		public boolean equals(Object that) {
-		    if (that == null || this.getClass() != that.getClass()) {
-		        return false;
-		    }
-		    $javaRecordName thatObj = ($javaRecordName)that;
-		""".replace("$javaRecordName", javaRecordName).indent(DEFAULT_INDENT);
-
-		bodyContent += equalsStatements.indent(DEFAULT_INDENT);
-		bodyContent +=
-		"""
-		    return true;
+	/**
+	 * Generates the constructor code for the class
+	 * @param f the field to use for the code generation
+	 * @return the generated code
+	 */
+	private static String generateConstructorCodeForField(final Field f) {
+		final StringBuilder sb = new StringBuilder("""
+								if ($fieldName == null) {
+								    throw new NullPointerException("Parameter '$fieldName' must be supplied and can not be null");
+								}""".replace("$fieldName", f.nameCamelFirstLower()));
+		if (f instanceof final OneOfField oof) {
+			for (final Field subField: oof.fields()) {
+				if(subField.optionalValueType()) {
+					sb.append("""
+       
+							// handle special case where protobuf does not have destination between a OneOf with optional
+							// value of empty vs an unset OneOf.
+							if($fieldName.kind() == $fieldUpperNameOneOfType.$subFieldNameUpper && $fieldName.value() == null) {
+							$fieldName = new OneOf<>($fieldUpperNameOneOfType.UNSET, null);
+							}"""
+							.replace("$fieldName", f.nameCamelFirstLower())
+							.replace("$fieldUpperName", f.nameCamelFirstUpper())
+							.replace("$subFieldNameUpper", camelToUpperSnake(subField.name()))
+					);
+				}
+			}
 		}
-		""".indent(DEFAULT_INDENT);
+		return sb.toString().indent(DEFAULT_INDENT);
+	}
 
-		// Has methods
-		bodyContent += String.join("\n", hasMethods);
-		bodyContent += "\n";
+	/**
+	 * Generates codec fields for the calss
+	 * @param msgDef the message definition
+	 * @param lookupHelper the lookup helper
+	 * @param javaRecordName the name of the class
+	 * @return the generated code
+	 */
+	@NonNull
+	private static String generateCodecFields(final MessageDefContext msgDef, final ContextualLookupHelper lookupHelper, final String javaRecordName) {
+		return """
+				/** Protobuf codec for reading and writing in protobuf format */
+				public static final Codec<$modelClass> PROTOBUF = new $qualifiedCodecClass();
+				/** JSON codec for reading and writing in JSON format */
+				public static final JsonCodec<$modelClass> JSON = new $qualifiedJsonCodecClass();
+								
+				/** Default instance with all fields set to default values */
+				public static final $modelClass DEFAULT = newBuilder().build();
+				"""
+				.replace("$modelClass", javaRecordName)
+				.replace("$qualifiedCodecClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef))
+				.replace("$qualifiedJsonCodecClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.JSON_CODEC, msgDef))
+				.indent(DEFAULT_INDENT);
+	}
 
-		// oneof getters
-		bodyContent += String.join("\n    ", oneofGetters);
-		bodyContent += "\n";
+	/**
+	 * Generates accessor fields for the class
+	 * @param item message element context provided by the parser
+	 * @param fields the fields to use for the code generation
+	 * @param imports the imports to use for the code generation
+	 * @param hasMethods the has methods to use for the code generation
+	 */
+	private static void generateCodeForField(final ContextualLookupHelper lookupHelper,
+                                             final Protobuf3Parser.MessageElementContext item,
+                                             final List<Field> fields,
+                                             final Set<String> imports,
+                                             final List<String> hasMethods) {
+		final SingleField field = new SingleField(item.field(), lookupHelper);
+		fields.add(field);
+		field.addAllNeededImports(imports, true, false, false);
+		if (field.type() == FieldType.MESSAGE) {
+			hasMethods.add("""
+					/**
+					 * Convenience method to check if the $fieldName has a value
+					 *
+					 * @return true of the $fieldName has a value
+					 */
+					public boolean has$fieldNameUpperFirst() {
+						return $fieldName != null;
+					}
+					
+					/**
+					 * Gets the value for $fieldName if it has a value, or else returns the default
+					 * value for the type.
+					 *
+					 * @param defaultValue the default value to return if $fieldName is null
+					 * @return the value for $fieldName if it has a value, or else returns the default value
+					 */
+					public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
+						return has$fieldNameUpperFirst() ? $fieldName : defaultValue;
+					}
+					
+					/**
+					 * Gets the value for $fieldName if it has a value, or else throws an NPE.
+					 * value for the type.
+					 *
+					 * @return the value for $fieldName if it has a value
+					 * @throws NullPointerException if $fieldName is null
+					 */
+					public @NonNull $javaFieldType $fieldNameOrThrow() {
+						return requireNonNull($fieldName, "Field $fieldName is null");
+					}
+					
+					/**
+					 * Executes the supplied {@link Consumer} if, and only if, the $fieldName has a value
+					 *
+					 * @param ifPresent the {@link Consumer} to execute
+					 */
+					public void if$fieldNameUpperFirst(@NonNull final Consumer<$javaFieldType> ifPresent) {
+						if (has$fieldNameUpperFirst()) {
+							ifPresent.accept($fieldName);
+						}
+					}
+					"""
+					.replace("$fieldNameUpperFirst", field.nameCamelFirstUpper())
+					.replace("$javaFieldType", field.javaFieldType())
+					.replace("$fieldName", field.nameCamelFirstLower())
+					.indent(DEFAULT_INDENT)
+			);
+		}
+	}
 
-		// builder copy & new builder methods
+	/**
+	 * Generates the code related to the oneof field
+	 * @param lookupHelper the lookup helper
+	 * @param item message element context provided by the parser
+	 * @param javaRecordName the name of the class
+	 * @param imports the imports to use for the code generation
+	 * @param oneofEnums the oneof enums to use for the code generation
+	 * @param fields the fields to use for the code generation
+	 * @return the generated code
+	 */
+	private static List<String>  generateCodeForOneOf(final ContextualLookupHelper lookupHelper,
+                                                      final Protobuf3Parser.MessageElementContext item,
+                                                      final String javaRecordName,
+                                                      final Set<String> imports,
+                                                      final List<String> oneofEnums,
+                                                      final List<Field> fields) {
+		final List<String> oneofGetters = new ArrayList<>();
+		final var oneOfField = new OneOfField(item.oneof(), javaRecordName, lookupHelper);
+		final var enumName = oneOfField.nameCamelFirstUpper() + "OneOfType";
+		final int maxIndex = oneOfField.fields().get(oneOfField.fields().size() - 1).fieldNumber();
+		final Map<Integer, EnumValue> enumValues = new HashMap<>();
+		for (final var field : oneOfField.fields()) {
+			final String javaFieldType = javaPrimitiveToObjectType(field.javaFieldType());
+			final String enumComment = cleanDocStr(field.comment())
+				.replaceAll("[\t\s]*/\\*\\*","") // remove doc start indenting
+				.replaceAll("\n[\t\s]+\\*","\n") // remove doc indenting
+				.replaceAll("/\\*\\*","") //  remove doc start
+				.replaceAll("\\*\\*/",""); //  remove doc end
+			enumValues.put(field.fieldNumber(), new EnumValue(field.name(), field.deprecated(), enumComment));
+			// generate getters for one ofs
+			oneofGetters.add("""
+					/**
+					 * Direct typed getter for one of field $fieldName.
+					 *
+					 * @return one of value or null if one of is not set or a different one of value
+					 */
+					public @Nullable $javaFieldType $fieldName() {
+						return $oneOfField.kind() == $enumName.$enumValue ? ($javaFieldType)$oneOfField.value() : null;
+					}
+					
+					/**
+					 * Convenience method to check if the $oneOfField has a one-of with type $enumValue
+					 *
+					 * @return true of the one of kind is $enumValue
+					 */
+					public boolean has$fieldNameUpperFirst() {
+						return $oneOfField.kind() == $enumName.$enumValue;
+					}
+					
+					/**
+					 * Gets the value for $fieldName if it has a value, or else returns the default
+					 * value for the type.
+					 *
+					 * @param defaultValue the default value to return if $fieldName is null
+					 * @return the value for $fieldName if it has a value, or else returns the default value
+					 */
+					public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
+						return has$fieldNameUpperFirst() ? $fieldName() : defaultValue;
+					}
+					
+					/**
+					 * Gets the value for $fieldName if it was set, or throws a NullPointerException if it was not set.
+					 *
+					 * @return the value for $fieldName if it has a value
+					 * @throws NullPointerException if $fieldName is null
+					 */
+					public @NonNull $javaFieldType $fieldNameOrThrow() {
+						return requireNonNull($fieldName(), "Field $fieldName is null");
+					}
+					"""
+					.replace("$fieldNameUpperFirst",field.nameCamelFirstUpper())
+					.replace("$fieldName",field.nameCamelFirstLower())
+					.replace("$javaFieldType",javaFieldType)
+					.replace("$oneOfField",oneOfField.nameCamelFirstLower())
+					.replace("$enumName",enumName)
+					.replace("$enumValue",camelToUpperSnake(field.name()))
+					.indent(DEFAULT_INDENT)
+			);
+			if (field.type() == FieldType.MESSAGE) {
+				field.addAllNeededImports(imports, true, false, false);
+			}
+		}
+		final String enumComment = """
+							/**
+							 * Enum for the type of "%s" oneof value
+							 */""".formatted(oneOfField.name());
+		final String enumString = createEnum(enumComment ,"",enumName,maxIndex,enumValues, true)
+				.indent(DEFAULT_INDENT * 2);
+		oneofEnums.add(enumString);
+		fields.add(oneOfField);
+		imports.add("com.hedera.pbj.runtime");
+		return oneofGetters;
+	}
+
+	@NotNull
+	private static String genrateBuilderFactoryMethods(String bodyContent, final List<Field> fields) {
 		bodyContent +=
     		"""
 			/**
@@ -375,45 +607,10 @@ public final class ModelGenerator implements Generator {
 			"""
 			.formatted(fields.stream().map(Field::nameCamelFirstLower).collect(Collectors.joining(", ")))
 			.indent(DEFAULT_INDENT);
-
-		// generate builder
-		bodyContent += generateBuilder(msgDef, fields, lookupHelper);
-		bodyContent += "\n";
-
-		// oneof enums
-		bodyContent += String.join("\n    ", oneofEnums);
-
-		// === Build file
-		try (FileWriter javaWriter = new FileWriter(javaFile)) {
-			javaWriter.write(
-     				"""
-					package $package;
-					$imports
-					import com.hedera.pbj.runtime.Codec;
-					import java.util.function.Consumer;
-					import edu.umd.cs.findbugs.annotations.Nullable;
-					import static java.util.Objects.requireNonNull;
-					
-					$javaDocComment$deprecated
-					public record $javaRecordName(
-					$fields){
-					$bodyContent}
-					"""
-					.replace("$package",modelPackage)
-					.replace("$imports",imports.isEmpty() ? "" : imports.stream().collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
-					.replace("$javaDocComment",javaDocComment)
-					.replace("$deprecated", deprecated)
-					.replace("$javaRecordName",javaRecordName)
-					.replace("$fields", fields.stream().map(field ->
-							(field.type() == FieldType.MESSAGE ? "@Nullable " : "")
-									+ field.javaFieldType() + " " + field.nameCamelFirstLower()
-					).collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT))
-					.replace("$bodyContent",bodyContent)
-			);
-		}
+		return bodyContent;
 	}
 
-	private static void generateBuilderMethods(List<String> builderMethods, Field field) {
+	private static void generateBuilderMethods(final List<String> builderMethods, final Field field) {
 		final String prefix, postfix, fieldToSet;
 		final OneOfField parentOneOfField = field.parent();
 		if (parentOneOfField != null) {
@@ -497,13 +694,20 @@ public final class ModelGenerator implements Generator {
 		}
 	}
 
-	private static String generateBuilder(final Protobuf3Parser.MessageDefContext msgDef, List<Field> fields, final ContextualLookupHelper lookupHelper) {
+	/**
+	 * Generates the builder for the class
+	 * @param msgDef the message definition
+	 * @param fields the fields to use for the code generation
+	 * @param lookupHelper the lookup helper
+	 * @return the generated code
+	 */
+	private static String generateBuilder(final MessageDefContext msgDef, final List<Field> fields, final ContextualLookupHelper lookupHelper) {
 		final String javaRecordName = msgDef.messageName().getText();
-		List<String> builderMethods = new ArrayList<>();
-		for (Field field: fields) {
+		final List<String> builderMethods = new ArrayList<>();
+		for (final Field field: fields) {
 			if (field.type() == Field.FieldType.ONE_OF) {
 				final OneOfField oneOfField = (OneOfField) field;
-				for (Field subField: oneOfField.fields()) {
+				for (final Field subField: oneOfField.fields()) {
 					generateBuilderMethods(builderMethods, subField);
 				}
 			} else {
@@ -546,7 +750,12 @@ public final class ModelGenerator implements Generator {
 				.indent(DEFAULT_INDENT);
 	}
 
-	private static String generatePrePopulatedBuilder(List<Field> fields) {
+	/**
+	 * Generates the pre-populated builder for the class
+	 * @param fields the fields to use for the code generation
+	 * @return the generated code
+	 */
+	private static String generatePrePopulatedBuilder(final List<Field> fields) {
 		if (fields.isEmpty()) {
 			return "";
 		}
@@ -570,7 +779,14 @@ public final class ModelGenerator implements Generator {
 				.indent(DEFAULT_INDENT);
 	}
 
-	private static String getDefaultValue(Field field, final Protobuf3Parser.MessageDefContext msgDef, final ContextualLookupHelper lookupHelper) {
+	/**
+	 * Gets the default value for the field
+	 * @param field the field to use for the code generation
+	 * @param msgDef the message definition
+	 * @param lookupHelper the lookup helper
+	 * @return the generated code
+	 */
+	private static String getDefaultValue(final Field field, final MessageDefContext msgDef, final ContextualLookupHelper lookupHelper) {
 		if (field.type() == Field.FieldType.ONE_OF) {
 			return lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef)+"."+field.javaDefault();
 		} else {
@@ -578,28 +794,4 @@ public final class ModelGenerator implements Generator {
 		}
 	}
 
-	private static String generateConstructorCode(final Field f) {
-		StringBuilder sb = new StringBuilder("""
-								if ($fieldName == null) {
-								    throw new NullPointerException("Parameter '$fieldName' must be supplied and can not be null");
-								}""".replace("$fieldName", f.nameCamelFirstLower()));
-		if (f instanceof final OneOfField oof) {
-			for (Field subField: oof.fields()) {
-				if(subField.optionalValueType()) {
-					sb.append("""
-       
-							// handle special case where protobuf does not have destination between a OneOf with optional
-							// value of empty vs an unset OneOf.
-							if($fieldName.kind() == $fieldUpperNameOneOfType.$subFieldNameUpper && $fieldName.value() == null) {
-							$fieldName = new OneOf<>($fieldUpperNameOneOfType.UNSET, null);
-							}"""
-							.replace("$fieldName", f.nameCamelFirstLower())
-							.replace("$fieldUpperName", f.nameCamelFirstUpper())
-							.replace("$subFieldNameUpper", camelToUpperSnake(subField.name()))
-					);
-				}
-			}
-		}
-		return sb.toString().indent(DEFAULT_INDENT);
-	}
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
@@ -29,7 +29,7 @@ public final class SchemaGenerator implements Generator {
 		final File javaFile = Common.getJavaFile(destinationSrcDir, schemaPackage, schemaClassName);
 		final List<Field> fields = new ArrayList<>();
 		final Set<String> imports = new TreeSet<>();
-		for(var item: msgDef.messageBody().messageElement()) {
+		for (final var item : msgDef.messageBody().messageElement()) {
 			if (item.messageDef() != null) { // process sub messages
 				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
 			} else if (item.oneof() != null) { // process one ofs

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -187,8 +187,9 @@ public final class TestGenerator implements Generator {
 						}
 						options.add(listStr + ("\n.stream()\n"+
           							"""
-										.map(value -> new OneOf<>(%sOneOfType.%s, value))
+										.map(value -> new %s<>(%sOneOfType.%s, value))
 										.toList()""".formatted(
+										((OneOfField) field).className(),
 										modelClassName + "." + field.nameCamelFirstUpper(),
 										enumValueName
 								)).indent(DEFAULT_INDENT )
@@ -201,9 +202,10 @@ public final class TestGenerator implements Generator {
 			}
 			return """
 					Stream.of(
-					    List.of(new OneOf<>(%sOneOfType.UNSET, null)),
+					    List.of(new %s<>(%sOneOfType.UNSET, null)),
 					    %s
 					).flatMap(List::stream).toList()""".formatted(
+							((OneOfField)field).className(),
 							modelClassName+"."+field.nameCamelFirstUpper(),
                     String.join(",\n", options).indent(DEFAULT_INDENT)
 					).indent(DEFAULT_INDENT * 2);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -35,7 +35,7 @@ public final class TestGenerator implements Generator {
 		final Set<String> imports = new TreeSet<>();
 		imports.add("com.hedera.pbj.runtime.io.buffer");
 		imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
-		for(var item: msgDef.messageBody().messageElement()) {
+		for (final var item: msgDef.messageBody().messageElement()) {
 			if (item.messageDef() != null) { // process sub messages
 				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
 			} else if (item.oneof() != null) { // process one ofs
@@ -170,10 +170,10 @@ public final class TestGenerator implements Generator {
 			final String optionsList = generateTestData(modelClassName, field, field.optionalValueType(), false);
 			return """
 					generateListArguments(%s)""".formatted(optionsList);
-		} else if(field instanceof final OneOfField oneOf) {
+		} else if (field instanceof final OneOfField oneOf) {
 			final List<String> options = new ArrayList<>();
 			for (var subField: oneOf.fields()) {
-				if(subField instanceof SingleField) {
+				if (subField instanceof SingleField) {
 					final String enumValueName = Common.camelToUpperSnake(subField.name());
 					// special cases to break cyclic dependencies
 					if (!("THRESHOLD_KEY".equals(enumValueName) || "KEY_LIST".equals(enumValueName)

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -59,6 +59,7 @@ public final class JsonCodecGenerator implements Generator {
 									
 					import com.hedera.pbj.runtime.*;
 					import com.hedera.pbj.runtime.io.*;
+					import com.hedera.pbj.runtime.io.buffer.*;
 					import java.io.IOException;
 					import java.nio.*;
 					import java.nio.charset.*;

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -118,7 +118,7 @@ class JsonCodecParseMethodGenerator {
      * @param sb StringBuilder to append code to
      */
     private static void generateFieldCaseStatement(final StringBuilder sb, final Field field) {
-        if(field.repeated()) {
+        if (field.repeated()) {
             if (field.type() == Field.FieldType.MESSAGE) {
                 sb.append("parseObjArray(kvPair.value().arr(), "+field.messageType()+".JSON)");
             } else {
@@ -136,7 +136,7 @@ class JsonCodecParseMethodGenerator {
                 }
                 sb.append(").toList()");
             }
-        } else if(field.optionalValueType()) {
+        } else if (field.optionalValueType()) {
             switch(field.messageType()) {
                 case "Int32Value", "UInt32Value" -> sb.append("parseInteger(kvPair.value())");
                 case "Int64Value", "UInt64Value" -> sb.append("parseLong(kvPair.value())");

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -30,8 +30,9 @@ class JsonCodecParseMethodGenerator {
                 final OneOfField field = (OneOfField)f;
                 return """
                            /** Constant for an unset oneof for $fieldName */
-                           public static final OneOf<$enum> $unsetFieldName = new OneOf<>($enum.UNSET,null);
+                           public static final $className<$enum> $unsetFieldName = new $className<>($enum.UNSET,null);
                        """
+                        .replace("$className", field.className())
                         .replace("$enum", field.getEnumClassRef())
                         .replace("$fieldName", field.name())
                         .replace("$unsetFieldName", Common.camelToUpperSnake(field.name())+"_UNSET")
@@ -95,7 +96,7 @@ class JsonCodecParseMethodGenerator {
             if (field instanceof final OneOfField oneOfField) {
                 for(final Field subField: oneOfField.fields()) {
                     sb.append("case \"" + toJsonFieldName(subField.name()) +"\" /* [" + subField.fieldNumber() + "] */ " +
-                            "-> temp_" + oneOfField.name()+" = new OneOf<>(\n"+
+                            "-> temp_" + oneOfField.name() + " = new %s<>(\n".formatted(oneOfField.className()) +
                             oneOfField.getEnumClassRef().indent(DEFAULT_INDENT) +"."+Common.camelToUpperSnake(subField.name())+
                             ", \n".indent(DEFAULT_INDENT));
                     generateFieldCaseStatement(sb,subField);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
@@ -81,26 +81,26 @@ final class JsonCodecWriteMethodGenerator {
         if (field.parent() != null) {
             final OneOfField oneOfField = field.parent();
             final String oneOfType = modelClassName+"."+oneOfField.nameCamelFirstUpper()+"OneOfType";
-            prefix += "if(data."+oneOfField.nameCamelFirstLower()+"().kind() == "+ oneOfType +"."+
+            prefix += "if (data."+oneOfField.nameCamelFirstLower()+"().kind() == "+ oneOfType +"."+
                     Common.camelToUpperSnake(field.name())+")";
             prefix += "\n";
             return prefix + "fieldLines.add(" + basicFieldCode + ");";
         } else {
             if (field.repeated()) {
-                return prefix + "if(!data." + field.nameCamelFirstLower() + "().isEmpty()) fieldLines.add(" + basicFieldCode + ");";
+                return prefix + "if (!data." + field.nameCamelFirstLower() + "().isEmpty()) fieldLines.add(" + basicFieldCode + ");";
             } else if (field.type() == Field.FieldType.BYTES){
-                return prefix + "if(data." + field.nameCamelFirstLower() + "() != " + field.javaDefault() +
+                return prefix + "if (data." + field.nameCamelFirstLower() + "() != " + field.javaDefault() +
                         " && data." + field.nameCamelFirstLower() + "() != null" +
                         " && data." + field.nameCamelFirstLower() + "().length() > 0) fieldLines.add(" + basicFieldCode + ");";
             } else {
-                return prefix + "if(data." + field.nameCamelFirstLower() + "() != " + field.javaDefault() + ") fieldLines.add(" + basicFieldCode + ");";
+                return prefix + "if (data." + field.nameCamelFirstLower() + "() != " + field.javaDefault() + ") fieldLines.add(" + basicFieldCode + ");";
             }
         }
     }
 
     @NonNull
     private static String generateBasicFieldLines(Field field, String getValueCode, String fieldDef, String fieldName) {
-        if(field.optionalValueType()) {
+        if (field.optionalValueType()) {
             return switch (field.messageType()) {
                 case "StringValue", "BoolValue", "Int32Value",
                         "UInt32Value", "FloatValue",

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -43,9 +43,7 @@ public final class CodecGenerator implements Generator {
 			} else if (item.field() != null && item.field().fieldName() != null) {
 				final var field = new SingleField(item.field(), lookupHelper);
 				fields.add(field);
-//				if (field.type() == Field.FieldType.MESSAGE) {
-					field.addAllNeededImports(imports, true, true, false);
-//				}
+				field.addAllNeededImports(imports, true, true, false);
 			} else if (item.reserved() == null && item.optionStatement() == null) {
 				System.err.println("WriterGenerator Warning - Unknown element: "+item+" -- "+item.getText());
 			}
@@ -58,6 +56,7 @@ public final class CodecGenerator implements Generator {
 									
 					import com.hedera.pbj.runtime.*;
 					import com.hedera.pbj.runtime.io.*;
+					import com.hedera.pbj.runtime.io.buffer.*;
 					import com.hedera.pbj.runtime.io.stream.EOFException;
 					import java.io.IOException;
 					import java.nio.*;

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
@@ -59,13 +59,13 @@ class CodecMeasureRecordMethodGenerator {
             final OneOfField oneOfField = field.parent();
             final String oneOfType = modelClassName+"."+oneOfField.nameCamelFirstUpper()+"OneOfType";
             getValueCode = "data."+oneOfField.nameCamelFirstLower()+"().as()";
-            prefix += "if(data."+oneOfField.nameCamelFirstLower()+"().kind() == "+ oneOfType +"."+
+            prefix += "if (data."+oneOfField.nameCamelFirstLower()+"().kind() == "+ oneOfType +"."+
                     Common.camelToUpperSnake(field.name())+")";
             prefix += "\n";
         }
 
         final String writeMethodName = field.methodNameType();
-        if(field.optionalValueType()) {
+        if (field.optionalValueType()) {
             return prefix + switch (field.messageType()) {
                 case "StringValue" -> "size += sizeOfOptionalString(%s, %s);"
                         .formatted(fieldDef,getValueCode);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -30,8 +30,9 @@ class CodecParseMethodGenerator {
                 final OneOfField field = (OneOfField)f;
                 return """
                            /** Constant for an unset oneof for $fieldName */
-                           public static final OneOf<$enum> $unsetFieldName = new OneOf<>($enum.UNSET,null);
+                           public static final $className<$enum> $unsetFieldName = new $className<>($enum.UNSET,null);
                        """
+                        .replace("$className", field.className())
                         .replace("$enum", field.getEnumClassRef())
                         .replace("$fieldName", field.name())
                         .replace("$unsetFieldName", Common.camelToUpperSnake(field.name())+"_UNSET")
@@ -321,7 +322,7 @@ class CodecParseMethodGenerator {
             throw new PbjCompilerException("Fields can not be oneof and repeated ["+field+"]");
         } else if (field.parent() != null) {
             final var oneOfField = field.parent();
-            sb.append("temp_" + oneOfField.name() + " =  new OneOf<>(" +
+            sb.append("temp_" + oneOfField.name() + " =  new %s<>(".formatted(oneOfField.className()) +
                     oneOfField.getEnumClassRef() + '.' + Common.camelToUpperSnake(field.name()) + ", value);\n");
         } else if (field.repeated()) {
             sb.append("temp_" + field.name() + " = addToList(temp_" + field.name() + ",value);\n");

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -60,13 +60,13 @@ final class CodecWriteMethodGenerator {
             final OneOfField oneOfField = field.parent();
             final String oneOfType = modelClassName+"."+oneOfField.nameCamelFirstUpper()+"OneOfType";
             getValueCode = "data."+oneOfField.nameCamelFirstLower()+"().as()";
-            prefix += "if(data."+oneOfField.nameCamelFirstLower()+"().kind() == "+ oneOfType +"."+
+            prefix += "if (data."+oneOfField.nameCamelFirstLower()+"().kind() == "+ oneOfType +"."+
                     Common.camelToUpperSnake(field.name())+")";
             prefix += "\n";
         }
 
         final String writeMethodName = field.methodNameType();
-        if(field.optionalValueType()) {
+        if (field.optionalValueType()) {
             return prefix + switch (field.messageType()) {
                 case "StringValue" -> "writeOptionalString(out, %s, %s);"
                         .formatted(fieldDef,getValueCode);

--- a/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/LookupHelperTest.java
+++ b/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/LookupHelperTest.java
@@ -1,11 +1,35 @@
 package com.hedera.pbj.compiler.impl;
 
+import static com.hedera.pbj.compiler.impl.LookupHelper.extractComparableFields;
 import static com.hedera.pbj.compiler.impl.LookupHelper.normalizeFileName;
+import static java.util.Arrays.asList;
+import static org.gradle.internal.impldep.org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageBodyContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageDefContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageElementContext;
+import org.gradle.internal.impldep.org.apache.commons.lang.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Set;
 
 class LookupHelperTest {
+    @Mock
+    MessageDefContext defContext;
+    @Mock
+    Protobuf3Parser.OptionCommentContext optionComment;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
 
     @Test
     void testNormalizeFileName_withQuotes() {
@@ -33,5 +57,76 @@ class LookupHelperTest {
             assertEquals(expected, actual);
         }
     }
+
+    @Test
+    void testExtractComparableFields_nullComment() {
+        assertTrue(extractComparableFields(defContext).isEmpty(), "Should return empty list");
+    }
+
+    @Test
+    void testExtractComparableFields_emptyComment() {
+        when(defContext.optionComment()).thenReturn(optionComment);
+        assertTrue(extractComparableFields(defContext).isEmpty(), "Should return empty list");
+    }
+
+    @Test
+    void testExtractComparableFields_malformedComment() {
+        when(optionComment.getText()).thenReturn(randomAlphabetic(10));
+        when(defContext.optionComment()).thenReturn(optionComment);
+        assertTrue(extractComparableFields(defContext).isEmpty(), "Should return empty list");
+    }
+
+    @Test
+    void testExtractComparableFields_notApplicableComment() {
+        when(optionComment.getText()).thenReturn("// <<<pbj.java_package = \"com.hedera.pbj.test.proto.pbj\">>>");
+        when(defContext.optionComment()).thenReturn(optionComment);
+        assertTrue(extractComparableFields(defContext).isEmpty(), "Should return empty list");
+    }
+
+    @Test
+    void testExtractComparableFields_commentWithUnkownField() {
+        when(optionComment.getText()).thenReturn("// <<<pbj.comparable = \"int32Number, int64Number, unknown, text\" >>>");
+        when(defContext.optionComment()).thenReturn(optionComment);
+        final var messageBody = mock(MessageBodyContext.class);
+        final var int32Number = createMessageElement("int32Number");
+        final var int64Number = createMessageElement("int64Number");
+        final var text = createMessageElement("text");
+        when(messageBody.messageElement()).thenReturn(asList(
+                int32Number, int64Number, text
+        ));
+        when(defContext.messageBody()).thenReturn(messageBody);
+        assertThrows(IllegalArgumentException.class, () -> extractComparableFields(defContext),
+                "Should throw IllegalArgumentException");
+    }
+
+    @Test
+    void testExtractComparableFields_validComment() {
+        when(optionComment.getText()).thenReturn("// <<<pbj.comparable = \"int32Number, int64Number, text\" >>>");
+        when(defContext.optionComment()).thenReturn(optionComment);
+        final var messageBody = mock(MessageBodyContext.class);
+        final var int32Number = createMessageElement("int32Number");
+        final var int64Number = createMessageElement("int64Number");
+        final var text = createMessageElement("text");
+        when(messageBody.messageElement()).thenReturn(asList(
+                int32Number, int64Number, text
+        ));
+        when(defContext.messageBody()).thenReturn(messageBody);
+        Set<String> comparableFields = extractComparableFields(defContext);
+        assertEquals(3, comparableFields.size(), "Should return 3 fields");
+        assertTrue(comparableFields.containsAll(asList("int32Number", "int64Number", "text")),
+                "Should contain all 3 fields");
+    }
+
+    private static MessageElementContext createMessageElement(final String fieldNameStr) {
+        final var messageElement = mock(MessageElementContext.class);
+        final var field = mock(Protobuf3Parser.FieldContext.class);
+        final var fieldName = mock(Protobuf3Parser.FieldNameContext.class);
+        when(fieldName.getText()).thenReturn(fieldNameStr);
+        when(field.fieldName()).thenReturn(fieldName);
+        when(messageElement.field()).thenReturn(field);
+
+        return messageElement;
+    }
+
 
 }

--- a/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/LookupHelperTest.java
+++ b/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/LookupHelperTest.java
@@ -12,14 +12,12 @@ import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageBodyContext;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageDefContext;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageElementContext;
-import org.gradle.internal.impldep.org.apache.commons.lang.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.util.Set;
+import java.util.List;
 
 class LookupHelperTest {
     @Mock
@@ -47,7 +45,7 @@ class LookupHelperTest {
         assertEquals(fileName, normalizeFileName(fileName));
     }
     private static void normalizeAndVerify(String fileName) {
-        if(System.getProperty("os.name").toLowerCase().contains("windows")) {
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
             String expected = "state\\common.proto";
             String actual = normalizeFileName(fileName);
             assertEquals(expected, actual);
@@ -111,10 +109,11 @@ class LookupHelperTest {
                 int32Number, int64Number, text
         ));
         when(defContext.messageBody()).thenReturn(messageBody);
-        Set<String> comparableFields = extractComparableFields(defContext);
+        List<String> comparableFields = extractComparableFields(defContext);
         assertEquals(3, comparableFields.size(), "Should return 3 fields");
-        assertTrue(comparableFields.containsAll(asList("int32Number", "int64Number", "text")),
-                "Should contain all 3 fields");
+        assertEquals("int32Number", comparableFields.get(0), "Should return int32Number");
+        assertEquals("int64Number", comparableFields.get(1), "Should return int64Number");
+        assertEquals("text", comparableFields.get(2), "Should return text");
     }
 
     private static MessageElementContext createMessageElement(final String fieldNameStr) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
@@ -3,25 +3,22 @@ package com.hedera.pbj.runtime;
 import java.util.Objects;
 
 /**
- * When a protobuf schema defines a field as "oneof", it is often useful
- * for parsers to represent the field as a {@link OneOf} because there is
- * often no useful supertype common to all fields within the "oneof". This
- * class takes the field num and an enum (defined by the parser) representing
- * the different possible types in this "oneof", and the actual value as
- * an object.
+ *
+ * This is a version of {@link OneOf} that implements `Comparable` interface to allow sorting of lists of ComparableOneOf objects.
+ * It requires that the value implements `Comparable` interface as well.
  *
  * @param kind     An enum representing the kind of data being represented. Must not be null.
  * @param value    The actual value in the "oneof". May be null.
  * @param <E>      The enum type
  */
-public record OneOf<E extends Enum<E>>(E kind, Object value) {
+public record ComparableOneOf<E extends Enum<E>>(E kind, Comparable value) implements Comparable<ComparableOneOf<E>> {
     /**
-     * Construct a new OneOf
+     * Construct a new ComparableOneOf
      *
      * @param kind     An enum representing the kind of data being represented. Must not be null.
      * @param value    The actual value in the "oneof". May be null.
      */
-    public OneOf {
+    public ComparableOneOf {
         if (kind == null) {
             throw new NullPointerException("An enum 'kind' must be supplied");
         }
@@ -41,7 +38,7 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof OneOf<?> oneOf)) return false;
+        if (!(o instanceof ComparableOneOf<?> oneOf)) return false;
         return kind.equals(oneOf.kind) && Objects.equals(value, oneOf.value);
     }
 
@@ -50,5 +47,17 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) {
         return Objects.hash(kind, value);
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public int compareTo(ComparableOneOf<E> thatObj) {
+        if (thatObj == null) {
+            return 1;
+        }
+        final int kindCompare = kind.compareTo(thatObj.kind);
+        if (kindCompare != 0) {
+            return kindCompare;
+        }
+        return value.compareTo(thatObj.value);
+    }
 }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -356,7 +356,7 @@ public final class JsonTools {
     public static String field(String fieldName, Long value, boolean quote) {
         if (value == null) {
             return rawFieldCode(fieldName, "null");
-        } else if(quote) {
+        } else if (quote) {
             return rawFieldCode(fieldName, '\"' + Long.toString(value) + '\"');
         } else {
             return rawFieldCode(fieldName, Long.toString(value));

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
@@ -52,10 +52,14 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) implements Comparab
 
     @Override
     public int compareTo(OneOf<E> thatObj) {
-        if(thatObj == null) {
+        if (thatObj == null) {
             return 1;
         }
-        return kind.compareTo(thatObj.kind);
+        final int kindCompare = kind.compareTo(thatObj.kind);
+        if (kindCompare != 0) {
+            return kindCompare;
+        }
+        return ((Comparable) value).compareTo(thatObj.value);
     }
 }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  * @param value    The actual value in the "oneof". May be null.
  * @param <E>      The enum type
  */
-public record OneOf<E>(E kind, Object value) {
+public record OneOf<E extends Enum<E>>(E kind, Object value) implements Comparable<OneOf<E>> {
     /**
      * Construct a new OneOf
      *
@@ -48,6 +48,14 @@ public record OneOf<E>(E kind, Object value) {
     @Override
     public int hashCode() {
         return Objects.hash(kind, value);
+    }
+
+    @Override
+    public int compareTo(OneOf<E> thatObj) {
+        if(thatObj == null) {
+            return 1;
+        }
+        return kind.compareTo(thatObj.kind);
     }
 }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -357,7 +357,7 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
         // Compare the lengths first
         final int minLength = Math.min(length, otherData.length);
         for (int i = 0; i < minLength; i++) {
-            final int compare = Byte.compare(getByte(i), otherData.getByte(i));
+            final int compare = Byte.compareUnsigned(getByte(i), otherData.getByte(i));
             if (compare != 0) {
                 return compare;
             }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
  * An immutable representation of a byte array. This class is designed to be efficient and usable across threads.
  */
 @SuppressWarnings("unused")
-public final class Bytes implements RandomAccessData {
+public final class Bytes implements RandomAccessData, Comparable<Bytes> {
 
     /** An instance of an empty {@link Bytes} */
     public static final Bytes EMPTY = new Bytes(new byte[0]);
@@ -345,6 +345,25 @@ public final class Bytes implements RandomAccessData {
                 }
             }
         };
+    }
+
+    /**
+     * Compare this {@link Bytes} object to another {@link Bytes} object. The comparison is done on a byte-by-byte
+     * @param otherData the object to be compared.
+     * @return a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than
+     */
+    @Override
+    public int compareTo(Bytes otherData) {
+        // Compare the lengths first
+        final int minLength = Math.min(length, otherData.length);
+        for (int i = 0; i < minLength; i++) {
+            final int compare = Byte.compare(getByte(i), otherData.getByte(i));
+            if (compare != 0) {
+                return compare;
+            }
+        }
+        // If all compared elements are equal, the shorter array is considered less
+        return length - otherData.length;
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -363,7 +363,7 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
             }
         }
         // If all compared elements are equal, the shorter array is considered less
-        return length - otherData.length;
+        return Integer.compare(length, otherData.length);
     }
 
     /**

--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -13,6 +13,7 @@ group = "com.hedera.pbj.integration-tests"
 
 dependencies {
     implementation("com.hedera.pbj:pbj-runtime")
+    implementation("com.hedera.pbj:pbj-compiler")
     implementation("com.google.protobuf:protobuf-java:3.21.12")
     implementation("com.google.protobuf:protobuf-java-util:3.21.12")
     compileOnly("com.github.spotbugs:spotbugs-annotations:4.7.3")

--- a/pbj-integration-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/pbj-integration-tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pbj-integration-tests/src/main/proto/comparable.proto
+++ b/pbj-integration-tests/src/main/proto/comparable.proto
@@ -54,5 +54,14 @@ message LimitedComparableTest {
   string text = 4;
   ComparableEnum comparableEnum = 5;
   ComparableSubObj subObject = 6;
+}
+
+// <<<pbj.comparable = "int32Number" >>>
+message LimitedComparableTestWithOneOf {
+  int32 int32Number = 1;
+  oneof oneOfExample {
+    string oneOfText = 10;
+    ComparableSubObj oneOfSubObject = 12;
+  }
 
 }

--- a/pbj-integration-tests/src/main/proto/comparable.proto
+++ b/pbj-integration-tests/src/main/proto/comparable.proto
@@ -10,14 +10,29 @@ import "timestampTest.proto";
 import "google/protobuf/wrappers.proto";
 import "everything.proto";
 
+// <<<pbj.comparable = "num" >>>
+message ComparableSubObj {
+  int32 num = 1;
+}
+
+// <<<pbj.comparable = "int32Number, doubleNumber, booleanField, text, comparableEnum, subObject, bytes" >>>
 message ComparableTest {
   int32 int32Number = 1;
   double doubleNumber = 2;
   bool booleanField = 3;
   string text = 4;
-  bytes bytesField = 5;
-  ComparableEnum comparableEnum = 6;
-  ComparableSubObj subObject = 7;
+  ComparableEnum comparableEnum = 5;
+  ComparableSubObj subObject = 6;
+  bytes bytes = 7;
+}
+
+// <<<pbj.comparable = "oneofExample" >>>
+message ComparableOneOfTest {
+  oneof oneofExample {
+    string text1OneOf = 10;
+    string text2OneOf = 11;
+    ComparableSubObj subObject = 12;
+  }
 }
 
 enum ComparableEnum {
@@ -27,9 +42,6 @@ enum ComparableEnum {
   THREE = 3;
 }
 
-message ComparableSubObj {
-  int32 num = 1;
-}
 
 /**
  * Example of a message with a limited set of fields that are comparable.

--- a/pbj-integration-tests/src/main/proto/comparable.proto
+++ b/pbj-integration-tests/src/main/proto/comparable.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+import "timestampTest.proto";
+import "google/protobuf/wrappers.proto";
+import "everything.proto";
+
+message ComparableTest {
+  int32 int32Number = 1;
+  double doubleNumber = 2;
+  bool booleanField = 3;
+  string text = 4;
+  bytes bytesField = 5;
+  ComparableEnum comparableEnum = 6;
+  ComparableSubObj subObject = 7;
+}
+
+enum ComparableEnum {
+  UNSPECIFIED = 0;
+  ONE = 1;
+  TWO = 2;
+  THREE = 3;
+}
+
+message ComparableSubObj {
+  int32 num = 1;
+}
+
+/**
+ * Example of a message with a limited set of fields that are comparable.
+ */
+// <<<pbj.comparable = "int32Number, text, subObject" >>>
+message LimitedComparableTest {
+  int32 int32Number = 1;
+  int64 int64Number = 2;
+  bool booleanField = 3;
+  string text = 4;
+  ComparableEnum comparableEnum = 5;
+  ComparableSubObj subObject = 6;
+
+}

--- a/pbj-integration-tests/src/main/proto/comparable.proto
+++ b/pbj-integration-tests/src/main/proto/comparable.proto
@@ -85,7 +85,6 @@ enum ComparableEnum {
   THREE = 3;
 }
 
-
 /**
  * Example of a message with a limited set of fields that are comparable.
  */
@@ -97,6 +96,14 @@ message LimitedComparableTest {
   string text = 4;
   ComparableEnum comparableEnum = 5;
   ComparableSubObj subObject = 6;
+}
+
+// <<<pbj.comparable = "int32Number, int64Number" >>>
+message LimitedComparableTestWithRepeated {
+  int32 int32Number = 1;
+  // repeated fields should be fine as long as they are not mentioned in `pbj.comparable`
+  repeated int32 int32Numbers = 2;
+  int64 int64Number = 3;
 }
 
 // <<<pbj.comparable = "int32Number" >>>

--- a/pbj-integration-tests/src/main/proto/comparable.proto
+++ b/pbj-integration-tests/src/main/proto/comparable.proto
@@ -26,6 +26,49 @@ message ComparableTest {
   bytes bytes = 7;
 }
 
+// <<<pbj.comparable = "stringValue" >>>
+message StringValueComparableTest {
+  google.protobuf.StringValue stringValue = 1;
+}
+
+// <<<pbj.comparable = "boolValue" >>>
+message BoolValueComparableTest {
+  google.protobuf.BoolValue boolValue = 1;
+}
+
+// <<<pbj.comparable = "int32Value, uint32Value" >>>
+message Int32ValueComparableTest {
+  google.protobuf.Int32Value int32Value = 1;
+  google.protobuf.UInt32Value uint32Value = 2;
+}
+
+// <<<pbj.comparable = "int64Value, uint64Value" >>>
+message Int64ValueComparableTest {
+  google.protobuf.Int64Value int64Value = 1;
+  google.protobuf.UInt64Value uint64Value = 2;
+}
+
+// <<<pbj.comparable = "floatValue" >>>
+message FloatValueComparableTest {
+  google.protobuf.FloatValue floatValue = 1;
+}
+
+// <<<pbj.comparable = "doubleValue" >>>
+message DoubleValueComparableTest {
+  google.protobuf.DoubleValue doubleValue = 1;
+}
+
+// <<<pbj.comparable = "bytesValue" >>>
+message BytesValueComparableTest {
+  google.protobuf.BytesValue bytesValue = 1;
+}
+
+// <<<pbj.comparable = "uint32Value, uint64Value" >>>
+message UnsignedComparableTest {
+  uint32 uint32Value = 1;
+  uint64 uint64Value = 2;
+}
+
 // <<<pbj.comparable = "oneofExample" >>>
 message ComparableOneOfTest {
   oneof oneofExample {

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToNegativeTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToNegativeTest.java
@@ -20,7 +20,7 @@ class CompareToNegativeTest {
     void testNonComparableSubObj() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
                 getCompileFilesIn("non_compilable_comparable_sub_obj.proto"));
-        assertEquals("Field NonComparableSubObj.subObject specified in `pbj.comparable` option has is supposed to implement `Comparable` interface but it doesn't.",
+        assertEquals("Field NonComparableSubObj.subObject specified in `pbj.comparable` option must implement `Comparable` interface but it doesn't.",
                 exception.getMessage());
     }
 
@@ -36,7 +36,7 @@ class CompareToNegativeTest {
     void testNonComparableOneOfField() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
                 getCompileFilesIn("non_compilable_comparable_oneOf.proto"));
-        assertEquals("Field NonComparableSubObj.subObject specified in `pbj.comparable` option has is supposed to implement `Comparable` interface but it doesn't.",
+        assertEquals("Field NonComparableSubObj.subObject specified in `pbj.comparable` option must implement `Comparable` interface but it doesn't.",
                 exception.getMessage());
     }
 

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToNegativeTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToNegativeTest.java
@@ -1,0 +1,47 @@
+package com.hedera.pbj.intergration.test;
+
+import static com.hedera.pbj.compiler.PbjCompilerTask.compileFilesIn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+class CompareToNegativeTest {
+
+    @TempDir
+    private static File outputDir;
+
+    @Test
+    void testNonComparableSubObj() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                getCompileFilesIn("non_compilable_comparable_sub_obj.proto"));
+        assertEquals("Field NonComparableSubObj.subObject specified in `pbj.comparable` option has is supposed to implement `Comparable` interface but it doesn't.",
+                exception.getMessage());
+    }
+
+    @Test
+    void testRepeatedField() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                getCompileFilesIn("non_compilable_comparable_repeated.proto"));
+        assertEquals("Field `int32List` specified in `pbj.comparable` option is repeated. Repeated fields are not supported by this option.",
+                exception.getMessage());
+    }
+
+    @Test
+    void testNonComparableOneOfField() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                getCompileFilesIn("non_compilable_comparable_oneOf.proto"));
+        assertEquals("Field NonComparableSubObj.subObject specified in `pbj.comparable` option has is supposed to implement `Comparable` interface but it doesn't.",
+                exception.getMessage());
+    }
+
+    private static void getCompileFilesIn(String fileName) throws Exception {
+        URL fileUrl = CompareToNegativeTest.class.getClassLoader().getResource(fileName);
+        compileFilesIn(List.of(new File(fileUrl.toURI())), outputDir, outputDir);
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
@@ -7,12 +7,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.hedera.pbj.runtime.ComparableOneOf;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.test.proto.pbj.BoolValueComparableTest;
+import com.hedera.pbj.test.proto.pbj.BytesValueComparableTest;
 import com.hedera.pbj.test.proto.pbj.ComparableEnum;
 import com.hedera.pbj.test.proto.pbj.ComparableOneOfTest;
 import com.hedera.pbj.test.proto.pbj.ComparableSubObj;
 import com.hedera.pbj.test.proto.pbj.ComparableTest;
+import com.hedera.pbj.test.proto.pbj.DoubleValueComparableTest;
+import com.hedera.pbj.test.proto.pbj.FloatValueComparableTest;
+import com.hedera.pbj.test.proto.pbj.Int32ValueComparableTest;
+import com.hedera.pbj.test.proto.pbj.Int64ValueComparableTest;
 import com.hedera.pbj.test.proto.pbj.LimitedComparableTest;
 import com.hedera.pbj.test.proto.pbj.LimitedComparableTestWithOneOf;
+import com.hedera.pbj.test.proto.pbj.StringValueComparableTest;
+import com.hedera.pbj.test.proto.pbj.UnsignedComparableTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -32,7 +40,6 @@ class CompareToTest {
                 new ComparableTest(2, 0.0, false, null, null, null, null),
                 new ComparableTest(3, 0.0, false, null, null, null, null));
     }
-
     @Test
     void testCompareTo_double() {
         assertComparables(
@@ -41,7 +48,6 @@ class CompareToTest {
                 new ComparableTest(3, 2.66, false, null, null, null, null)
         );
     }
-
     @Test
     void testCompareTo_bool() {
         assertComparables(
@@ -49,7 +55,6 @@ class CompareToTest {
                 new ComparableTest(0, 0.0, true, null, null, null, null)
         );
     }
-
     @Test
     void testCompareTo_string() {
         assertComparables(
@@ -58,7 +63,6 @@ class CompareToTest {
                 new ComparableTest(0, 0.0, false, "c", null, null, null)
         );
     }
-
     @Test
     void testCompareTo_bytes() {
         assertComparables(
@@ -67,7 +71,6 @@ class CompareToTest {
                 new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("aaa"))
         );
     }
-
     @Test
     void testCompareTo_bytes_same_lenth() {
          assertComparables(
@@ -76,7 +79,6 @@ class CompareToTest {
                 new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("abc"))
         );
     }
-
     @Test
     void testCompareTo_enum(){
         assertComparables(
@@ -85,7 +87,6 @@ class CompareToTest {
                 new ComparableTest(0, 0.0, false, null, ComparableEnum.THREE, null, null)
         );
     }
-
     @Test
     void testCompareTo_subObject(){
         assertComparables(
@@ -94,7 +95,6 @@ class CompareToTest {
                 new ComparableTest(0, 0.0, false, null, null,  new ComparableSubObj(3), null)
         );
     }
-
     @Test
      void compareTo_mixed() {
          assertComparables(
@@ -104,8 +104,100 @@ class CompareToTest {
                  new ComparableTest(2, 0.0, false, null, null,  new ComparableSubObj(2), null)
          );
      }
-
      @Test
+     void compareTo_StringValue() {
+            assertComparables(
+                    new StringValueComparableTest(null),
+                    new StringValueComparableTest("a"),
+                    new StringValueComparableTest("b"),
+                    new StringValueComparableTest("c")
+            );
+     }
+     @Test
+     void compareTo_BoolValue() {
+            assertComparables(
+                    new BoolValueComparableTest(null),
+                    new BoolValueComparableTest(false),
+                    new BoolValueComparableTest(true)
+            );
+     }
+     @Test
+     void compareTo_Int32Value() {
+            assertComparables(
+                    new Int32ValueComparableTest(null, null),
+                    new Int32ValueComparableTest(1, null),
+                    new Int32ValueComparableTest(2, null),
+                    new Int32ValueComparableTest(3, null)
+            );
+     }
+     @Test
+     void compareTo_Uint32Value() {
+            assertComparables(
+                    new Int32ValueComparableTest(null, null),
+                    new Int32ValueComparableTest(null, 0),
+                    new Int32ValueComparableTest(null, 3),
+                    new Int32ValueComparableTest(null, -2),
+                    new Int32ValueComparableTest(null, -1)
+            );
+     }
+    @Test
+    void compareTo_Int64Value() {
+        assertComparables(
+                new Int64ValueComparableTest(null, null),
+                new Int64ValueComparableTest(1L, null),
+                new Int64ValueComparableTest(2L, null),
+                new Int64ValueComparableTest(3L, null)
+        );
+    }
+    @Test
+    void compareTo_UInt64Value() {
+        assertComparables(
+                new Int64ValueComparableTest(null, null),
+                new Int64ValueComparableTest(null, 0L),
+                new Int64ValueComparableTest(null, 3L),
+                new Int64ValueComparableTest(null, -2L),
+                new Int64ValueComparableTest(null, -1L)
+        );
+    }
+    @Test
+    void compareTo_FloatValue() {
+        assertComparables(
+                new FloatValueComparableTest(null),
+                new FloatValueComparableTest(1.0f),
+                new FloatValueComparableTest(2.5f),
+                new FloatValueComparableTest(7.7f));
+    }
+    @Test
+    void compareTo_DoubleValue() {
+        assertComparables(
+                new DoubleValueComparableTest(null),
+                new DoubleValueComparableTest(1.0),
+                new DoubleValueComparableTest(2.5),
+                new DoubleValueComparableTest(7.7));
+    }
+    @Test
+    void compareTo_ByteValue() {
+        assertComparables(
+                new BytesValueComparableTest(null),
+                new BytesValueComparableTest(Bytes.wrap("a")),
+                new BytesValueComparableTest(Bytes.wrap("b")),
+                new BytesValueComparableTest(Bytes.wrap("c")));
+    }
+    @Test
+    void comareTo_unsigned() {
+        assertComparables(
+                new UnsignedComparableTest(0, 0L),
+                new UnsignedComparableTest(3, 0L),
+                new UnsignedComparableTest(-2, 0L),
+                new UnsignedComparableTest(-1, 0L));
+        assertComparables(
+                new UnsignedComparableTest(0, 0L),
+                new UnsignedComparableTest(0, 3L),
+                new UnsignedComparableTest(0, -2L),
+                new UnsignedComparableTest(0, -1L)
+        );
+    }
+    @Test
      void limitedCompareTo_nonComparableOneOf() {
         // This code is only here to be compiled. OneOf field is not listed in `pbj.comparable` option
          // and therefore it has `OneOf` type, not `ComparableOneOf`.

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
@@ -1,0 +1,176 @@
+package com.hedera.pbj.intergration.test;
+
+import static java.util.Collections.shuffle;
+import static java.util.Collections.sort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.test.proto.pbj.ComparableEnum;
+import com.hedera.pbj.test.proto.pbj.ComparableSubObj;
+import com.hedera.pbj.test.proto.pbj.ComparableTest;
+import com.hedera.pbj.test.proto.pbj.LimitedComparableTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.random.RandomGenerator;
+
+/**
+ * Unit test for {@link ComparableTest} and {@link LimitedComparableTest} objects.
+ * The goal is to test the generated {@link Comparable} interface implementation.
+ */
+public class CompareToTest {
+
+    @Test
+    void testCompareTo_int32() {
+        assertComparables(
+                new ComparableTest(1, 0.0, false, null, null, null, null),
+                new ComparableTest(2, 0.0, false, null, null, null, null),
+                new ComparableTest(3, 0.0, false, null, null, null, null));
+    }
+
+    @Test
+    void testCompareTo_double() {
+        assertComparables(
+                new ComparableTest(1, 0.0, false, null, null, null, null),
+                new ComparableTest(2, 1.5, false, null, null, null, null),
+                new ComparableTest(3, 2.66, false, null, null, null, null)
+        );
+    }
+
+    @Test
+    void testCompareTo_bool() {
+        assertComparables(
+                new ComparableTest(0, 0.0, false, null, null, null, null),
+                new ComparableTest(0, 0.0, true, null, null, null, null)
+        );
+    }
+
+    @Test
+    void testCompareTo_string() {
+        assertComparables(
+                new ComparableTest(0, 0.0, false, "a", null, null, null),
+                new ComparableTest(0, 0.0, false, "b", null, null, null),
+                new ComparableTest(0, 0.0, false, "c", null, null, null)
+        );
+    }
+
+    @Test
+    void testCompareTo_bytes() {
+        assertComparables(
+                new ComparableTest(0, 0.0, false, null, Bytes.wrap("1"), null, null),
+                new ComparableTest(0, 0.0, false, null, Bytes.wrap("12"), null, null),
+                new ComparableTest(0, 0.0, false, null, Bytes.wrap("123"), null, null)
+        );
+    }
+
+    @Test
+    void testCompareTo_bytes_same_lenth() {
+        final var test1 = new ComparableTest(0, 0.0, false, null, Bytes.wrap("1"), null, null);
+        final var test2 = new ComparableTest(0, 0.0, false, null, Bytes.wrap("2"), null, null);
+        final var test3 = new ComparableTest(0, 0.0, false, null, Bytes.wrap("3"), null, null);
+
+        final var list = new ComparableTest[] {test2, test3, test1};
+        Arrays.sort(list);
+        // if the length is the same, then the element are not reordered
+        assertEquals(test1, list[2], "test1 expected");
+        assertEquals(test2, list[0], "test2 expected");
+        assertEquals(test3, list[1], "test3 expected");
+    }
+
+    @Test
+    void testCompareTo_enum(){
+        assertComparables(
+                new ComparableTest(0, 0.0, false, null, null, ComparableEnum.ONE, null),
+                new ComparableTest(0, 0.0, false, null, null, ComparableEnum.TWO, null),
+                new ComparableTest(0, 0.0, false, null, null, ComparableEnum.THREE, null)
+        );
+    }
+
+    @Test
+    void testCompareTo_subObject(){
+        assertComparables(
+                new ComparableTest(0, 0.0, false, null, null, null, new ComparableSubObj(1)),
+                new ComparableTest(0, 0.0, false, null, null, null,  new ComparableSubObj(2)),
+                new ComparableTest(0, 0.0, false, null, null, null,  new ComparableSubObj(3))
+        );
+    }
+
+     @Test
+     void compareTo_mixed() {
+         assertComparables(
+                 new ComparableTest(1, 0.0, false, null, null, null, new ComparableSubObj(1)),
+                 new ComparableTest(1, 0.0, false, null, null, null, new ComparableSubObj(2)),
+                 new ComparableTest(2, 0.0, false, null, null, null, new ComparableSubObj(1)),
+                 new ComparableTest(2, 0.0, false, null, null, null,  new ComparableSubObj(2))
+         );
+     }
+
+     @Test
+     void limitedCompareTo_int32() {
+         assertComparables(
+                 new LimitedComparableTest(1, 0L, false, null, null, null),
+                 new LimitedComparableTest(2, 0L, false, null, null, null),
+                 new LimitedComparableTest(3, 0L, false, null, null, null));
+     }
+
+     @Test
+     void limitedCompareTo_text() {
+         assertComparables(
+                 new LimitedComparableTest(0, 0L, false, "1", null, null),
+                 new LimitedComparableTest(0, 0L, false, "2", null, null),
+                 new LimitedComparableTest(0, 0L, false, "3", null, null));
+     }
+
+     @Test
+     void limitedCompareTo_subObj() {
+         assertComparables(
+                 new LimitedComparableTest(0, 0L, false, null, null,  new ComparableSubObj(1)),
+                 new LimitedComparableTest(0, 0L, false, null, null,  new ComparableSubObj(2)),
+                 new LimitedComparableTest(0, 0L, false, null, null,  new ComparableSubObj(3)));
+     }
+
+     @Test
+     void limitedCompareTo_mixed() {
+        // note that only field 1, 4 and 6 are comparable, others are ignored
+         assertComparables(
+                 new LimitedComparableTest(1, nextLong(), nextBoolean(), "1", nextEnum(),  new ComparableSubObj(1)),
+                 new LimitedComparableTest(1, nextLong(), nextBoolean(), "1", nextEnum(),  new ComparableSubObj(2)),
+                 new LimitedComparableTest(1, nextLong(), nextBoolean(), "2", nextEnum(),  new ComparableSubObj(1)),
+                 new LimitedComparableTest(1, nextLong(), nextBoolean(), "2", nextEnum(),  new ComparableSubObj(2)),
+                 new LimitedComparableTest(2, nextLong(), nextBoolean(), "1", nextEnum(),  new ComparableSubObj(1)),
+                 new LimitedComparableTest(2, nextLong(), nextBoolean(), "1", nextEnum(),  new ComparableSubObj(2)),
+                 new LimitedComparableTest(2, nextLong(), nextBoolean(), "2", nextEnum(),  new ComparableSubObj(1)),
+                 new LimitedComparableTest(2, nextLong(), nextBoolean(), "2", nextEnum(),  new ComparableSubObj(2))
+         );
+     }
+
+    private static long nextLong() {
+        return  RandomGenerator.getDefault().nextLong();
+    }
+
+    private static boolean nextBoolean() {
+        return  RandomGenerator.getDefault().nextBoolean();
+    }
+
+    private static ComparableEnum nextEnum() {
+        return ComparableEnum.fromProtobufOrdinal(RandomGenerator.getDefault().nextInt(ComparableEnum.values().length));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void assertComparables(final Comparable... objs) {
+        final var list = new ArrayList<Comparable>() {
+            {
+                for (Comparable<?> obj : objs) {
+                    add(obj);
+                }
+            }
+        };
+        // randomize list first before sort it
+        shuffle(list);
+        sort(list);
+        for (int i = 0; i < objs.length; i++) {
+            assertEquals(objs[i], list.get(i), "obj[" + i + "] expected");
+        }
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
@@ -4,6 +4,7 @@ import static java.util.Collections.shuffle;
 import static java.util.Collections.sort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.hedera.pbj.runtime.ComparableOneOf;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.test.proto.pbj.ComparableEnum;
@@ -11,6 +12,7 @@ import com.hedera.pbj.test.proto.pbj.ComparableOneOfTest;
 import com.hedera.pbj.test.proto.pbj.ComparableSubObj;
 import com.hedera.pbj.test.proto.pbj.ComparableTest;
 import com.hedera.pbj.test.proto.pbj.LimitedComparableTest;
+import com.hedera.pbj.test.proto.pbj.LimitedComparableTestWithOneOf;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -104,6 +106,13 @@ class CompareToTest {
      }
 
      @Test
+     void limitedCompareTo_nonComparableOneOf() {
+        // This code is only here to be compiled. OneOf field is not listed in `pbj.comparable` option
+         // and therefore it has `OneOf` type, not `ComparableOneOf`.
+        new LimitedComparableTestWithOneOf(0, new OneOf<>(LimitedComparableTestWithOneOf.OneOfExampleOneOfType.ONE_OF_SUB_OBJECT, new ComparableSubObj(1)));
+     }
+
+     @Test
      void limitedCompareTo_int32() {
          assertComparables(
                  new LimitedComparableTest(1, 0L, false, null, null, null),
@@ -154,8 +163,8 @@ class CompareToTest {
          );
      }
 
-     private ComparableOneOfTest createOneOf(ComparableOneOfTest.OneofExampleOneOfType type, Object value) {
-         return new ComparableOneOfTest(new OneOf<>(type, value));
+     private ComparableOneOfTest createOneOf(ComparableOneOfTest.OneofExampleOneOfType type, Comparable value) {
+         return new ComparableOneOfTest(new ComparableOneOf<>(type, value));
      }
 
     private static long nextLong() {

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/CompareToTest.java
@@ -4,22 +4,24 @@ import static java.util.Collections.shuffle;
 import static java.util.Collections.sort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.test.proto.pbj.ComparableEnum;
+import com.hedera.pbj.test.proto.pbj.ComparableOneOfTest;
 import com.hedera.pbj.test.proto.pbj.ComparableSubObj;
 import com.hedera.pbj.test.proto.pbj.ComparableTest;
 import com.hedera.pbj.test.proto.pbj.LimitedComparableTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+
 import java.util.random.RandomGenerator;
 
 /**
  * Unit test for {@link ComparableTest} and {@link LimitedComparableTest} objects.
  * The goal is to test the generated {@link Comparable} interface implementation.
  */
-public class CompareToTest {
+class CompareToTest {
 
     @Test
     void testCompareTo_int32() {
@@ -58,51 +60,46 @@ public class CompareToTest {
     @Test
     void testCompareTo_bytes() {
         assertComparables(
-                new ComparableTest(0, 0.0, false, null, Bytes.wrap("1"), null, null),
-                new ComparableTest(0, 0.0, false, null, Bytes.wrap("12"), null, null),
-                new ComparableTest(0, 0.0, false, null, Bytes.wrap("123"), null, null)
+                new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("a")),
+                new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("aa")),
+                new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("aaa"))
         );
     }
 
     @Test
     void testCompareTo_bytes_same_lenth() {
-        final var test1 = new ComparableTest(0, 0.0, false, null, Bytes.wrap("1"), null, null);
-        final var test2 = new ComparableTest(0, 0.0, false, null, Bytes.wrap("2"), null, null);
-        final var test3 = new ComparableTest(0, 0.0, false, null, Bytes.wrap("3"), null, null);
-
-        final var list = new ComparableTest[] {test2, test3, test1};
-        Arrays.sort(list);
-        // if the length is the same, then the element are not reordered
-        assertEquals(test1, list[2], "test1 expected");
-        assertEquals(test2, list[0], "test2 expected");
-        assertEquals(test3, list[1], "test3 expected");
+         assertComparables(
+                new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("aba")),
+                new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("abb")),
+                new ComparableTest(0, 0.0, false, null, null, null, Bytes.wrap("abc"))
+        );
     }
 
     @Test
     void testCompareTo_enum(){
         assertComparables(
-                new ComparableTest(0, 0.0, false, null, null, ComparableEnum.ONE, null),
-                new ComparableTest(0, 0.0, false, null, null, ComparableEnum.TWO, null),
-                new ComparableTest(0, 0.0, false, null, null, ComparableEnum.THREE, null)
+                new ComparableTest(0, 0.0, false, null, ComparableEnum.ONE, null, null),
+                new ComparableTest(0, 0.0, false, null, ComparableEnum.TWO, null, null),
+                new ComparableTest(0, 0.0, false, null, ComparableEnum.THREE, null, null)
         );
     }
 
     @Test
     void testCompareTo_subObject(){
         assertComparables(
-                new ComparableTest(0, 0.0, false, null, null, null, new ComparableSubObj(1)),
-                new ComparableTest(0, 0.0, false, null, null, null,  new ComparableSubObj(2)),
-                new ComparableTest(0, 0.0, false, null, null, null,  new ComparableSubObj(3))
+                new ComparableTest(0, 0.0, false, null, null, new ComparableSubObj(1), null),
+                new ComparableTest(0, 0.0, false, null, null,  new ComparableSubObj(2), null),
+                new ComparableTest(0, 0.0, false, null, null,  new ComparableSubObj(3), null)
         );
     }
 
-     @Test
+    @Test
      void compareTo_mixed() {
          assertComparables(
-                 new ComparableTest(1, 0.0, false, null, null, null, new ComparableSubObj(1)),
-                 new ComparableTest(1, 0.0, false, null, null, null, new ComparableSubObj(2)),
-                 new ComparableTest(2, 0.0, false, null, null, null, new ComparableSubObj(1)),
-                 new ComparableTest(2, 0.0, false, null, null, null,  new ComparableSubObj(2))
+                 new ComparableTest(1, 0.0, false, null, null, new ComparableSubObj(1), null),
+                 new ComparableTest(1, 0.0, false, null, null, new ComparableSubObj(2), null),
+                 new ComparableTest(2, 0.0, false, null, null, new ComparableSubObj(1), null),
+                 new ComparableTest(2, 0.0, false, null, null,  new ComparableSubObj(2), null)
          );
      }
 
@@ -145,12 +142,28 @@ public class CompareToTest {
          );
      }
 
+     @Test
+     void oneOfCompareTo() {
+         assertComparables(
+                 createOneOf(ComparableOneOfTest.OneofExampleOneOfType.TEXT1_ONE_OF, "a"),
+                 createOneOf(ComparableOneOfTest.OneofExampleOneOfType.TEXT1_ONE_OF, "b"),
+                 createOneOf(ComparableOneOfTest.OneofExampleOneOfType.TEXT2_ONE_OF, "a"),
+                 createOneOf(ComparableOneOfTest.OneofExampleOneOfType.TEXT2_ONE_OF, "b"),
+                 createOneOf(ComparableOneOfTest.OneofExampleOneOfType.SUB_OBJECT, new ComparableSubObj(1)),
+                 createOneOf(ComparableOneOfTest.OneofExampleOneOfType.SUB_OBJECT, new ComparableSubObj(2))
+         );
+     }
+
+     private ComparableOneOfTest createOneOf(ComparableOneOfTest.OneofExampleOneOfType type, Object value) {
+         return new ComparableOneOfTest(new OneOf<>(type, value));
+     }
+
     private static long nextLong() {
-        return  RandomGenerator.getDefault().nextLong();
+        return RandomGenerator.getDefault().nextLong();
     }
 
     private static boolean nextBoolean() {
-        return  RandomGenerator.getDefault().nextBoolean();
+        return RandomGenerator.getDefault().nextBoolean();
     }
 
     private static ComparableEnum nextEnum() {

--- a/pbj-integration-tests/src/test/resources/non_compilable_comparable_oneOf.proto
+++ b/pbj-integration-tests/src/test/resources/non_compilable_comparable_oneOf.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+
+message NonComparableSubObj {
+  int32 num = 1;
+}
+
+// <<<pbj.comparable = "oneofExample" >>>
+message NonCompilableComparableOneOfTest {
+  oneof oneofExample {
+    string text1OneOf = 10;
+    NonComparableSubObj subObject = 11;
+  }
+}

--- a/pbj-integration-tests/src/test/resources/non_compilable_comparable_repeated.proto
+++ b/pbj-integration-tests/src/test/resources/non_compilable_comparable_repeated.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+// <<<pbj.comparable = "int32List" >>>
+message NonSupportedComparableTestBytes {
+    repeated int32 int32List = 2;
+}
+

--- a/pbj-integration-tests/src/test/resources/non_compilable_comparable_sub_obj.proto
+++ b/pbj-integration-tests/src/test/resources/non_compilable_comparable_sub_obj.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+
+message NonComparableSubObj {
+  int32 num = 1;
+}
+
+// <<<pbj.comparable = "subObject" >>>
+message NonCompilableComparableTest {
+  NonComparableSubObj subObject = 1;
+}
+
+


### PR DESCRIPTION
PR highlights: 
- by default all fields of a class are used in `compareTo` method. 
- `pbj.comparable` option in a comment can be used to specify limited set of fields to be used in `compareTo`. 
```
// <<<pbj.comparable = "int32Number, text, subObject" >>>
```
- there was a small modification in Protobuf grammar definition to support it
- `Bytes` and `BytesValue` fields are compared using byte-by-byte comparison 
- repeatable fields are not supported



Misc:
- refactored ModelGenerator: extracted code-generating code into several independent methods
- upgraded Gradle version to 8.5 to support Java 21
- added dependency to Mockito framework in pbj-compiler


**Related issue(s)**:

Fixes #103 
