### PR TITLE
fix 68: improve parsing

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -248,12 +248,17 @@ public final class TestGenerator implements Generator {
 	 * Generate code for test method. The test method is designed to reuse thread local buffers. This is
 	 * very important for performance as without this the tests quickly overwhelm the garbage collector.
 	 *
+	 * This method also adds a public static final reference to the ProtoC class for this model object.
+	 *
 	 * @param modelClassName The class name of the model object we are creating a test for
 	 * @param protoCJavaFullQualifiedClass The qualified class name of the protoc generated object class
 	 * @return Code for test method
 	 */
 	private static String generateTestMethod(final String modelClassName, final String protoCJavaFullQualifiedClass) {
 		return """
+				/** A reference to the protoc generated object class. */
+				public static final Class<$protocModelClass> PROTOC_MODEL_CLASS = $protocModelClass.class;
+
 				@ParameterizedTest
 				@MethodSource("createModelTestArguments")
 				public void test$modelClassNameAgainstProtoC(final NoToStringWrapper<$modelClassName> modelObjWrapper) throws Exception {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -257,7 +257,8 @@ public final class TestGenerator implements Generator {
 	private static String generateTestMethod(final String modelClassName, final String protoCJavaFullQualifiedClass) {
 		return """
 				/** A reference to the protoc generated object class. */
-				public static final Class<$protocModelClass> PROTOC_MODEL_CLASS = $protocModelClass.class;
+				public static final Class<$protocModelClass> PROTOC_MODEL_CLASS
+						= $protocModelClass.class;
 
 				@ParameterizedTest
 				@MethodSource("createModelTestArguments")

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -114,54 +114,58 @@ class CodecParseMethodGenerator {
 
                     // -- PARSE LOOP ---------------------------------------------
                     // Continue to parse bytes out of the input stream until we get to the end.
-                    try {
-                        while (input.hasRemaining()) {
+                    while (input.hasRemaining()) {
+                        // Note: ReadableStreamingData.hasRemaining() won't flip to false
+                        // until the end of stream is actually hit with a read operation.
+                        // So we catch this exception here and **only** here, because an EOFException
+                        // anywhere else suggests that we're processing malformed data and so
+                        // we must re-throw the exception then.
+                        final int tag;
+                        try {
                             // Read the "tag" byte which gives us the field number for the next field to read
                             // and the wire type (way it is encoded on the wire).
-                            final int tag = input.readVarInt(false);
+                            tag = input.readVarInt(false);
+                        } catch (EOFException e) {
+                            // There's no more fields. Stop the parsing loop.
+                            break;
+                        }
 
-                            // The field is the top 5 bits of the byte. Read this off
-                            final int field = tag >>> TAG_FIELD_OFFSET;
+                        // The field is the top 5 bits of the byte. Read this off
+                        final int field = tag >>> TAG_FIELD_OFFSET;
 
-                            // Ask the Schema to inform us what field this represents.
-                            final var f = getField(field);
+                        // Ask the Schema to inform us what field this represents.
+                        final var f = getField(field);
 
-                            // Given the wire type and the field type, parse the field
-                            switch (tag) {
-                $caseStatements
-                                default -> {
-                                    // The wire type is the bottom 3 bits of the byte. Read that off
-                                    final int wireType = tag & TAG_WRITE_TYPE_MASK;
-                                    // handle error cases here, so we do not do if statements in normal loop
-                                    // Validate the field number is valid (must be > 0)
-                                    if (field == 0) {
-                                        throw new IOException("Bad protobuf encoding. We read a field value of " + field);
-                                    }
-                                    // Validate the wire type is valid (must be >=0 && <= 5). Otherwise we cannot parse this.
-                                    // Note: it is always >= 0 at this point (see code above where it is defined).
-                                    if (wireType > 5) {
-                                        throw new IOException("Cannot understand wire_type of " + wireType);
-                                    }
-                                    // It may be that the parser subclass doesn't know about this field
-                                    if (f == null) {
-                                        if (strictMode) {
-                                            // Since we are parsing is strict mode, this is an exceptional condition.
-                                            throw new UnknownFieldException(field);
-                                        } else {
-                                            // We just need to read off the bytes for this field to skip it and move on to the next one.
-                                            skipField(input, ProtoConstants.get(wireType));
-                                        }
+                        // Given the wire type and the field type, parse the field
+                        switch (tag) {
+            $caseStatements
+                            default -> {
+                                // The wire type is the bottom 3 bits of the byte. Read that off
+                                final int wireType = tag & TAG_WRITE_TYPE_MASK;
+                                // handle error cases here, so we do not do if statements in normal loop
+                                // Validate the field number is valid (must be > 0)
+                                if (field == 0) {
+                                    throw new IOException("Bad protobuf encoding. We read a field value of " + field);
+                                }
+                                // Validate the wire type is valid (must be >=0 && <= 5). Otherwise we cannot parse this.
+                                // Note: it is always >= 0 at this point (see code above where it is defined).
+                                if (wireType > 5) {
+                                    throw new IOException("Cannot understand wire_type of " + wireType);
+                                }
+                                // It may be that the parser subclass doesn't know about this field
+                                if (f == null) {
+                                    if (strictMode) {
+                                        // Since we are parsing is strict mode, this is an exceptional condition.
+                                        throw new UnknownFieldException(field);
                                     } else {
-                                        throw new IOException("Bad tag [" + tag + "], field [" + field + "] wireType [" + wireType + "]");
+                                        // We just need to read off the bytes for this field to skip it and move on to the next one.
+                                        skipField(input, ProtoConstants.get(wireType));
                                     }
+                                } else {
+                                    throw new IOException("Bad tag [" + tag + "], field [" + field + "] wireType [" + wireType + "]");
                                 }
                             }
                         }
-                    }
-                    catch (EOFException e) {
-                        // Do nothing.
-                        // This is a workaround of hasRemaining() returning true, even there are no more elements.
-                        // The subsequent readByte will throw EOFException if there ar no more elements.
                     }
                     return new $modelClassName($fieldsList);
                 }
@@ -215,13 +219,20 @@ class CodecParseMethodGenerator {
                 "field=" + fieldNum + " [" + field.name() + "] */ -> {\n");
         sb.append("""
 				// Read the length of packed repeated field data
-				final var length = input.readVarInt(false);
+				final long length = input.readVarInt(false);
+				if (input.remaining() < length) {
+				    throw new BufferUnderflowException();
+				}
 				final var beforeLimit = input.limit();
+				final long beforePosition = input.position();
 				input.limit(input.position() + length);
 				while (input.hasRemaining()) {
 				    $tempFieldName = addToList($tempFieldName,$readMethod);
 				}
-				input.limit(beforeLimit);"""
+				input.limit(beforeLimit);
+				if (input.position() != beforePosition + length) {
+				    throw new BufferUnderflowException();
+				}"""
                 .replace("$tempFieldName", "temp_" + field.name())
                 .replace("$readMethod", readMethod(field))
                 .indent(DEFAULT_INDENT)

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/MalformedProtobufException.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/MalformedProtobufException.java
@@ -15,4 +15,8 @@ public class MalformedProtobufException extends IOException {
 	public MalformedProtobufException(final String message) {
 		super(message);
 	}
+
+	public MalformedProtobufException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -208,18 +208,19 @@ public final class ProtoParserTools {
         if (input.remaining() < length) {
             throw new BufferUnderflowException();
         }
-        final byte[] bytes = new byte[length];
-        final long bytesRead = input.readBytes(bytes);
+        final ByteBuffer bb = ByteBuffer.allocate(length);
+        final long bytesRead = input.readBytes(bb);
         if (bytesRead != length) {
             throw new BufferUnderflowException();
         }
+        bb.rewind();
 
         try {
             // Shouldn't use `new String()` because we want to error out on malformed UTF-8 bytes.
             return StandardCharsets.UTF_8.newDecoder()
                     .onMalformedInput(CodingErrorAction.REPORT)
                     .onUnmappableCharacter(CodingErrorAction.REPORT)
-                    .decode(ByteBuffer.wrap(bytes))
+                    .decode(bb)
                     .toString();
         } catch (CharacterCodingException e) {
             throw new MalformedProtobufException("Malformed UTF-8 string encountered", e);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -5,7 +5,10 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -200,7 +203,7 @@ public final class ProtoParserTools {
      * @param input the input to read from
      * @return Read string
      */
-    public static String readString(final ReadableSequentialData input) {
+    public static String readString(final ReadableSequentialData input) throws IOException {
         final int length = input.readVarInt(false);
         if (input.remaining() < length) {
             throw new BufferUnderflowException();
@@ -211,7 +214,16 @@ public final class ProtoParserTools {
             throw new BufferUnderflowException();
         }
 
-        return new String(bytes,StandardCharsets.UTF_8);
+        try {
+            // Shouldn't use `new String()` because we want to error out on malformed UTF-8 bytes.
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            throw new MalformedProtobufException("Malformed UTF-8 string encountered", e);
+        }
     }
 
     /**
@@ -250,6 +262,9 @@ public final class ProtoParserTools {
             case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLong(false);
             case WIRE_TYPE_DELIMITED -> {
                 final int length = input.readVarInt(false);
+                if (length < 0) {
+                    throw new IOException("Encountered a field with negative length " + length);
+                }
                 input.skip(length);
             }
             case WIRE_TYPE_GROUP_START -> throw new IOException("Wire type 'Group Start' is unsupported");

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SequentialData.java
@@ -74,7 +74,7 @@ public interface SequentialData {
 
     /**
      * Move {@link #position()} forward by {@code count} bytes. If the {@code count} would move the position past the
-     * {@link #limit()}, then clamp the position to the {@link #limit()}.
+     * {@link #limit()}, then a buffer overflow or underflow exception is thrown.
      *
      * @param count number of bytes to skip. If 0 or negative, then no bytes are skipped.
      * @return the actual number of bytes skipped.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
@@ -298,7 +298,7 @@ public sealed class BufferedData
      */
     @Override
     public long skip(final long count) {
-        if (count > Integer.MAX_VALUE || buffer.remaining() < (int) count) {
+        if (count > Integer.MAX_VALUE || (int) count > buffer.remaining()) {
             throw new BufferUnderflowException();
         }
         if (count <= 0) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
@@ -297,8 +297,10 @@ public sealed class BufferedData
      * {@inheritDoc}
      */
     @Override
-    public long skip(long count) {
-        count = Math.min(count, buffer.remaining());
+    public long skip(final long count) {
+        if (count > Integer.MAX_VALUE || buffer.remaining() < (int) count) {
+            throw new BufferUnderflowException();
+        }
         if (count <= 0) {
             return 0;
         }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessSequenceAdapter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessSequenceAdapter.java
@@ -83,13 +83,15 @@ final class RandomAccessSequenceAdapter implements ReadableSequentialData {
     /** {@inheritDoc} */
     @Override
     public long skip(final long count) {
-        final var c = Math.min(count, remaining());
-        if (c <= 0) {
+        if (count > remaining()) {
+            throw new BufferUnderflowException();
+        }
+        if (count <= 0) {
             return 0;
         }
 
-        position += c;
-        return c;
+        position += count;
+        return count;
     }
 
     // ================================================================================================================

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -151,7 +151,7 @@ public class ReadableStreamingData implements ReadableSequentialData, Closeable 
     /** {@inheritDoc} */
     @Override
     public long skip(final long n) {
-        if (n > limit) {
+        if (position + n > limit) {
             throw new BufferUnderflowException();
         }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -151,14 +151,16 @@ public class ReadableStreamingData implements ReadableSequentialData, Closeable 
     /** {@inheritDoc} */
     @Override
     public long skip(final long n) {
-        final long clamped = Math.min(n, limit);
+        if (n > limit) {
+            throw new BufferUnderflowException();
+        }
 
-        if (clamped <= 0) {
+        if (n <= 0) {
             return 0;
         }
 
         try {
-            long numSkipped = in.skip(clamped);
+            long numSkipped = in.skip(n);
             position += numSkipped;
             return numSkipped;
         } catch (final IOException e) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
@@ -7,7 +7,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
@@ -106,7 +105,7 @@ public class WritableStreamingData implements WritableSequentialData, Closeable 
             // We can only skip UP TO count.
             // And if the maximum bytes we can end up skipping is not positive, then we can't skip any bytes.
             if (count > remaining()) {
-                throw new BufferUnderflowException();
+                throw new BufferOverflowException();
             }
             if (count <= 0) {
                 return 0;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
@@ -7,6 +7,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
@@ -100,11 +101,13 @@ public class WritableStreamingData implements WritableSequentialData, Closeable 
      * @return the actual number of bytes skipped.
      */
     @Override
-    public long skip(long count) {
+    public long skip(final long count) {
         try {
-            // We can only skip UP TO count, but if there are fewer bytes remaining, then we can only skip that many.
+            // We can only skip UP TO count.
             // And if the maximum bytes we can end up skipping is not positive, then we can't skip any bytes.
-            count = Math.min(count, remaining());
+            if (count > remaining()) {
+                throw new BufferUnderflowException();
+            }
             if (count <= 0) {
                 return 0;
             }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/CharBufferToWritableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/CharBufferToWritableSequentialData.java
@@ -5,6 +5,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import java.nio.BufferUnderflowException;
 import java.nio.CharBuffer;
 
 /**
@@ -39,9 +40,15 @@ public class CharBufferToWritableSequentialData implements WritableSequentialDat
 
     @Override
     public long skip(long count) {
-        final long numToSkip = Math.max(Math.min(count, charBuffer.remaining()), 0);
-        charBuffer.position((int) numToSkip);
-        return numToSkip;
+        if (count > charBuffer.remaining()) {
+            throw new BufferUnderflowException();
+        }
+        if (count <= 0) {
+            return 0;
+        }
+        // Note: skip() should be relative. But it's okay, this is a test implementation.
+        charBuffer.position((int) count);
+        return count;
     }
 
     @Override

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/Sneaky.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/Sneaky.java
@@ -1,0 +1,25 @@
+package com.hedera.pbj.runtime.test;
+
+/**
+ * A utility class that implements sneakyThrow().
+ */
+public final class Sneaky {
+    /**
+     * Throw a checked exception pretending that it's unchecked,
+     * and also pretend to return a value for convenience.
+     *
+     * A non-void method could perform `return sneakyThrow(ex);` to avoid
+     * adding an extra line of code with a no-op return statement.
+     * A void method could just call this method and not worry about the return value.
+     *
+     * @param throwable any exception, even a checked exception
+     * @return this method never really returns a value, but javac thinks it could
+     * @param <E> an exception type that javac assumes is an unchecked exception
+     * @param <R> a fake return type for convenience of calling this from non-void methods
+     * @throws E this method always throws its argument throwable regardless of its type,
+     *           but javac thinks it's of type E, which it assumes to be an unchecked exception.
+     */
+    public static <E extends Throwable, R> R sneakyThrow(final Throwable throwable) throws E {
+        throw (E) throwable;
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/UncheckedThrowingFunction.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/UncheckedThrowingFunction.java
@@ -1,0 +1,29 @@
+package com.hedera.pbj.runtime.test;
+
+import java.util.function.Function;
+
+/**
+ * A utility wrapper for functions that throw checked exceptions.
+ *
+ * @param function a throwing function
+ * @param <T> function argument type
+ * @param <R> function return type
+ */
+public final record UncheckedThrowingFunction<T, R>(
+        ThrowingFunction<T, R> function
+) implements Function<T, R>  {
+
+    /** A function that can throw checked exceptions. */
+    public static interface ThrowingFunction<T, R> {
+        R apply(T arg) throws Throwable;
+    }
+
+    @Override
+    public R apply(T t) {
+        try {
+            return function.apply(t);
+        } catch (Throwable e) {
+            return Sneaky.sneakyThrow(e);
+        }
+    }
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
 import net.bytebuddy.utility.RandomString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -176,7 +177,7 @@ class ProtoParserToolsTest {
                     d.writeVarInt(length, false); // write the size first
                     d.writeUTF8(v);
                 },
-                ProtoParserTools::readString,
+                new UncheckedThrowingFunction<>(ProtoParserTools::readString),
                 length + 1);
     }
     @Test
@@ -276,7 +277,6 @@ class ProtoParserToolsTest {
     private static void skipTag(BufferedData data) {
         data.readVarInt(false);
     }
-
 
     private static <T> void testRead(final Supplier<? extends T> valueSupplier,
                                      final BiConsumer<BufferedData, ? super T> valueWriter,

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
@@ -58,9 +58,14 @@ final class ReadableSequentialDataTest extends ReadableSequentialTestBase {
 
         @Override
         public long skip(long count) {
-            final long numToSkip = Math.max(Math.min(count, limit - position), 0);
-            position += numToSkip;
-            return numToSkip;
+            if (count > limit - position) {
+                throw new BufferUnderflowException();
+            }
+            if (count <= 0) {
+                return 0;
+            }
+            position += count;
+            return count;
         }
 
         @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
@@ -158,8 +158,6 @@ public abstract class ReadableSequentialTestBase extends ReadableTestBase {
     void skipMoreThanAvailable() {
         final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
         assertThrows(BufferUnderflowException.class, () -> stream.skip(20));
-        assertThat(stream.hasRemaining()).isTrue();
-        assertThat(stream.remaining()).isEqualTo(10);
     }
 
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
@@ -2,9 +2,12 @@ package com.hedera.pbj.runtime.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.nio.BufferUnderflowException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -154,9 +157,9 @@ public abstract class ReadableSequentialTestBase extends ReadableTestBase {
     @DisplayName("Skipping more bytes than are available")
     void skipMoreThanAvailable() {
         final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
-        assertThat(stream.skip(20)).isEqualTo(10);
-        assertThat(stream.hasRemaining()).isFalse();
-        assertThat(stream.remaining()).isZero();
+        assertThrows(BufferUnderflowException.class, () -> stream.skip(20));
+        assertThat(stream.hasRemaining()).isTrue();
+        assertThat(stream.remaining()).isEqualTo(10);
     }
 
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/SequentialTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/SequentialTestBase.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.nio.BufferUnderflowException;

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableSequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableSequentialDataTest.java
@@ -2,6 +2,7 @@ package com.hedera.pbj.runtime.io;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
 import java.util.Arrays;
 
 final class WritableSequentialDataTest extends WritableTestBase {
@@ -58,9 +59,14 @@ final class WritableSequentialDataTest extends WritableTestBase {
 
         @Override
         public long skip(long count) {
-            final long numToSkip = Math.max(Math.min(count, limit - position), 0);
-            position += numToSkip;
-            return numToSkip;
+            if (count > limit - position) {
+                throw new BufferUnderflowException();
+            }
+            if (count <= 0) {
+                return 0;
+            }
+            position += count;
+            return count;
         }
 
         @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -1146,9 +1147,9 @@ public abstract class WritableTestBase extends SequentialTestBase {
             // When we try to write an int, then we get a BufferOverflowException
             final var pos = 10 - 1; // A position that doesn't reserve enough bytes
             seq.skip(pos);
-            for (int i = pos; i < 10; i++, seq.skip(1)) {
-                assertThatThrownBy(() -> seq.writeVarInt(1234, zigZag)).isInstanceOf(BufferOverflowException.class);
-            }
+            assertThatThrownBy(() -> seq.writeVarInt(1234, zigZag)).isInstanceOf(BufferOverflowException.class);
+            // A subsequent skip() will also throw an exception now that we hit the end of buffer
+            assertThatThrownBy(() -> seq.skip(1)).isInstanceOf(BufferUnderflowException.class);
         }
 
         @Test
@@ -1225,9 +1226,9 @@ public abstract class WritableTestBase extends SequentialTestBase {
             // When we try to write an int, then we get a BufferOverflowException
             final var pos = 10 - 1; // A position that doesn't reserve enough bytes
             seq.skip(pos);
-            for (int i = pos; i < 10; i++, seq.skip(1)) {
-                assertThatThrownBy(() -> seq.writeVarLong(3882918382L, zigZag)).isInstanceOf(BufferOverflowException.class);
-            }
+            assertThatThrownBy(() -> seq.writeVarLong(3882918382L, zigZag)).isInstanceOf(BufferOverflowException.class);
+            // A subsequent skip() will also throw an exception now that we hit the end of buffer
+            assertThatThrownBy(() -> seq.skip(1)).isInstanceOf(BufferUnderflowException.class);
         }
 
         @Test

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
@@ -1149,7 +1149,10 @@ public abstract class WritableTestBase extends SequentialTestBase {
             seq.skip(pos);
             assertThatThrownBy(() -> seq.writeVarInt(1234, zigZag)).isInstanceOf(BufferOverflowException.class);
             // A subsequent skip() will also throw an exception now that we hit the end of buffer
-            assertThatThrownBy(() -> seq.skip(1)).isInstanceOf(BufferUnderflowException.class);
+            assertThatThrownBy(() -> seq.skip(1)).isInstanceOfAny(
+                    BufferUnderflowException.class,
+                    BufferOverflowException.class
+            );
         }
 
         @Test
@@ -1228,7 +1231,10 @@ public abstract class WritableTestBase extends SequentialTestBase {
             seq.skip(pos);
             assertThatThrownBy(() -> seq.writeVarLong(3882918382L, zigZag)).isInstanceOf(BufferOverflowException.class);
             // A subsequent skip() will also throw an exception now that we hit the end of buffer
-            assertThatThrownBy(() -> seq.skip(1)).isInstanceOf(BufferUnderflowException.class);
+            assertThatThrownBy(() -> seq.skip(1)).isInstanceOfAny(
+                    BufferUnderflowException.class,
+                    BufferOverflowException.class
+            );
         }
 
         @Test


### PR DESCRIPTION
**Description**:
Addressing a few parsing issues that led to discrepancies between Google Protobuf behavior and PBJ's. Specifically:
1. Re-implementing https://github.com/hashgraph/pbj/pull/47 to reduce the scope of the try/catch block that swallows EOFException to only do that at the beginning of reading a field. When this exception is thrown anywhere else during the parsing of the field, then the parser errors out too.
2. Adding length/position checks to the repeated fields parser.
3. Modifying the string parser to error out on invalid UTF-8 data.
4. Modifying the delimited field skipper to error out on negative length.
5. Modifying the skip() implementation to error out if there's not enough bytes remaining in the buffer to skip.

Also introducing a couple of helper classes - `Sneaky` and `UncheckedThrowingFunction`, as well as adding a new static field to PBJ models Test files to reference their corresponding Google Protoc model class. This latter one-liner part isn't technically needed in this fix, but I'll be using it in a future PR shortly, and I don't want to touch anything from pbj-core in that PR.

**Related issue(s)**:

Fixes #68 

**Notes for reviewer**:
Build passes and existing tests pass. In a future PR, the results of this fix will help improve the fuzz testing framework, but that's a part of that separate future PR.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
