### PR TITLE
fix: 76: Need API to write repeated bytes fields one message by one

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -288,10 +288,7 @@ public final class ProtoWriterTools {
      */
     public static void writeBytes(final WritableSequentialData out, final FieldDefinition field,
             final RandomAccessData value) throws IOException {
-        assert field.type() == FieldType.BYTES ||
-                field.type() == FieldType.STRING ||
-                field.type() == FieldType.MESSAGE
-                : "Not a byte[] type " + field;
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
         assert !field.repeated() : "Use writeBytesList with repeated types";
         writeBytesNoChecks(out, field, value, true);
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -227,28 +227,47 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a string to data output
+     * Write a string to data output, assuming the field is non-repeated.
      *
      * @param out The data output to write to
-     * @param field the descriptor for the field we are writing
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
      * @param value the string value to write
      * @throws IOException If a I/O error occurs
      */
-    public static void writeString(WritableSequentialData out, FieldDefinition field, String value) throws IOException {
+    public static void writeString(final WritableSequentialData out, final FieldDefinition field,
+            final String value) throws IOException {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert !field.repeated() : "Use writeStringList with repeated types";
         writeStringNoChecks(out, field, value);
     }
 
     /**
-     * Write a integer to data output - No validation checks
+     * Write a string to data output, assuming the field is repeated. Usually this method is called multiple
+     * times, one for every repeated value. If all values are available immediately, {@link #writeStringList(
+     * WritableSequentialData, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     * @throws IOException If a I/O error occurs
+     */
+    public static void writeOneRepeatedString(final WritableSequentialData out, final FieldDefinition field,
+            final String value) throws IOException {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "writeOneRepeatedString can only be used with repeated fields";
+        writeStringNoChecks(out, field, value);
+    }
+
+    /**
+     * Write a integer to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
      * @param value the string value to write
      * @throws IOException If a I/O error occurs
      */
-    private static void writeStringNoChecks(WritableSequentialData out, FieldDefinition field, String value) throws IOException {
+    private static void writeStringNoChecks(final WritableSequentialData out, final FieldDefinition field,
+            final String value) throws IOException {
         // When not a oneOf don't write default value
         if (!field.oneOf() && (value == null || value.isEmpty())) {
             return;
@@ -259,21 +278,44 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a bytes to data output
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
      *
      * @param out The data output to write to
-     * @param field the descriptor for the field we are writing
+     * @param field the descriptor for the field we are writing, the field must not be repeated
      * @param value the bytes value to write
      * @throws IOException If a I/O error occurs
      */
-    public static void writeBytes(WritableSequentialData out, FieldDefinition field, RandomAccessData value) throws IOException {
-        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+    public static void writeBytes(final WritableSequentialData out, final FieldDefinition field,
+            final RandomAccessData value) throws IOException {
+        assert field.type() == FieldType.BYTES ||
+                field.type() == FieldType.STRING ||
+                field.type() == FieldType.MESSAGE
+                : "Not a byte[] type " + field;
         assert !field.repeated() : "Use writeBytesList with repeated types";
         writeBytesNoChecks(out, field, value, true);
     }
 
     /**
-     * Write a bytes to data output
+     * Write a bytes to data output, assuming the corresponding field is repeated, and field type
+     * is any delimited: bytes, string, or message. Usually this method is called multiple times, one
+     * for every repeated value. If all values are available immediately, {@link #writeBytesList(
+     * WritableSequentialData, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param value the bytes value to write
+     * @throws IOException If a I/O error occurs
+     */
+    public static void writeOneRepeatedBytes(final WritableSequentialData out, final FieldDefinition field,
+            final RandomAccessData value) throws IOException {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
+        writeBytesNoChecks(out, field, value, true);
+    }
+
+    /**
+     * Write a bytes to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -281,7 +323,8 @@ public final class ProtoWriterTools {
      * @param skipZeroLength this is true for normal single bytes and false for repeated lists
      * @throws IOException If a I/O error occurs
      */
-    private static void writeBytesNoChecks(WritableSequentialData out, FieldDefinition field, RandomAccessData value, boolean skipZeroLength) throws IOException {
+    private static void writeBytesNoChecks(final WritableSequentialData out, final FieldDefinition field,
+            final RandomAccessData value, final boolean skipZeroLength) throws IOException {
         // When not a oneOf don't write default value
         if (!field.oneOf() && (skipZeroLength && (value.length() == 0))) {
             return;
@@ -297,24 +340,46 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a message to data output
+     * Write a message to data output, assuming the corresponding field is non-repeated.
      *
      * @param out The data output to write to
-     * @param field the descriptor for the field we are writing
+     * @param field the descriptor for the field we are writing, the field must not be repeated
      * @param message the message to write
      * @param writer method reference to writer for the given message type
      * @param sizeOf method reference to sizeOf measure method for the given message type
      * @throws IOException If a I/O error occurs
      * @param <T> type of message
      */
-    public static <T> void writeMessage(WritableSequentialData out, FieldDefinition field, T message, ProtoWriter<T> writer, ToIntFunction<T> sizeOf) throws IOException {
+    public static <T> void writeMessage(final WritableSequentialData out, final FieldDefinition field,
+            final T message, final ProtoWriter<T> writer, final ToIntFunction<T> sizeOf) throws IOException {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert !field.repeated() : "Use writeMessageList with repeated types";
         writeMessageNoChecks(out, field, message, writer, sizeOf);
     }
 
     /**
-     * Write a message to data output - No checks
+     * Write a message to data output, assuming the corresponding field is repeated. Usually this method is
+     * called multiple times, one for every repeated value. If all values are available immediately, {@link
+     * #writeMessageList(WritableSequentialData, FieldDefinition, List, ProtoWriter, ToIntFunction)}  should
+     * be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param message the message to write
+     * @param writer method reference to writer for the given message type
+     * @param sizeOf method reference to sizeOf measure method for the given message type
+     * @throws IOException If a I/O error occurs
+     * @param <T> type of message
+     */
+    public static <T> void writeOneRepeatedMessage(final WritableSequentialData out, final FieldDefinition field,
+            final T message, final ProtoWriter<T> writer, final ToIntFunction<T> sizeOf) throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "writeOneRepeatedMessage can only be used with repeated fields";
+        writeMessageNoChecks(out, field, message, writer, sizeOf);
+    }
+
+    /**
+     * Write a message to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -324,7 +389,8 @@ public final class ProtoWriterTools {
      * @throws IOException If a I/O error occurs
      * @param <T> type of message
      */
-    private static <T> void writeMessageNoChecks(WritableSequentialData out, FieldDefinition field, T message, ProtoWriter<T> writer, ToIntFunction<T> sizeOf) throws IOException {
+    private static <T> void writeMessageNoChecks(final WritableSequentialData out, final FieldDefinition field,
+            final T message, final ProtoWriter<T> writer, final ToIntFunction<T> sizeOf) throws IOException {
         // When not a oneOf don't write default value
         if (field.oneOf() && message == null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
@@ -385,6 +385,21 @@ class ProtoWriterToolsTest {
     }
 
     @Test
+    void testWriteOneRepeatedString() throws IOException {
+        final FieldDefinition definition = createRepeatedFieldDefinition(STRING);
+        final String value1 = RANDOM_STRING.nextString();
+        final String value2 = RANDOM_STRING.nextString();
+        final BufferedData buf1 = BufferedData.allocate(256);
+        ProtoWriterTools.writeStringList(buf1, definition, List.of(value1, value2));
+        final Bytes writtenBytes1 = buf1.getBytes(0, buf1.position());
+        final BufferedData buf2 = BufferedData.allocate(256);
+        ProtoWriterTools.writeOneRepeatedString(buf2, definition, value1);
+        ProtoWriterTools.writeOneRepeatedString(buf2, definition, value2);
+        final Bytes writtenBytes2 = buf2.getBytes(0, buf2.position());
+        assertEquals(writtenBytes1, writtenBytes2);
+    }
+
+    @Test
     void testWriteBytes_smallBuffer() throws IOException {
         BufferedData bd = BufferedData.allocate(1);
         FieldDefinition definition = createFieldDefinition(BYTES);
@@ -414,6 +429,21 @@ class ProtoWriterToolsTest {
     }
 
     @Test
+    void testWriteOneRepeatedBytes() throws IOException {
+        final FieldDefinition definition = createRepeatedFieldDefinition(BYTES);
+        final Bytes value1 = Bytes.wrap(RANDOM_STRING.nextString());
+        final Bytes value2 = Bytes.wrap(RANDOM_STRING.nextString());
+        final BufferedData buf1 = BufferedData.allocate(256);
+        ProtoWriterTools.writeBytesList(buf1, definition, List.of(value1, value2));
+        final Bytes writtenBytes1 = buf1.getBytes(0, buf1.position());
+        final BufferedData buf2 = BufferedData.allocate(256);
+        ProtoWriterTools.writeOneRepeatedBytes(buf2, definition, value1);
+        ProtoWriterTools.writeOneRepeatedBytes(buf2, definition, value2);
+        final Bytes writtenBytes2 = buf2.getBytes(0, buf2.position());
+        assertEquals(writtenBytes1, writtenBytes2);
+    }
+
+    @Test
     void testWriteMessage() throws IOException {
         FieldDefinition definition = createFieldDefinition(MESSAGE);
         String appleStr = RANDOM_STRING.nextString();
@@ -426,6 +456,24 @@ class ProtoWriterToolsTest {
     }
 
     @Test
+    void testWriteOneRepeatedMessage() throws IOException {
+        final FieldDefinition definition = createRepeatedFieldDefinition(MESSAGE);
+        final String appleStr1 = RANDOM_STRING.nextString();
+        final Apple apple1 = Apple.newBuilder().setVariety(appleStr1).build();
+        final String appleStr2 = RANDOM_STRING.nextString();
+        final Apple apple2 = Apple.newBuilder().setVariety(appleStr2).build();
+        final BufferedData buf1 = BufferedData.allocate(256);
+        final ProtoWriter<Apple> writer = (data, out) -> out.writeBytes(data.toByteArray());
+        ProtoWriterTools.writeMessageList(buf1, definition, List.of(apple1, apple2), writer, Apple::getSerializedSize);
+        final Bytes writtenBytes1 = buf1.getBytes(0, buf1.position());
+        final BufferedData buf2 = BufferedData.allocate(256);
+        ProtoWriterTools.writeOneRepeatedMessage(buf2, definition, apple1, writer, Apple::getSerializedSize);
+        ProtoWriterTools.writeOneRepeatedMessage(buf2, definition, apple2, writer, Apple::getSerializedSize);
+        final Bytes writtenBytes2 = buf2.getBytes(0, buf2.position());
+        assertEquals(writtenBytes1, writtenBytes2);
+    }
+
+    @Test
     void testWriteOneOfMessage() throws IOException {
         FieldDefinition definition = createOneOfFieldDefinition(MESSAGE);
         writeMessage(bufferedData, definition, null, (data, out) -> out.writeBytes(data.toByteArray()), Apple::getSerializedSize);
@@ -433,7 +481,6 @@ class ProtoWriterToolsTest {
         assertEquals((definition.number() << TAG_TYPE_BITS) | WIRE_TYPE_DELIMITED.ordinal(), bufferedData.readVarInt(false));
         int length = bufferedData.readVarInt(false);
         assertEquals(0, length);
-
     }
 
     @Test

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
@@ -633,7 +633,7 @@ class ProtoWriterToolsTest {
 
     @Test
     void testWriteOptionalBytes() throws IOException {
-        FieldDefinition definition = createOptionalFieldDefinition(STRING);
+        FieldDefinition definition = createOptionalFieldDefinition(BYTES);
         byte[] valToWrite = new byte[10];
         RNG.nextBytes(valToWrite);
         writeOptionalBytes(bufferedData, definition, Bytes.wrap(valToWrite));


### PR DESCRIPTION
Fix summary:
* New methods are added to `ProtoWriterTools` to write repeated fields one by one (in contrast to `writeXYZList()`, which expects all repeated values are passed as a list): `writeOneRepeatedBytes()`, `writeOneRepeatedMessage()`, and `writeOneRepeatedString()`
* These methods are identical to the corresponding `writeXYZ()`, except the assertion about field repeated type is opposite
* New tests are provided for the new methods. They check that the new methods, if called multiple times, are identical to the corresponding `writeXYZList()`

Fixes: https://github.com/hashgraph/pbj/issues/76
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
