### PR TITLE
fix: 157: optimize enum default value initialization

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -199,7 +199,7 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 		} else if (repeated) {
 			return "Collections.emptyList()";
 		} else if (type == FieldType.ENUM) {
-			return messageType+".values()[0]";
+			return messageType+".fromProtobufOrdinal(0)";
 		} else {
 			return type.javaDefault;
 		}


### PR DESCRIPTION
**Description**:
Replacing `enum.values()[0]` with `enum.fromProtobufOrdinal(0)` in generated Builder implementations.

**Related issue(s)**:

Fixes #157 

**Notes for reviewer**:
`gr test` passes in all three PBJ repos.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
