### PR TITLE
fix 104: make RandomAccessSequenceAdapter.readBytes(int) always make …

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -43,7 +43,7 @@ public interface Codec<T /*extends Record*/> {
      *     input
      */
     @NonNull default T parse(@NonNull Bytes bytes) throws IOException {
-        return parse(bytes.toCopyingReadableSequentialData());
+        return parse(bytes.toReadableSequentialData());
     }
 
     /**
@@ -77,7 +77,7 @@ public interface Codec<T /*extends Record*/> {
      *     input
      */
     @NonNull default T parseStrict(@NonNull Bytes bytes) throws IOException {
-        return parseStrict(bytes.toCopyingReadableSequentialData());
+        return parseStrict(bytes.toReadableSequentialData());
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -322,17 +322,6 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     }
 
     /**
-     * Create and return a new {@link ReadableSequentialData} that is backed by this {@link Bytes}
-     * and that returns a replicated Bytes object upon a call to readBytes(int length).
-     *
-     * @return A {@link ReadableSequentialData} backed by this {@link Bytes}.
-     */
-    @NonNull
-    public ReadableSequentialData toCopyingReadableSequentialData() {
-        return new RandomAccessSequenceAdapter(this, true);
-    }
-
-    /**
      * Exposes this {@link Bytes} as an {@link InputStream}. This is a zero-copy operation.
      *
      * @return An {@link InputStream} that streams over the full set of data in this {@link Bytes}.


### PR DESCRIPTION
…a copy

**Description**:
As a follow-up for https://github.com/hashgraph/pbj/pull/167 , per a discussion with @jasperpotts and @OlegMazurov , we've decided to make the RandomAccessSequenceAdapter.readBytes(int) method always create a replica before returning the bytes. This class is currently used in Bytes only, and users of Bytes assume that the object is immutable. Since this cannot be guaranteed for objects created via Bytes.wrap(), this single method in the RandomAccessSequenceAdapter class will now replicate the bytes.

A comment in code suggests that we could make this conditional on the type of the delegate object. However, as mentioned, Bytes is the only current user of the class, so this condition would be a no-op today.

Per the discussion, if we notice a performance degradation after this change is merged, we'll evaluate the specific code-paths where the degradation is the most significant, and may consider introducing readBytesNoCopy() method to support a faster code-path provided we can prove that it's safe to do so based on the ownership of the underlying array.

**Related issue(s)**:

Fixes #104 

**Notes for reviewer**:
All tests, including a test written for the original PR linked above, pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
