### PR TITLE
feat: add support for automatic Nexus plugin based releases

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -150,7 +150,7 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: |
-          ./gradlew release-maven-central --no-parallel --scan -PpublishSigningEnabled=true \
+          ./gradlew releaseMavenCentral --no-parallel --scan -PpublishSigningEnabled=true \
               -Pgradle.publish.key=${GRADLE_PUBLISH_KEY} -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}
 
       - name: Gradle Maven Central Snapshot
@@ -159,4 +159,4 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        run: ./gradlew release-maven-central-snapshot --no-parallel --scan -PpublishSigningEnabled=true
+        run: ./gradlew releaseMavenCentralSnapshot --no-parallel --scan -PpublishSigningEnabled=true

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -150,7 +150,7 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: |
-          ./gradlew releaseMavenCentral --no-parallel --scan -PpublishSigningEnabled=true \
+          ./gradlew release --no-parallel --scan -PpublishSigningEnabled=true \
               -Pgradle.publish.key=${GRADLE_PUBLISH_KEY} -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}
 
       - name: Gradle Maven Central Snapshot
@@ -159,4 +159,4 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        run: ./gradlew releaseMavenCentralSnapshot --no-parallel --scan -PpublishSigningEnabled=true
+        run: ./gradlew releaseSnapshot --no-parallel --scan -PpublishSigningEnabled=true

--- a/pbj-core/buildSrc/build.gradle.kts
+++ b/pbj-core/buildSrc/build.gradle.kts
@@ -28,5 +28,5 @@ dependencies {
     implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
     implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.2")
     implementation("net.swiftzer.semver:semver:1.3.0")
-    implementation("org.gradlex:java-module-dependencies:1.4.1")
+    implementation("org.gradlex:java-module-dependencies:1.5.2")
 }

--- a/pbj-core/buildSrc/build.gradle.kts
+++ b/pbj-core/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@ plugins { `kotlin-dsl` }
 repositories { gradlePluginPortal() }
 
 dependencies {
-    implementation("com.adarshr:gradle-test-logger-plugin:3.2.0")
-    implementation("com.autonomousapps:dependency-analysis-gradle-plugin:1.21.0")
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.21.0")
+    implementation("com.adarshr:gradle-test-logger-plugin:4.0.0")
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin:1.29.0")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
     implementation("com.gradle.publish:plugin-publish-plugin:1.2.1")
     implementation("gradle.plugin.lazy.zoo.gradle:git-data-plugin:1.2.2")
     implementation("net.swiftzer.semver:semver:1.3.0")
     implementation("org.gradlex:java-module-dependencies:1.4.1")
+    implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
 }

--- a/pbj-core/buildSrc/build.gradle.kts
+++ b/pbj-core/buildSrc/build.gradle.kts
@@ -25,7 +25,8 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
     implementation("com.gradle.publish:plugin-publish-plugin:1.2.1")
     implementation("gradle.plugin.lazy.zoo.gradle:git-data-plugin:1.2.2")
+    implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
+    implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.2")
     implementation("net.swiftzer.semver:semver:1.3.0")
     implementation("org.gradlex:java-module-dependencies:1.4.1")
-    implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
 }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
@@ -32,6 +32,8 @@ plugins {
 group = "com.hedera.pbj"
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
         vendor.set(JvmVendorSpec.ADOPTIUM)

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
@@ -44,9 +44,6 @@ javaModuleDependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
         vendor.set(JvmVendorSpec.ADOPTIUM)

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
@@ -31,18 +31,6 @@ plugins {
 
 group = "com.hedera.pbj"
 
-javaModuleDependencies {
-    moduleNameToGA.put(
-        "com.github.spotbugs.annotations",
-        "com.github.spotbugs:spotbugs-annotations"
-    )
-    moduleNameToGA.put("com.google.protobuf", "com.google.protobuf:protobuf-java")
-    moduleNameToGA.put("org.antlr.antlr4.runtime", "org.antlr:antlr4-runtime")
-    moduleNameToGA.put("org.mockito.inline", "org.mockito:mockito-inline")
-    // The following line is commented out because it causes the Gradle build to break
-    // moduleNameToGA.put("org.mockito.junit.jupiter", "org.mockito:mockito-junit-jupiter")
-}
-
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,14 @@ javaModuleDependencies {
     moduleNameToGA.put("com.google.protobuf", "com.google.protobuf:protobuf-java")
     moduleNameToGA.put("org.antlr.antlr4.runtime", "org.antlr:antlr4-runtime")
     moduleNameToGA.put("org.mockito.inline", "org.mockito:mockito-inline")
+    // The following line is commented out because it causes the Gradle build to break
+    // moduleNameToGA.put("org.mockito.junit.jupiter", "org.mockito:mockito-junit-jupiter")
 }
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
         vendor.set(JvmVendorSpec.ADOPTIUM)

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
@@ -30,5 +30,3 @@ tasks.register("releaseMavenCentral") {
     group = "release"
     dependsOn(tasks.named("publishPlugins"))
 }
-
-tasks.register("releaseMavenCentralSnapshot") { group = "release" }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.autonomousapps.DependencyAnalysisSubExtension
+
 plugins {
     id("com.hedera.pbj.conventions")
     id("com.gradle.plugin-publish")
@@ -30,3 +32,7 @@ tasks.register("releaseMavenCentral") {
     group = "release"
     dependsOn(tasks.named("publishPlugins"))
 }
+
+// As a Gradle plugin cannot be a Java Module, we do not have official internal packages.
+// We tell the dependency analysis to treat packages as "internal".
+configure<DependencyAnalysisSubExtension>() { abi { exclusions { ignoreSubPackage("impl") } } }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ tasks.generateGrammarSource {
 // Do not generate Java Doc for generated antlr grammar
 tasks.withType<Javadoc> { excludes.add("com/hedera/pbj/compiler/impl/grammar/**") }
 
-tasks.register("release-maven-central") {
+tasks.register("releaseMavenCentral") {
     group = "release"
     dependsOn(tasks.named("publishPlugins"))
 }
 
-tasks.register("release-maven-central-snapshot") { group = "release" }
+tasks.register("releaseMavenCentralSnapshot") { group = "release" }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.gradle-plugin.gradle.kts
@@ -28,7 +28,7 @@ tasks.generateGrammarSource {
 // Do not generate Java Doc for generated antlr grammar
 tasks.withType<Javadoc> { excludes.add("com/hedera/pbj/compiler/impl/grammar/**") }
 
-tasks.register("releaseMavenCentral") {
+tasks.register("release") {
     group = "release"
     dependsOn(tasks.named("publishPlugins"))
 }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
@@ -44,12 +44,12 @@ tasks.withType<CloseNexusStagingRepository> {
     dependsOn(":pbj-runtime:publishToSonatype")
 }
 
-tasks.register("releaseMavenCentral") {
+tasks.register("release") {
     group = "release"
     dependsOn(tasks.closeAndReleaseStagingRepository)
 }
 
-tasks.register("releaseMavenCentralSnapshot") {
+tasks.register("releaseSnapshot") {
     group = "release"
     dependsOn(":pbj-runtime:publishToSonatype")
 }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
@@ -1,4 +1,23 @@
 /*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.github.gradlenexus.publishplugin.CloseNexusStagingRepository
+import io.github.gradlenexus.publishplugin.ReleaseNexusStagingRepository
+
+/*
  * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +39,26 @@ plugins {
     id("com.hedera.pbj.spotless-conventions")
     id("com.hedera.pbj.spotless-kotlin-conventions")
     id("com.autonomousapps.dependency-analysis")
+    id("io.github.gradle-nexus.publish-plugin")
 }
 
+group = "com.hedera.pbj"
+
 spotless { kotlinGradle { target("buildSrc/**/*.gradle.kts") } }
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = System.getenv("OSSRH_USERNAME")
+            password = System.getenv("OSSRH_PASSWORD")
+        }
+    }
+}
+
+tasks.withType<CloseNexusStagingRepository>().configureEach {
+    mustRunAfter(tasks.withType<PublishToMavenRepository>())
+}
+
+tasks.withType<ReleaseNexusStagingRepository>().configureEach {
+    mustRunAfter(tasks.withType<PublishToMavenRepository>())
+}

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.root.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,6 @@
  */
 
 import io.github.gradlenexus.publishplugin.CloseNexusStagingRepository
-import io.github.gradlenexus.publishplugin.ReleaseNexusStagingRepository
-
-/*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 plugins {
     id("com.hedera.pbj.repositories")
@@ -55,10 +38,18 @@ nexusPublishing {
     }
 }
 
-tasks.withType<CloseNexusStagingRepository>().configureEach {
-    mustRunAfter(tasks.withType<PublishToMavenRepository>())
+tasks.withType<CloseNexusStagingRepository> {
+    // The publishing of all components to Maven Central (in this case only 'pbj-runtime') is
+    // automatically done before close (which is done before release).
+    dependsOn(":pbj-runtime:publishToSonatype")
 }
 
-tasks.withType<ReleaseNexusStagingRepository>().configureEach {
-    mustRunAfter(tasks.withType<PublishToMavenRepository>())
+tasks.register("releaseMavenCentral") {
+    group = "release"
+    dependsOn(tasks.closeAndReleaseStagingRepository)
+}
+
+tasks.register("releaseMavenCentralSnapshot") {
+    group = "release"
+    dependsOn(":pbj-runtime:publishToSonatype")
 }

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.runtime.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.runtime.gradle.kts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import io.github.gradlenexus.publishplugin.CloseNexusStagingRepository
-import io.github.gradlenexus.publishplugin.ReleaseNexusStagingRepository
-
 plugins {
     id("java-library")
     id("com.hedera.pbj.conventions")
@@ -39,17 +36,3 @@ protobuf {
 val maven = publishing.publications.create<MavenPublication>("maven") { from(components["java"]) }
 
 signing.sign(maven)
-
-tasks.register("releaseMavenCentral") {
-    group = "release"
-    dependsOn(
-        tasks.named("publishToSonatype"),
-        rootProject.tasks.withType<CloseNexusStagingRepository>(),
-        rootProject.tasks.withType<ReleaseNexusStagingRepository>()
-    )
-}
-
-tasks.register("releaseMavenCentralSnapshot") {
-    group = "release"
-    dependsOn(tasks.named("publishToSonatype"))
-}

--- a/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.runtime.gradle.kts
+++ b/pbj-core/buildSrc/src/main/kotlin/com.hedera.pbj.runtime.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("java-library")
     id("com.hedera.pbj.conventions")
     id("com.google.protobuf") // protobuf plugin is only used for tests
+    id("me.champeau.jmh")
 }
 
 tasks.generateGrammarSource {

--- a/pbj-core/gradle/modules.properties
+++ b/pbj-core/gradle/modules.properties
@@ -1,0 +1,3 @@
+com.github.spotbugs.annotations=com.github.spotbugs:spotbugs-annotations
+com.google.protobuf=com.google.protobuf:protobuf-java
+org.antlr.antlr4.runtime=org.antlr:antlr4-runtime

--- a/pbj-core/pbj-compiler/build.gradle.kts
+++ b/pbj-core/pbj-compiler/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ mainModuleInfo {
 testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.mockito")
-    requires("org.mockito.junit.jupiter")
 }
 
 gradlePlugin {

--- a/pbj-core/pbj-runtime/build.gradle.kts
+++ b/pbj-core/pbj-runtime/build.gradle.kts
@@ -17,11 +17,11 @@
 plugins { id("com.hedera.pbj.runtime") }
 
 testModuleInfo {
+    requires("com.google.protobuf")
+    requires("org.assertj.core")
+    requires("net.bytebuddy")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
-    requires("org.assertj.core")
     requires("org.mockito")
-    requires("com.google.protobuf")
-    runtimeOnly("org.mockito.inline")
     requiresStatic("com.github.spotbugs.annotations")
 }

--- a/pbj-core/pbj-runtime/build.gradle.kts
+++ b/pbj-core/pbj-runtime/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-plugins {
-    id("com.hedera.pbj.runtime")
-    id("me.champeau.jmh").version("0.7.1")
-}
+plugins { id("com.hedera.pbj.runtime") }
 
 testModuleInfo {
     requires("org.junit.jupiter.api")

--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -43,8 +43,6 @@ dependencyResolutionManagement {
             version("org.mockito", "4.6.1")
             version("org.mockito.inline", "4.6.1")
             version("org.mockito.junit.jupiter", "5.10.0")
-
-            library("dd", "dd:xx:1.0")
         }
     }
 }

--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -37,12 +37,12 @@ dependencyResolutionManagement {
             version("com.github.spotbugs.annotations", "4.7.3")
 
             // Testing only versions
-            version("org.junit.jupiter.api", "5.9.0")
-            version("org.junit.jupiter.params", "5.9.0")
+            version("com.google.protobuf", "3.21.9")
             version("org.assertj.core", "3.23.1")
+            version("org.junit.jupiter.api", "5.10.0")
             version("org.mockito", "4.6.1")
             version("org.mockito.inline", "4.6.1")
-            version("com.google.protobuf", "3.21.9")
+            version("org.mockito.junit.jupiter", "5.10.0")
 
             library("dd", "dd:xx:1.0")
         }


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds support for Nexus based automatic releases.
- Renames the `release-maven-*` tasks to follow typical Gradle conventions.
- Updates several plugin versions.
- Adds explicit Java source and target compatibility flags. 

### Related Issues 

- Closes #185 