### PR TITLE
fix 114: Wrap unchecked Exceptions in checked Exception

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -45,7 +45,7 @@ class JsonCodecParseMethodGenerator {
         return """
                 /**
                  * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. 
-                 * Throwsan UnknownFieldException wrapped in a ParseException if in strict mode ONLY.
+                 * Throws an UnknownFieldException wrapped in a ParseException if in strict mode ONLY.
                  *
                  * @param root The JSON parsed object tree to parse data from
                  * @return Parsed HashObject model object or null if data input was null or empty

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -44,35 +44,38 @@ class JsonCodecParseMethodGenerator {
     static String generateParseObjectMethod(final String modelClassName, final List<Field> fields) {
         return """
                 /**
-                 * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. Throws if in strict mode ONLY.
+                 * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. 
+                 * Throwsan UnknownFieldException wrapped in a ParseException if in strict mode ONLY.
                  *
                  * @param root The JSON parsed object tree to parse data from
                  * @return Parsed HashObject model object or null if data input was null or empty
-                 * @throws UnknownFieldException If an unknown field is encountered while parsing the object, and we are in strict mode
-                 * @throws IOException If the protobuf stream is not empty and has malformed JSON.
-                 * @throws NoSuchElementException If there is no element of type T that can be parsed from this input
+                 * @throws ParseException If parsing fails
                  */
                 public @NonNull $modelClassName parse(
                         @Nullable final JSONParser.ObjContext root,
-                        final boolean strictMode) throws IOException {
-                    // -- TEMP STATE FIELDS --------------------------------------
-                $fieldDefs
+                        final boolean strictMode) throws ParseException {
+                    try {
+                        // -- TEMP STATE FIELDS --------------------------------------
+                        $fieldDefs
 
-                    // -- EXTRACT VALUES FROM PARSE TREE ---------------------------------------------
-                    
-                    for (JSONParser.PairContext kvPair : root.pair()) {
-                        switch (kvPair.STRING().getText()) {
-                            $caseStatements
-                            default -> {
-                                if (strictMode) {
-                                    // Since we are parsing is strict mode, this is an exceptional condition.
-                                    throw new UnknownFieldException(kvPair.STRING().getText());
+                        // -- EXTRACT VALUES FROM PARSE TREE ---------------------------------------------
+
+                        for (JSONParser.PairContext kvPair : root.pair()) {
+                            switch (kvPair.STRING().getText()) {
+                                $caseStatements
+                                default -> {
+                                    if (strictMode) {
+                                        // Since we are parsing is strict mode, this is an exceptional condition.
+                                        throw new UnknownFieldException(kvPair.STRING().getText());
+                                    }
                                 }
                             }
                         }
+
+                        return new $modelClassName($fieldsList);
+                    } catch (Exception ex) {
+                        throw new ParseException(ex);
                     }
-                    
-                    return new $modelClassName($fieldsList);
                 }
                 """
         .replace("$modelClassName",modelClassName)

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
@@ -26,9 +26,9 @@ class CodecFastEqualsMethodGenerator {
                  * @param item The item to compare. Cannot be null.
                  * @param input The input with the bytes to compare
                  * @return true if the bytes represent the item, false otherwise.
-                 * @throws IOException If it is impossible to read from the {@link ReadableSequentialData}
+                 * @throws ParseException If parsing fails
                  */
-                public boolean fastEquals(@NonNull $modelClass item, @NonNull final ReadableSequentialData input) throws IOException {
+                public boolean fastEquals(@NonNull $modelClass item, @NonNull final ReadableSequentialData input) throws ParseException {
                     return item.equals(parse(input));
                 }
                 """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
@@ -22,9 +22,9 @@ class CodecMeasureDataMethodGenerator {
                  *
                  * @param input The input to use
                  * @return The length of the data item in the input
-                 * @throws IOException If it is impossible to read from the {@link ReadableSequentialData}
+                 * @throws ParseException If parsing fails
                  */
-                public int measure(@NonNull final ReadableSequentialData input) throws IOException {
+                public int measure(@NonNull final ReadableSequentialData input) throws ParseException {
                     final var start = input.position();
                     parse(input);
                     final var end = input.position();

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -80,7 +80,8 @@ class CodecParseMethodGenerator {
                  * @return Parsed $modelClassName model object or null if data input was null or empty
                  * @throws ParseException If parsing fails
                  */
-                public @NonNull $modelClassName parseStrict(@NonNull final ReadableSequentialData input) throws ParseException {
+                public @NonNull $modelClassName parseStrict(@NonNull final ReadableSequentialData input)
+                        throws ParseException {
                     return parseInternal(input, true);
                 }
                 """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -53,7 +53,8 @@ class CodecParseMethodGenerator {
                  * @return Parsed $modelClassName model object or null if data input was null or empty
                  * @throws ParseException If parsing fails
                  */
-                public @NonNull $modelClassName parse(@NonNull final ReadableSequentialData input) throws ParseException {
+                public @NonNull $modelClassName parse(@NonNull final ReadableSequentialData input)
+                        throws ParseException {
                     return parseInternal(input, false);
                 }
                 """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -147,9 +147,11 @@ class CodecParseMethodGenerator {
                                     // handle error cases here, so we do not do if statements in normal loop
                                     // Validate the field number is valid (must be > 0)
                                     if (field == 0) {
-                                        throw new IOException("Bad protobuf encoding. We read a field value of " + field);
+                                        throw new IOException("Bad protobuf encoding. We read a field value of "
+                                            + field);
                                     }
-                                    // Validate the wire type is valid (must be >=0 && <= 5). Otherwise we cannot parse this.
+                                    // Validate the wire type is valid (must be >=0 && <= 5).
+                                    // Otherwise we cannot parse this.
                                     // Note: it is always >= 0 at this point (see code above where it is defined).
                                     if (wireType > 5) {
                                         throw new IOException("Cannot understand wire_type of " + wireType);
@@ -160,11 +162,13 @@ class CodecParseMethodGenerator {
                                             // Since we are parsing is strict mode, this is an exceptional condition.
                                             throw new UnknownFieldException(field);
                                         } else {
-                                            // We just need to read off the bytes for this field to skip it and move on to the next one.
+                                            // We just need to read off the bytes for this field to skip it
+                                            // and move on to the next one.
                                             skipField(input, ProtoConstants.get(wireType));
                                         }
                                     } else {
-                                        throw new IOException("Bad tag [" + tag + "], field [" + field + "] wireType [" + wireType + "]");
+                                        throw new IOException("Bad tag [" + tag + "], field [" + field
+                                                + "] wireType [" + wireType + "]");
                                     }
                                 }
                             }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -51,9 +51,9 @@ class CodecParseMethodGenerator {
                  *              method. If null, the method returns immediately. If there are no bytes remaining in the data input,
                  *              then the method also returns immediately.
                  * @return Parsed $modelClassName model object or null if data input was null or empty
-                 * @throws IOException If the protobuf stream is not empty and has malformed protobuf bytes (i.e. isn't valid protobuf).
+                 * @throws ParseException If parsing fails
                  */
-                public @NonNull $modelClassName parse(@NonNull final ReadableSequentialData input) throws IOException {
+                public @NonNull $modelClassName parse(@NonNull final ReadableSequentialData input) throws ParseException {
                     return parseInternal(input, false);
                 }
                 """
@@ -77,11 +77,9 @@ class CodecParseMethodGenerator {
                  *              method. If null, the method returns immediately. If there are no bytes remaining in the data input,
                  *              then the method also returns immediately.
                  * @return Parsed $modelClassName model object or null if data input was null or empty
-                 * @throws UnknownFieldException If an unknown field is encountered while parsing the object
-                 * @throws IOException If the protobuf stream is not empty and has malformed
-                 * 									  protobuf bytes (i.e. isn't valid protobuf).
+                 * @throws ParseException If parsing fails
                  */
-                public @NonNull $modelClassName parseStrict(@NonNull final ReadableSequentialData input) throws IOException {
+                public @NonNull $modelClassName parseStrict(@NonNull final ReadableSequentialData input) throws ParseException {
                     return parseInternal(input, true);
                 }
                 """
@@ -103,13 +101,11 @@ class CodecParseMethodGenerator {
                  *              method. If null, the method returns immediately. If there are no bytes remaining in the data input,
                  *              then the method also returns immediately.
                  * @return Parsed $modelClassName model object or null if data input was null or empty
-                 * @throws UnknownFieldException If an unknown field is encountered while parsing the object and we are in strict mode
-                 * @throws IOException If the protobuf stream is not empty and has malformed
-                 * 									  protobuf bytes (i.e. isn't valid protobuf).
+                 * @throws ParseException If parsing fails
                  */
                 private @NonNull $modelClassName parseInternal(
                         @NonNull final ReadableSequentialData input,
-                        final boolean strictMode) throws IOException {
+                        final boolean strictMode) throws ParseException {
                     try {
                         // -- TEMP STATE FIELDS --------------------------------------
                         $fieldDefs
@@ -174,8 +170,8 @@ class CodecParseMethodGenerator {
                             }
                         }
                         return new $modelClassName($fieldsList);
-                    } catch (final RuntimeException uncheckedException) {
-                        throw new IOException("Unchecked parsing exception", uncheckedException);
+                    } catch (final Exception anyException) {
+                        throw new ParseException(anyException);
                     }
                 }
                 """

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -3,7 +3,6 @@ package com.hedera.pbj.runtime;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.NoSuchElementException;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
@@ -27,22 +26,18 @@ public interface Codec<T /*extends Record*/> {
      *
      * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
      * @return The parsed object. It must not return null.
-     * @throws IOException If it is impossible to read from the {@link ReadableSequentialData}
-     * @throws NoSuchElementException If there is no element of type T that can be parsed from this
-     *     input
+     * @throws ParseException If parsing fails
      */
-    @NonNull T parse(@NonNull ReadableSequentialData input) throws IOException;
+    @NonNull T parse(@NonNull ReadableSequentialData input) throws ParseException;
 
     /**
      * Parses an object from the {@link Bytes} and returns it.
      *
      * @param bytes The {@link Bytes} from which to read the data to construct an object
      * @return The parsed object. It must not return null.
-     * @throws IOException If it is impossible to read from the {@link Bytes}
-     * @throws NoSuchElementException If there is no element of type T that can be parsed from this
-     *     input
+     * @throws ParseException If parsing fails
      */
-    @NonNull default T parse(@NonNull Bytes bytes) throws IOException {
+    @NonNull default T parse(@NonNull Bytes bytes) throws ParseException {
         return parse(bytes.toReadableSequentialData());
     }
 
@@ -55,12 +50,9 @@ public interface Codec<T /*extends Record*/> {
      *
      * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
      * @return The parsed object. It must not return null.
-     * @throws IOException If it is impossible to read from the {@link ReadableSequentialData}
-     * @throws UnknownFieldException If an unknown field is encountered while parsing the object
-     * @throws NoSuchElementException If there is no element of type T that can be parsed from this
-     *     input
+     * @throws ParseException If parsing fails
      */
-    @NonNull T parseStrict(@NonNull ReadableSequentialData input) throws IOException;
+    @NonNull T parseStrict(@NonNull ReadableSequentialData input) throws ParseException;
 
     /**
      * Parses an object from the {@link Bytes} and returns it. Throws an exception if fields
@@ -71,12 +63,9 @@ public interface Codec<T /*extends Record*/> {
      *
      * @param bytes The {@link Bytes} from which to read the data to construct an object
      * @return The parsed object. It must not return null.
-     * @throws IOException If it is impossible to read from the {@link Bytes}
-     * @throws UnknownFieldException If an unknown field is encountered while parsing the object
-     * @throws NoSuchElementException If there is no element of type T that can be parsed from this
-     *     input
+     * @throws ParseException If parsing fails
      */
-    @NonNull default T parseStrict(@NonNull Bytes bytes) throws IOException {
+    @NonNull default T parseStrict(@NonNull Bytes bytes) throws ParseException {
         return parseStrict(bytes.toReadableSequentialData());
     }
 
@@ -96,9 +85,9 @@ public interface Codec<T /*extends Record*/> {
      *
      * @param input The input to use
      * @return The length of the data item in the input
-     * @throws IOException If it is impossible to read from the {@link ReadableSequentialData}
+     * @throws ParseException If parsing fails
      */
-    int measure(@NonNull ReadableSequentialData input) throws IOException;
+    int measure(@NonNull ReadableSequentialData input) throws ParseException;
 
     /**
      * Compute number of bytes that would be written when calling {@code write()} method.
@@ -118,9 +107,9 @@ public interface Codec<T /*extends Record*/> {
      * @param item The item to compare. Cannot be null.
      * @param input The input with the bytes to compare
      * @return true if the bytes represent the item, false otherwise.
-     * @throws IOException If it is impossible to read from the {@link ReadableSequentialData}
+     * @throws ParseException If parsing fails
      */
-    boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws IOException;
+    boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException;
 
     /**
      * Converts a Record into a Bytes object

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -130,7 +130,7 @@ public final class JsonTools {
                     try {
                         return codec.parse(v.obj(), false);
                     } catch (ParseException e) {
-                        throw new RuntimeException(e);
+                        throw new UncheckedParseException(e);
                     }
                 }).toList();
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -129,8 +129,8 @@ public final class JsonTools {
                 .map(v -> {
                     try {
                         return codec.parse(v.obj(), false);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
+                    } catch (ParseException e) {
+                        throw new RuntimeException(e);
                     }
                 }).toList();
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
@@ -1,0 +1,14 @@
+package com.hedera.pbj.runtime;
+
+/**
+ * A checked exception thrown by Codec parse() methods when the parsing operation fails.
+ *
+ * The `cause` of this exception provides more details on the nature of the failure
+ * which can be caused by I/O issues, malformed input data, or any other reason
+ * that prevents the parse() method from completing the operation.
+ */
+public class ParseException extends Exception {
+    public ParseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
@@ -1,7 +1,7 @@
 package com.hedera.pbj.runtime;
 
 /**
- * A checked exception thrown by Codec parse() methods when the parsing operation fails.
+ * A checked exception thrown by Codec.parse() methods when the parsing operation fails.
  *
  * The `cause` of this exception provides more details on the nature of the failure
  * which can be caused by I/O issues, malformed input data, or any other reason

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/UncheckedParseException.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/UncheckedParseException.java
@@ -1,0 +1,11 @@
+package com.hedera.pbj.runtime;
+
+/**
+ * An unchecked wrapper for a ParseException object used in rare cases
+ * where existing code shouldn't throw checked exceptions.
+ */
+public class UncheckedParseException extends RuntimeException {
+    public UncheckedParseException(ParseException cause) {
+        super(cause);
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/MalformedMessageTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/MalformedMessageTest.java
@@ -31,7 +31,7 @@ class MalformedMessageTest {
         final BufferedData data = prepareTestData(buffer);
         buffer.array()[1] += 1; // artificially increase message size
         // parser fails because the message size is not expected
-        assertThrows(BufferUnderflowException.class,() -> codec.parse(data));
+        assertThrows(IOException.class, () -> codec.parse(data));
     }
 
     @Test
@@ -41,7 +41,7 @@ class MalformedMessageTest {
         buffer.limit(10); // we trick the parser into thinking that there is more to process
         buffer.array()[9] = 0; // but the byte is not valid
         buffer.array()[1] += 1; // artificially increase message size
-        assertThrows(IOException.class,() -> codec.parse(data)); // parser fails because of an unknown tag
+        assertThrows(IOException.class, () -> codec.parse(data)); // parser fails because of an unknown tag
     }
 
     @Test
@@ -51,7 +51,7 @@ class MalformedMessageTest {
         buffer.limit(10); // we trick the parser into thinking that there is more to process
         buffer.array()[9] = 8; // the tag is valid but the data is not there
         buffer.array()[1] += 1; // artificially increase message size
-        assertThrows(BufferUnderflowException.class,() -> codec.parse(data));
+        assertThrows(IOException.class, () -> codec.parse(data));
     }
 
     @Test
@@ -59,7 +59,7 @@ class MalformedMessageTest {
         final ByteBuffer buffer = ByteBuffer.allocate(13);
         final BufferedData data = prepareTestData(buffer);
         buffer.array()[1] -= 1; // artificially decrease message size
-        assertThrows(BufferUnderflowException.class,() -> codec.parse(data));
+        assertThrows(IOException.class, () -> codec.parse(data));
     }
 
     private BufferedData prepareTestData(final ByteBuffer byteBuffer) throws IOException {

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/MalformedMessageTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/MalformedMessageTest.java
@@ -2,6 +2,7 @@ package com.hedera.pbj.intergration.test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.test.proto.pbj.Everything;
 import com.hedera.pbj.test.proto.pbj.TimestampTest;
@@ -10,8 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.BufferOverflowException;
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.random.RandomGenerator;
 
@@ -31,7 +30,7 @@ class MalformedMessageTest {
         final BufferedData data = prepareTestData(buffer);
         buffer.array()[1] += 1; // artificially increase message size
         // parser fails because the message size is not expected
-        assertThrows(IOException.class, () -> codec.parse(data));
+        assertThrows(ParseException.class, () -> codec.parse(data));
     }
 
     @Test
@@ -41,7 +40,7 @@ class MalformedMessageTest {
         buffer.limit(10); // we trick the parser into thinking that there is more to process
         buffer.array()[9] = 0; // but the byte is not valid
         buffer.array()[1] += 1; // artificially increase message size
-        assertThrows(IOException.class, () -> codec.parse(data)); // parser fails because of an unknown tag
+        assertThrows(ParseException.class, () -> codec.parse(data)); // parser fails because of an unknown tag
     }
 
     @Test
@@ -51,7 +50,7 @@ class MalformedMessageTest {
         buffer.limit(10); // we trick the parser into thinking that there is more to process
         buffer.array()[9] = 8; // the tag is valid but the data is not there
         buffer.array()[1] += 1; // artificially increase message size
-        assertThrows(IOException.class, () -> codec.parse(data));
+        assertThrows(ParseException.class, () -> codec.parse(data));
     }
 
     @Test
@@ -59,7 +58,7 @@ class MalformedMessageTest {
         final ByteBuffer buffer = ByteBuffer.allocate(13);
         final BufferedData data = prepareTestData(buffer);
         buffer.array()[1] -= 1; // artificially decrease message size
-        assertThrows(IOException.class, () -> codec.parse(data));
+        assertThrows(ParseException.class, () -> codec.parse(data));
     }
 
     private BufferedData prepareTestData(final ByteBuffer byteBuffer) throws IOException {


### PR DESCRIPTION
**Description**:
The Codec.parse() methods will throw a checked ParseException when parsing fails. The `cause` throwable of the ParseException provides details on the nature of the failure.

Original description:
~~Catching any RuntimeExceptions thrown in the parsing loop and wrapping them in IOException. Parsing is related to I/O, so this wrapping makes sense. Introducing a new dedicated checked ParseException would require changes to the parsing method signatures, and to all the places that use it which is a lot. Since the code calling the parsing method catches the IOException already, this fix solves the problem statement.~~

**Related issue(s)**:

Fixes #114

**Notes for reviewer**:
All tests pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
