### PR TITLE
fix 68: compare PBJ with Google Protobuf and tighten thresholds for f…

### DIFF
--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/Elapsed.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/Elapsed.java
@@ -1,0 +1,62 @@
+package com.hedera.pbj.integration.fuzz;
+
+import com.hedera.pbj.runtime.test.Sneaky;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A utility class to measure elapsed time of a running code.
+ * @param result the return value of the code, if any
+ * @param nanos the time the code took to run, in nanos
+ * @param <T> the return type of the code, or Void for Runnables.
+ */
+public final record Elapsed<T>(
+        T result,
+        long nanos
+) {
+
+    /**
+     * Measure the time the provided Callable takes to run.
+     *
+     * @param callable a callable
+     * @return an Elapsed record with the return value of the callable, and the time
+     * @param <T> the Callable's return value type
+     */
+    public static <T> Elapsed<T> time(final Callable<T> callable) {
+        long start = System.nanoTime();
+        try {
+            final T result = callable.call();
+            return new Elapsed<>(result, System.nanoTime() - start);
+        } catch (Exception ex) {
+            return Sneaky.sneakyThrow(ex);
+        }
+    }
+
+    /**
+     * Measure the time the provided Runnable takes to run.
+     *
+     * @param runnable a runnable
+     * @return an Elapsed record with the time. The result is set to null.
+     */
+    public static Elapsed<Void> time(final Runnable runnable) {
+        return time(() -> { runnable.run(); return null; });
+    }
+
+    /**
+     * Format the elapsed time in a human-readable form.
+     *
+     * The current implementation translates the nanos to seconds
+     * and returns a string of the form "X seconds".
+     *
+     * The returned value is suitable for reporting/logging purposes only.
+     * Callers should NOT rely on the exact format of the returned
+     * string because it may change in the future.
+     *
+     * @return a string describing the elapsed time
+     */
+    public String format() {
+        return TimeUnit.SECONDS.convert(nanos(), TimeUnit.NANOSECONDS) + " seconds";
+    }
+
+}

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzUtil.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/fuzz/FuzzUtil.java
@@ -1,0 +1,25 @@
+package com.hedera.pbj.integration.fuzz;
+
+import java.lang.reflect.Field;
+
+/**
+ * A utility class used in the fuzz testing framework.
+ */
+public final class FuzzUtil {
+    /**
+     * Get a value of a static field named `name` in a class `clz`.
+     *
+     * @param clz a class
+     * @param name a field name
+     * @return the field value
+     * @param <T> the type of the field value
+     */
+    public static <T> T getStaticFieldValue(final Class<?> clz, final String name) {
+        try {
+            final Field field = clz.getField(name);
+            return (T) field.get(null);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new FuzzTestException("Failed to get field " + name + " from " + clz.getName(), e);
+        }
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -2,7 +2,12 @@ package com.hedera.pbj.intergration.test;
 
 import com.hedera.hapi.node.base.tests.AccountIDTest;
 import com.hedera.hapi.node.base.tests.ContractIDTest;
-import com.hedera.pbj.integration.fuzz.*;
+import com.hedera.pbj.integration.fuzz.Elapsed;
+import com.hedera.pbj.integration.fuzz.FuzzTest;
+import com.hedera.pbj.integration.fuzz.FuzzTestResult;
+import com.hedera.pbj.integration.fuzz.FuzzUtil;
+import com.hedera.pbj.integration.fuzz.SingleFuzzTest;
+import com.hedera.pbj.integration.fuzz.SingleFuzzTestResult;
 import com.hedera.pbj.test.proto.pbj.tests.EverythingTest;
 import com.hedera.pbj.test.proto.pbj.tests.HashevalTest;
 import com.hedera.pbj.test.proto.pbj.tests.InnerEverythingTest;
@@ -125,6 +130,7 @@ public class SampleFuzzTest {
             double deserializationFailedMean
     ) {
         private static final NumberFormat PERCENTAGE_FORMAT = NumberFormat.getPercentInstance();
+
         static {
             PERCENTAGE_FORMAT.setMinimumFractionDigits(2);
         }
@@ -155,7 +161,11 @@ public class SampleFuzzTest {
             final List<? extends FuzzTestResult<?>> results = testCases()
                     // Note that we must run this stream sequentially to enable
                     // reproducing the tests for a given random seed.
-                    .map(testCase -> FuzzTest.fuzzTest(testCase.object(), THRESHOLD, random, testCase.protocModelClass()))
+                    .map(testCase -> FuzzTest.fuzzTest(
+                            testCase.object(),
+                            THRESHOLD,
+                            random,
+                            testCase.protocModelClass()))
                     .peek(result -> { if (debug) System.out.println(result.format()); })
                     .collect(Collectors.toList());
 

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -2,9 +2,7 @@ package com.hedera.pbj.intergration.test;
 
 import com.hedera.hapi.node.base.tests.AccountIDTest;
 import com.hedera.hapi.node.base.tests.ContractIDTest;
-import com.hedera.pbj.integration.fuzz.FuzzTest;
-import com.hedera.pbj.integration.fuzz.FuzzTestResult;
-import com.hedera.pbj.integration.fuzz.SingleFuzzTestResult;
+import com.hedera.pbj.integration.fuzz.*;
 import com.hedera.pbj.test.proto.pbj.tests.EverythingTest;
 import com.hedera.pbj.test.proto.pbj.tests.HashevalTest;
 import com.hedera.pbj.test.proto.pbj.tests.InnerEverythingTest;
@@ -48,7 +46,7 @@ public class SampleFuzzTest {
      * if random modifications of the object's payload produce
      * that many DESERIALIZATION_FAILED outcomes.
      */
-    private static final double THRESHOLD = .8;
+    private static final double THRESHOLD = .95;
 
     /**
      * A percentage threshold for the pass rate across tests
@@ -57,7 +55,7 @@ public class SampleFuzzTest {
      * The fuzz test as a whole is considered passed
      * if that many individual model tests pass.
      */
-    private static final double PASS_RATE_THRESHOLD = .9;
+    private static final double PASS_RATE_THRESHOLD = 1.;
 
     /**
      * A threshold for the mean value of the shares of DESERIALIZATION_FAILED
@@ -67,7 +65,7 @@ public class SampleFuzzTest {
      * if the mean value of all the individual DESERIALIZATION_FAILED
      * shares is greater than this threshold.
      */
-    private static final double DESERIALIZATION_FAILED_MEAN_THRESHOLD = .9;
+    private static final double DESERIALIZATION_FAILED_MEAN_THRESHOLD = .983;
 
     /**
      * Fuzz tests are tagged with this tag to allow Gradle/JUnit
@@ -89,22 +87,37 @@ public class SampleFuzzTest {
      */
     private static final long FIXED_RANDOM_SEED = 837582698436792L;
 
-    private static final List<List<?>> MODEL_TEST_OBJECTS = List.of(
-            AccountIDTest.ARGUMENTS,
-            ContractIDTest.ARGUMENTS,
-            EverythingTest.ARGUMENTS,
-            HashevalTest.ARGUMENTS,
-            InnerEverythingTest.ARGUMENTS,
-            MessageWithStringTest.ARGUMENTS,
-            TimestampTest2Test.ARGUMENTS,
-            TimestampTestSeconds2Test.ARGUMENTS,
-            TimestampTestSecondsTest.ARGUMENTS,
-            TimestampTestTest.ARGUMENTS
+    private static final List<Class<?>> MODEL_TEST_CLASSES = List.of(
+            AccountIDTest.class,
+            ContractIDTest.class,
+            EverythingTest.class,
+            HashevalTest.class,
+            InnerEverythingTest.class,
+            MessageWithStringTest.class,
+            TimestampTest2Test.class,
+            TimestampTestSeconds2Test.class,
+            TimestampTestSecondsTest.class,
+            TimestampTestTest.class
     );
 
-    private static Stream<?> objectTestCases() {
-        return MODEL_TEST_OBJECTS.stream()
-                .flatMap(List::stream);
+    private static record FuzzTestParams<T, P>(
+            T object,
+            Class<P> protocModelClass
+    ) {
+    }
+
+    private static Stream<? extends FuzzTestParams<?, ?>> testCases() {
+        return MODEL_TEST_CLASSES.stream()
+                .flatMap(clz -> {
+                    final Class<?> protocModelClass = FuzzUtil.getStaticFieldValue(clz, "PROTOC_MODEL_CLASS");
+
+                    return FuzzUtil.<List<?>>getStaticFieldValue(clz, "ARGUMENTS")
+                            .stream()
+                            .map(object -> new FuzzTestParams<>(
+                                    object,
+                                    protocModelClass
+                            ));
+                });
     }
 
     private static record ResultStats(
@@ -112,10 +125,13 @@ public class SampleFuzzTest {
             double deserializationFailedMean
     ) {
         private static final NumberFormat PERCENTAGE_FORMAT = NumberFormat.getPercentInstance();
+        static {
+            PERCENTAGE_FORMAT.setMinimumFractionDigits(2);
+        }
 
         boolean passed() {
-            return passRate > PASS_RATE_THRESHOLD
-                    && deserializationFailedMean > DESERIALIZATION_FAILED_MEAN_THRESHOLD;
+            return passRate >= PASS_RATE_THRESHOLD
+                    && deserializationFailedMean >= DESERIALIZATION_FAILED_MEAN_THRESHOLD;
         }
 
         String format() {
@@ -135,34 +151,40 @@ public class SampleFuzzTest {
 
         final Random random = buildRandom();
 
-        final List<? extends FuzzTestResult<?>> results = objectTestCases()
-                // Note that we must run this stream sequentially to enable
-                // reproducing the tests for a given random seed.
-                .map(object -> FuzzTest.fuzzTest(object, THRESHOLD, random))
-                .peek(result -> { if (debug) System.out.println(result.format()); })
-                .collect(Collectors.toList());
+        Elapsed<ResultStats> elapsedResultStats = Elapsed.time(() -> {
+            final List<? extends FuzzTestResult<?>> results = testCases()
+                    // Note that we must run this stream sequentially to enable
+                    // reproducing the tests for a given random seed.
+                    .map(testCase -> FuzzTest.fuzzTest(testCase.object(), THRESHOLD, random, testCase.protocModelClass()))
+                    .peek(result -> { if (debug) System.out.println(result.format()); })
+                    .collect(Collectors.toList());
 
-        final ResultStats resultStats = results.stream()
-                .map(result -> new ResultStats(
-                                result.passed() ? 1. : 0.,
-                                result.percentageMap().getOrDefault(SingleFuzzTestResult.DESERIALIZATION_FAILED, 0.)
-                        )
-                )
-                .reduce(
-                        (r1, r2) -> new ResultStats(
-                                r1.passRate() + r2.passRate(),
-                                r1.deserializationFailedMean() + r2.deserializationFailedMean())
-                )
-                .map(stats -> new ResultStats(
-                                stats.passRate() / (double) results.size(),
-                                stats.deserializationFailedMean() / (double) results.size()
-                        )
-                )
-                .orElse(new ResultStats(0., 0.));
+            return results.stream()
+                    .map(result -> new ResultStats(
+                                    result.passed() ? 1. : 0.,
+                                    result.percentageMap().getOrDefault(SingleFuzzTestResult.DESERIALIZATION_FAILED, 0.)
+                            )
+                    )
+                    .reduce(
+                            (r1, r2) -> new ResultStats(
+                                    r1.passRate() + r2.passRate(),
+                                    r1.deserializationFailedMean() + r2.deserializationFailedMean())
+                    )
+                    .map(stats -> new ResultStats(
+                                    stats.passRate() / (double) results.size(),
+                                    stats.deserializationFailedMean() / (double) results.size()
+                            )
+                    )
+                    .orElse(new ResultStats(0., 0.));
 
-        final String statsMessage = resultStats.format();
+        });
+
+        final String statsMessage = elapsedResultStats.result().format();
         System.out.println(statsMessage);
-        assertTrue(resultStats.passed(), statsMessage);
+        System.out.println("Total number of SingleFuzzTest runs: " + SingleFuzzTest.getNumberOfRuns());
+        System.out.println("Elapsed time: " + elapsedResultStats.format());
+
+        assertTrue(elapsedResultStats.result().passed(), statsMessage);
     }
 
     private Random buildRandom() {


### PR DESCRIPTION
…uzz tests

**Description**:
Main objectives:
1. Compare PBJ behavior with Google Protobuf when running fuzz tests, to ensure we always error out when Protobuf does. If we don't, the fuzz test will fail.
2. Tighten the fuzz test thresholds close to 100% now that we found a fixed a few issues.

Very minor refactoring of the existing fuzz testing code to support the above changes.

**Related issue(s)**:

Fixes #68 

**Notes for reviewer**:
```
$ gr fuzzTest --info
...
    Fuzz tests are configured to use a FIXED seed for `new Random(seed)`, and the seed value for this run is: 837582698436792
    Fuzz tests PASSED with passRate = 100.00% and deserializationFailedMean = 98.30%
    Total number of SingleFuzzTest runs: 1257180
    Elapsed time: 34 seconds
...
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
