### PR TITLE
fix: 156: optimize OneOf.hashCode()

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
@@ -47,7 +47,7 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) {
 
     @Override
     public int hashCode() {
-        return Objects.hash(kind, value);
+        return kind.hashCode() * 31 + Objects.hashCode(value);
     }
 
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
@@ -47,7 +47,7 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) {
 
     @Override
     public int hashCode() {
-        return kind.hashCode() * 31 + Objects.hashCode(value);
+        return (31 + kind.hashCode()) * 31 + (value == null ? 0 : value.hashCode());
     }
 
 }

--- a/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
@@ -30,7 +30,7 @@ class OneOfTest {
     @Test
     void hashCodeReturnsHashCode() {
         final var oneOf = new OneOf<>(TestEnum.KIND1, "Value");
-        assertEquals(Objects.hash(TestEnum.KIND1, "Value"), oneOf.hashCode());
+        assertEquals(TestEnum.KIND1.hashCode() * 31 + Objects.hashCode("Value"), oneOf.hashCode());
     }
 
     @Test

--- a/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
@@ -30,7 +30,7 @@ class OneOfTest {
     @Test
     void hashCodeReturnsHashCode() {
         final var oneOf = new OneOf<>(TestEnum.KIND1, "Value");
-        assertEquals(TestEnum.KIND1.hashCode() * 31 + Objects.hashCode("Value"), oneOf.hashCode());
+        assertEquals((31 + TestEnum.KIND1.hashCode()) * 31 + "Value".hashCode(), oneOf.hashCode());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Objects.hash(Object...) implicitly creates an array to hold all the arguments passed in, which has a high memory foot-print.

I'm replacing this call with a manual computation of the hash code. ~~Note that the value computed by the Objects.hash() is slightly different from the explicit computation (probably because it uses a seed value, while this fix implicitly uses a seed of 0), so I had to update the unit test as well. However,~~ I think it's a good idea to keep the unit test in sync with the actual code, to account for any changes that JDK may implement in Objects.hash() in the future.

**Related issue(s)**:

Fixes #156 

**Notes for reviewer**:
`gr test` passes in all the three PBJ repos.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
