### PR TITLE
fix 104: Parsing should never wrap

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -43,7 +43,7 @@ public interface Codec<T /*extends Record*/> {
      *     input
      */
     @NonNull default T parse(@NonNull Bytes bytes) throws IOException {
-        return parse(bytes.toReadableSequentialData());
+        return parse(bytes.toCopyingReadableSequentialData());
     }
 
     /**
@@ -77,7 +77,7 @@ public interface Codec<T /*extends Record*/> {
      *     input
      */
     @NonNull default T parseStrict(@NonNull Bytes bytes) throws IOException {
-        return parseStrict(bytes.toReadableSequentialData());
+        return parseStrict(bytes.toCopyingReadableSequentialData());
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -209,10 +209,9 @@ public final class Bytes implements RandomAccessData {
      */
     @NonNull
     public Bytes replicate() {
-        final var newLength = length - start;
-        final var bytes = new byte[newLength];
-        System.arraycopy(buffer, start, bytes, 0, newLength);
-        return new Bytes(bytes, 0, newLength);
+        final var bytes = new byte[length];
+        System.arraycopy(buffer, start, bytes, 0, length);
+        return new Bytes(bytes, 0, length);
     }
 
     /**
@@ -320,6 +319,17 @@ public final class Bytes implements RandomAccessData {
     @NonNull
     public ReadableSequentialData toReadableSequentialData() {
         return new RandomAccessSequenceAdapter(this);
+    }
+
+    /**
+     * Create and return a new {@link ReadableSequentialData} that is backed by this {@link Bytes}
+     * and that returns a replicated Bytes object upon a call to readBytes(int length).
+     *
+     * @return A {@link ReadableSequentialData} backed by this {@link Bytes}.
+     */
+    @NonNull
+    public ReadableSequentialData toCopyingReadableSequentialData() {
+        return new RandomAccessSequenceAdapter(this, true);
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
@@ -67,6 +67,20 @@ final class BytesTest {
         assertEquals(2, replicatedBytes.length());
         assertEquals(arr[1], replicatedBytes.getByte(0));
         assertEquals(arr[2], replicatedBytes.getByte(1));
+
+        // Also verify if the replica is really a replica and not a view
+        arr[0] = 100;
+        arr[1] = 90;
+        arr[2] = 80;
+
+        // First check if the original wrapped Bytes object sees the changes and keeps its length intact:
+        assertEquals(2, bytes.length());
+        assertEquals(90, bytes.getByte(0));
+        assertEquals(80, bytes.getByte(1));
+
+        // Now ensure the replica still has the original values defined at the very top
+        assertEquals(1, replicatedBytes.getByte(0));
+        assertEquals(2, replicatedBytes.getByte(1));
     }
 
     // ================================================================================================================

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
@@ -55,6 +55,19 @@ final class BytesTest {
         assertEquals("54686973206973206d7920537472696e6721", Bytes.wrap(s).toString());
     }
 
+    @Test
+    void testReplicate() {
+        byte[] arr = new byte[] { 0, 1, 2 };
+
+        // Only wrap the last two elements:
+        Bytes bytes = Bytes.wrap(arr, 1, 2);
+        Bytes replicatedBytes = bytes.replicate();
+
+        assertEquals(2, replicatedBytes.length());
+        assertEquals(arr[1], replicatedBytes.getByte(0));
+        assertEquals(arr[2], replicatedBytes.getByte(1));
+    }
+
     // ================================================================================================================
     // Verify Bytes.wrap(byte[])
 

--- a/pbj-integration-tests/src/main/proto/bytes.proto
+++ b/pbj-integration-tests/src/main/proto/bytes.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+/**
+ * Sample protobuf containing bytes.
+ */
+message MessageWithBytes {
+  bytes bytesField = 1;
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/ParserNeverWrapsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/ParserNeverWrapsTest.java
@@ -28,13 +28,14 @@ public class ParserNeverWrapsTest {
     private static class BytesWritableSequentialData implements WritableSequentialData {
         private final byte[] bytes;
 
+        private long position = 0;
+
+        private long limit;
+
         public BytesWritableSequentialData(byte[] bytes) {
             this.bytes = bytes;
             this.limit = bytes.length;
         }
-
-        private long position = 0;
-        private long limit;
 
         @Override
         public long capacity() {

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/ParserNeverWrapsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/ParserNeverWrapsTest.java
@@ -1,0 +1,199 @@
+package com.hedera.pbj.intergration.test;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.io.DataAccessException;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
+import com.hedera.pbj.test.proto.pbj.MessageWithBytes;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ParserNeverWrapsTest {
+
+    private static class BytesWritableSequentialData implements WritableSequentialData {
+        private final byte[] bytes;
+
+        public BytesWritableSequentialData(byte[] bytes) {
+            this.bytes = bytes;
+            this.limit = bytes.length;
+        }
+
+        private long position = 0;
+        private long limit;
+
+        @Override
+        public long capacity() {
+            return bytes.length;
+        }
+
+        @Override
+        public long position() {
+            return position;
+        }
+
+        @Override
+        public long limit() {
+            return limit;
+        }
+
+        @Override
+        public void limit(long limit) {
+            this.limit = limit;
+        }
+
+        @Override
+        public long skip(long count) {
+            // This doesn't matter in this test
+            position += count;
+            return count;
+        }
+
+        @Override
+        public void writeByte(byte b) throws DataAccessException {
+            bytes[(int) position++] = b;
+        }
+    }
+
+    private static record WrapTestData<T>(
+            Supplier<WritableSequentialData> wSeq,
+            Function<Codec<T>, T> parser,
+            Runnable resetter,
+            Supplier<byte[]> getter,
+            BiConsumer<Integer, byte[]> setter
+    ) {
+        static <T> WrapTestData<T> createByteArrayBufferedData(int size) {
+            // The current implementation creates ByteArrayBufferedData:
+            final BufferedData seq = BufferedData.allocate(size);
+            return new WrapTestData<T>(
+                    () -> seq,
+                    new UncheckedThrowingFunction<>(codec -> codec.parse(seq)),
+                    seq::reset,
+                    () -> seq.getBytes(0, size).toByteArray(),
+                    (pos, bytes) -> {
+                        seq.position(pos);
+                        seq.writeBytes(bytes);
+                    }
+            );
+        }
+
+        static <T> WrapTestData<T> createDirectBufferedData(int size) {
+            final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(size);
+            final BufferedData seq = BufferedData.wrap(byteBuffer);
+            return new WrapTestData<T>(
+                    () -> seq,
+                    new UncheckedThrowingFunction<>(codec -> codec.parse(seq)),
+                    seq::reset,
+                    () -> seq.getBytes(0, size).toByteArray(),
+                    (pos, bytes) -> {
+                        seq.position(pos);
+                        seq.writeBytes(bytes);
+                    }
+            );
+        }
+
+        static <T> WrapTestData<T> createBytes(int size) {
+            final byte[] byteArray = new byte[size];
+            final Bytes bytes = Bytes.wrap(byteArray);
+
+            final BytesWritableSequentialData seq = new BytesWritableSequentialData(byteArray);
+
+            return new WrapTestData<T>(
+                    () -> seq, // Only write once.
+                    new UncheckedThrowingFunction<>(codec -> codec.parse(bytes)),
+                    () -> {}, // reset() not supported and not needed for Bytes
+                    () -> byteArray, // return the actual array this Bytes object is wrapping
+                    (pos, arr) -> {
+                        for (int i = 0; i < arr.length; i++) {
+                            byteArray[pos + i] = arr[i];
+                        }
+                    }
+            );
+        }
+    }
+
+    static Stream<Function<Integer, WrapTestData>> provideWrapTestArguments() {
+        return Stream.of(
+                WrapTestData::createByteArrayBufferedData,
+                WrapTestData::createDirectBufferedData,
+                WrapTestData::createBytes
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideWrapTestArguments")
+    void testNoWrap(Function<Integer, WrapTestData> config) throws IOException {
+        final String randomString = UUID.randomUUID().toString();
+        final byte[] originalBytes = randomString.getBytes(StandardCharsets.UTF_8);
+
+        final MessageWithBytes originalMessage = MessageWithBytes.newBuilder()
+                .bytesField(Bytes.wrap(originalBytes))
+                .build();
+        final int size = MessageWithBytes.PROTOBUF.measureRecord(originalMessage);
+        final WrapTestData<MessageWithBytes> data = config.apply(size);
+        MessageWithBytes.PROTOBUF.write(originalMessage, data.wSeq().get());
+
+        int index = search(data.getter().get(), originalBytes);
+
+        assertNotEquals(-1, index, "Cannot find original bytes in the BufferedData");
+
+        data.resetter().run();
+        MessageWithBytes msg1 = data.parser().apply(MessageWithBytes.PROTOBUF);
+
+        // Make sure we parsed the original bytes the first time
+        assertArrayEquals(originalBytes, msg1.bytesField().toByteArray());
+
+        // Now modify the BufferedData and replace the original bytes completely
+        final String anotherRandomString = UUID.randomUUID().toString();
+        assertNotEquals(randomString, anotherRandomString);
+        final byte[] modifiedBytes = anotherRandomString.getBytes(StandardCharsets.UTF_8);
+
+        // We assume that the UUID uses 7-bit ASCII characters,
+        // so the size of the bytes array is the same for any random UUID.
+        assertEquals(originalBytes.length, modifiedBytes.length);
+        assertEquals(size - modifiedBytes.length, index);
+
+        data.setter().accept(index, modifiedBytes);
+
+        data.resetter().run();
+        MessageWithBytes msg2 = data.parser().apply(MessageWithBytes.PROTOBUF);
+
+        // Make sure we parsed the new bytes
+        assertArrayEquals(modifiedBytes, msg2.bytesField().toByteArray());
+
+        // Now check if the msg1 that we parsed from the same BufferedData before the modification
+        // still has the very original bytes, and not the modified bytes.
+        // In other words, ensure that the PROTOBUF.parse() didn't just wrap
+        // the original bytes array from the BufferedData, but instead created a copy.
+        assertArrayEquals(originalBytes, msg1.bytesField().toByteArray());
+    }
+
+    /** A brute-force search implementation because it's just a test. */
+    private static int search(byte[] bytes, byte[] pattern) {
+        for (int i = 0; i < bytes.length - pattern.length + 1; i++) {
+            for (int j = 0; j < pattern.length; j++) {
+                if (bytes[i + j] != pattern[j]) {
+                    break;
+                }
+                if (j == pattern.length - 1) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
**Description**:
Problem statement: in PBJ, parsing a model from a data buffer should create copies of data, especially for byte arrays, rather than use a direct view to the original buffer. Note that strings are covered for us by JDK itself because it always creates a copy. So of all the primitive types that we support in PBJ, only byte arrays need to be taken care of.

In this fix, the Codec.parse(Bytes) replaces usages of `Bytes.toReadableSequentialData` with a new `Bytes.toCopyingReadableSequentialData`. The latter initializes a returned `RandomAccessSequenceAdapter` object with a special flag that makes its `Bytes readBytes(int length)` method create a copy of the returned bytes.

Also, a test is added that checks all the three non-test implementations of the ReadableSequentialData on whether the wrapping occurs when parsing objects from these Data objects. Note that it is made sure that the test covering Bytes calls the particular Codec method that calls the `toCopyingReadableSequentialData` method.

The proposed solution is the least intrusive from the performance perspective. Ideally, the Bytes implementation itself should ensure to only return a view of the underlying data when explicitly requested. But it turns out that pretty much the entire implementation is built on the assumption of returning the view of the underlying data for performance reasons. So fixing this in Bytes directly would probably introduce performance regressions in other places.

Note that if anyone calls `Codec.parse(bytes.toReadableSequentialData)` explicitly, then they would still run into the wrapping issue. We can make this method package-private or otherwise restrict access to it if we don't want this to happen. As of today, this method was only used in Codec, which is being replaced in this fix, and also there's a single usage in `ReadableSequentialData.view()` default implementation. However, this very implementation actually creates a new bytes array. So the default implementation doesn't really provide a view. In any case, it doesn't seem to need fixing.

**Update on the above paragraph:** I just discovered that hedera-services uses toReadableSequentialData() left and right when passing it to a codec, even though the codec now provides a convenience method for parsing Bytes directly. So I'll be removing those calls from hedera-services in a separate PR.

Also, a bug in Bytes.replicate() is fixed. Previously it returned an incorrect, shortened replica when it itself was a view on a portion of another array with a non-zero offset. A new test is written for that as well.

**Related issue(s)**:

Fixes #104

**Notes for reviewer**:
The new test at pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/ParserNeverWrapsTest.java passes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
