### PR TITLE
fix: 175 CompareTo Generation fails if fields include underscores

### DIFF
--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.spotless-java-conventions.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.spotless-java-conventions.gradle.kts
@@ -23,7 +23,7 @@ spotless {
         toggleOffOn()
         // don't need to set target, it is inferred from java
         // apply a specific flavor of google-java-format
-        googleJavaFormat("1.15.0").aosp().reflowLongStrings()
+        googleJavaFormat("1.17.0").aosp().reflowLongStrings()
         // make sure every file has the following copyright header.
         // optionally, Spotless can set copyright years by digging
         // through git history (see "license" section below).

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
@@ -35,6 +35,8 @@ import org.gradle.api.tasks.TaskAction;
 
 /** Gradle Task that generates java src code from protobuf proto schema files. */
 public abstract class PbjCompilerTask extends SourceTask {
+    private static final int MAX_TRACE_FRAMES = 8;
+    private static final String STACK_ELEMENT_INDENT = "    ";
 
     /**
      * Set the java main directory that we write generated code into
@@ -120,6 +122,13 @@ public abstract class PbjCompilerTask extends SourceTask {
                     }
                 } catch (Exception e) {
                     System.err.println("Exception while processing file: " + protoFile);
+                    // Print an abbreviated stack trace for help in debugging.
+                    System.err.println(e);
+                    var trace = e.getStackTrace();
+                    int count = 0;
+                    for (var element : trace) {
+                        if (count++ < MAX_TRACE_FRAMES) System.err.println(STACK_ELEMENT_INDENT + element);
+                    }
                     throw e;
                 }
             }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -256,7 +256,7 @@ public final class ModelGenerator implements Generator {
 	private static List<Field> filterComparableFields(final MessageDefContext msgDef,
 													final ContextualLookupHelper lookupHelper,
 													final List<Field> fields) {
-		final Map<String, Field> fieldByName = fields.stream().collect(toMap(Field::nameCamelFirstLower, f -> f));
+		final Map<String, Field> fieldByName = fields.stream().collect(toMap(Field::name, f -> f));
 		final List<String> comparableFields = lookupHelper.getComparableFields(msgDef);
 		return comparableFields.stream().map(fieldByName::get).collect(Collectors.toList());
 	}

--- a/pbj-integration-tests/src/main/proto/comparable.proto
+++ b/pbj-integration-tests/src/main/proto/comparable.proto
@@ -15,7 +15,7 @@ message ComparableSubObj {
   int32 num = 1;
 }
 
-// <<<pbj.comparable = "int32Number, doubleNumber, booleanField, text, comparableEnum, subObject, bytes" >>>
+// <<<pbj.comparable = "int32Number, doubleNumber, booleanField, text, comparableEnum, subObject, test_bytes" >>>
 message ComparableTest {
   int32 int32Number = 1;
   double doubleNumber = 2;
@@ -23,7 +23,7 @@ message ComparableTest {
   string text = 4;
   ComparableEnum comparableEnum = 5;
   ComparableSubObj subObject = 6;
-  bytes bytes = 7;
+  bytes test_bytes = 7;
 }
 
 // <<<pbj.comparable = "stringValue" >>>


### PR DESCRIPTION
* Adjusted ModelGenerator to use field `name` instead of `nameCamelFirstLower` when filtering comparable fields.
* Added an abbreviated stack trace for exceptions when compiling proto files, to help debug future issues like this.
* Modified comparable.proto in integration tests, renaming `bytes bytes` to `bytes test_bytes` to prevent regression.
* Modified the spotless conventions to allow Java 21 to be used

Fixes: #175 
