### PR TITLE
fix 183: implement Flushable in WritableStreamingData

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.7.14-SNAPSHOT
+version=0.7.15-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
@@ -4,6 +4,7 @@ import com.hedera.pbj.runtime.io.DataAccessException;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
@@ -14,7 +15,7 @@ import java.util.Objects;
  * <p>A {@code WritableSequentialData} backed by an output stream. If the instance is closed,
  * the underlying {@link OutputStream} is closed too.
  */
-public class WritableStreamingData implements WritableSequentialData, Closeable {
+public class WritableStreamingData implements WritableSequentialData, Closeable, Flushable {
 
     /** The underlying output stream */
     private final OutputStream out;
@@ -218,5 +219,16 @@ public class WritableStreamingData implements WritableSequentialData, Closeable 
         } catch (final IOException e) {
             throw new DataAccessException(e);
         }
+    }
+
+    // ================================================================================================================
+    // Flushable Methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void flush() throws IOException {
+        out.flush();
     }
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 public class WritableStreamingDataTest extends WritableTestBase {
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/WritableStreamingDataTest.java
@@ -17,8 +17,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class WritableStreamingDataTest extends WritableTestBase {
 
@@ -99,5 +104,19 @@ public class WritableStreamingDataTest extends WritableTestBase {
         final var src = new ByteArrayInputStream("Gonna Throw".getBytes(StandardCharsets.UTF_8));
         // When we try to write some bytes, then we get an exception because the stream throws IOException
         assertThatThrownBy(() -> seq.writeBytes(src, 5)).isInstanceOf(DataAccessException.class);
+    }
+
+    @Test
+    @DisplayName("Calling flush() is delegated to the OutputStream")
+    void testFlushable() throws IOException {
+        final OutputStream out = mock(OutputStream.class);
+        doNothing().when(out).flush();
+
+        final WritableStreamingData seq = new WritableStreamingData(out);
+
+        seq.flush();
+
+        verify(out, times(1)).flush();
+        verifyNoMoreInteractions(out);
     }
 }


### PR DESCRIPTION
**Description**:
* Implement Flushable in WritableStreamingData.
* Update version to 0.7.15

**Related issue(s)**:

Fixes #183 

**Notes for reviewer**:
* A new unit test is added.
* `test` target in pbj-runtime passes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
