### PR TITLE
fix 114: fix jmh compilation

### DIFF
--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/JsonBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/JsonBench.java
@@ -9,6 +9,7 @@ import com.hedera.pbj.integration.AccountDetailsPbj;
 import com.hedera.pbj.integration.EverythingTestData;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.JsonCodec;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.test.proto.pbj.Everything;
 import com.hederahashgraph.api.proto.java.GetAccountDetailsResponse;
@@ -78,7 +79,7 @@ public abstract class JsonBench<P extends Record,G extends GeneratedMessageV3> {
 
 	/** Same as parsePbjByteBuffer because DataBuffer.wrap(byte[]) uses ByteBuffer today, added this because makes result plotting easier */
 	@Benchmark
-	public void parsePbj(JsonBenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws IOException {
+	public void parsePbj(JsonBenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws ParseException {
 		benchmarkState.jsonDataBuffer.position(0);
 		blackhole.consume(benchmarkState.pbjJsonCodec.parse(benchmarkState.jsonDataBuffer));
 	}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/ProtobufObjectBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/ProtobufObjectBench.java
@@ -9,6 +9,7 @@ import com.hedera.pbj.integration.EverythingTestData;
 import com.hedera.pbj.integration.NonSynchronizedByteArrayInputStream;
 import com.hedera.pbj.integration.NonSynchronizedByteArrayOutputStream;
 import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
@@ -101,7 +102,7 @@ public abstract class ProtobufObjectBench<P extends Record,G extends GeneratedMe
 	/** Same as parsePbjByteBuffer because DataBuffer.wrap(byte[]) uses ByteBuffer today, added this because makes result plotting easier */
 	@Benchmark
 	@OperationsPerInvocation(OPERATION_COUNT)
-	public void parsePbjByteArray(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws IOException {
+	public void parsePbjByteArray(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws ParseException {
 		for (int i = 0; i < 1000; i++) {
 			benchmarkState.protobufDataBuffer.resetPosition();
 			blackhole.consume(benchmarkState.pbjCodec.parse(benchmarkState.protobufDataBuffer));
@@ -110,7 +111,7 @@ public abstract class ProtobufObjectBench<P extends Record,G extends GeneratedMe
 
 	@Benchmark
 	@OperationsPerInvocation(OPERATION_COUNT)
-	public void parsePbjByteBuffer(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws IOException {
+	public void parsePbjByteBuffer(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws ParseException {
 		for (int i = 0; i < 1000; i++) {
 			benchmarkState.protobufDataBuffer.resetPosition();
 			blackhole.consume(benchmarkState.pbjCodec.parse(benchmarkState.protobufDataBuffer));
@@ -119,7 +120,7 @@ public abstract class ProtobufObjectBench<P extends Record,G extends GeneratedMe
 
 	@Benchmark
 	@OperationsPerInvocation(OPERATION_COUNT)
-	public void parsePbjByteBufferDirect(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws IOException {
+	public void parsePbjByteBufferDirect(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws ParseException {
 		for (int i = 0; i < 1000; i++) {
 			benchmarkState.protobufDataBufferDirect.resetPosition();
 			blackhole.consume(benchmarkState.pbjCodec.parse(benchmarkState.protobufDataBufferDirect));
@@ -127,7 +128,7 @@ public abstract class ProtobufObjectBench<P extends Record,G extends GeneratedMe
 	}
 	@Benchmark
 	@OperationsPerInvocation(OPERATION_COUNT)
-	public void parsePbjInputStream(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws IOException {
+	public void parsePbjInputStream(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws ParseException {
 		for (int i = 0; i < 1000; i++) {
 			benchmarkState.bin.resetPosition();
 			blackhole.consume(benchmarkState.pbjCodec.parse(new ReadableStreamingData(benchmarkState.bin)));

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/ProtobufObjectBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/intergration/jmh/ProtobufObjectBench.java
@@ -120,7 +120,8 @@ public abstract class ProtobufObjectBench<P extends Record,G extends GeneratedMe
 
 	@Benchmark
 	@OperationsPerInvocation(OPERATION_COUNT)
-	public void parsePbjByteBufferDirect(BenchmarkState<P,G> benchmarkState, Blackhole blackhole) throws ParseException {
+	public void parsePbjByteBufferDirect(BenchmarkState<P,G> benchmarkState, Blackhole blackhole)
+			throws ParseException {
 		for (int i = 0; i < 1000; i++) {
 			benchmarkState.protobufDataBufferDirect.resetPosition();
 			blackhole.consume(benchmarkState.pbjCodec.parse(benchmarkState.protobufDataBufferDirect));


### PR DESCRIPTION
**Description**:
Fixing compile-time errors in jmh after https://github.com/hashgraph/pbj/pull/172

The build failure: https://github.com/hashgraph/pbj/actions/runs/7618734592/job/20750476803

**Related issue(s)**:

Fixes #114 

**Notes for reviewer**:
`g jmh` is able to compile the code

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
