### PR TITLE
fix: Fix double-wrap of `ParseExecption`

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -173,6 +173,9 @@ class CodecParseMethodGenerator {
                         }
                         return new $modelClassName($fieldsList);
                     } catch (final Exception anyException) {
+                        if (anyException instanceof ParseException parseException) {
+                            throw parseException;
+                        }
                         throw new ParseException(anyException);
                     }
                 }


### PR DESCRIPTION
* Added a test in the catch block to rethrow ParseException rather than wrapping it in another ParseException
