### PR TITLE
fix: 208: limit max size

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.7.15-SNAPSHOT
+version=0.7.20-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
@@ -13,12 +13,23 @@ import static com.hedera.pbj.compiler.impl.Common.*;
 @SuppressWarnings("unused")
 public interface Field {
 
+	/** The default maximum size of a repeated or length-encoded field (Bytes, String, Message, etc.). */
+	public static final long DEFAULT_MAX_SIZE = 21 * 1024;
+
 	/**
 	 * Is this field a repeated field. Repeated fields are lists of values rather than a single value.
 	 *
 	 * @return true if this field is a list and false if it is a single value
 	 */
 	boolean repeated();
+
+	/**
+	 * Returns the field's max size relevant to repeated or length-encoded fields.
+	 * The returned value has no meaning for scalar fields (BOOL, INT, etc.).
+	 */
+	default long maxSize() {
+		return DEFAULT_MAX_SIZE;
+	}
 
 	/**
 	 * Get the field number, the number of the field in the parent message

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
@@ -11,4 +11,8 @@ public class ParseException extends Exception {
     public ParseException(Throwable cause) {
         super(cause);
     }
+
+    public ParseException(String message) {
+        super(message);
+    }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -211,6 +211,7 @@ public final class ProtoParserTools {
      * Read a String field from data input
      *
      * @param input the input to read from
+     * @param maxSize the maximum allowed size
      * @return Read string
      * @throws ParseException if the length is greater than maxSize
      */
@@ -284,7 +285,7 @@ public final class ProtoParserTools {
 
     /**
      * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
-     * 
+     *
      * @param input The input to move ahead
      * @param wireType The wire type of field to skip
      * @throws IOException For unsupported wire types

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -200,7 +200,26 @@ public final class ProtoParserTools {
      * @return Read string
      */
     public static String readString(final ReadableSequentialData input) throws IOException {
+        try {
+            return readString(input, Long.MAX_VALUE);
+        } catch (ParseException ex) {
+            throw new UncheckedParseException(ex);
+        }
+    }
+
+    /**
+     * Read a String field from data input
+     *
+     * @param input the input to read from
+     * @return Read string
+     * @throws ParseException if the length is greater than maxSize
+     */
+    public static String readString(final ReadableSequentialData input, final long maxSize)
+            throws IOException, ParseException {
         final int length = input.readVarInt(false);
+        if (length > maxSize) {
+            throw new ParseException("size " + length + " is greater than max " + maxSize);
+        }
         if (input.remaining() < length) {
             throw new BufferUnderflowException();
         }
@@ -231,7 +250,28 @@ public final class ProtoParserTools {
      * of InputData
      */
     public static Bytes readBytes(final ReadableSequentialData input) {
+        try {
+            return readBytes(input, Long.MAX_VALUE);
+        } catch (ParseException ex) {
+            throw new UncheckedParseException(ex);
+        }
+    }
+
+    /**
+     * Read a Bytes field from data input, or throw ParseException if the Bytes in the input
+     * is longer than the maxSize.
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return read Bytes object, this can be a copy or a direct reference to inputs data. So it has same life span
+     * of InputData
+     * @throws ParseException if the length is greater than maxSize
+     */
+    public static Bytes readBytes(final ReadableSequentialData input, final long maxSize) throws ParseException {
         final int length = input.readVarInt(false);
+        if (length > maxSize) {
+            throw new ParseException("size " + length + " is greater than max " + maxSize);
+        }
         if (input.remaining() < length) {
             throw new BufferUnderflowException();
         }
@@ -250,6 +290,24 @@ public final class ProtoParserTools {
      * @throws IOException For unsupported wire types
      */
     public static void skipField(final ReadableSequentialData input, final ProtoConstants wireType) throws IOException {
+        try {
+            skipField(input, wireType, Long.MAX_VALUE);
+        } catch (ParseException ex) {
+            throw new UncheckedParseException(ex);
+        }
+    }
+
+    /**
+     * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     * @param maxSize the maximum allowed size for repeated/length-encoded fields
+     * @throws IOException For unsupported wire types
+     * @throws ParseException if the length of a repeated/length-encoded field is greater than maxSize
+     */
+    public static void skipField(final ReadableSequentialData input, final ProtoConstants wireType, final long maxSize)
+            throws IOException, ParseException {
         switch (wireType) {
             case WIRE_TYPE_FIXED_64_BIT -> input.skip(8);
             case WIRE_TYPE_FIXED_32_BIT -> input.skip(4);
@@ -261,6 +319,9 @@ public final class ProtoParserTools {
                 final int length = input.readVarInt(false);
                 if (length < 0) {
                     throw new IOException("Encountered a field with negative length " + length);
+                }
+                if (length > maxSize) {
+                    throw new ParseException("size " + length + " is greater than max " + maxSize);
                 }
                 input.skip(length);
             }


### PR DESCRIPTION
**Description**:
This fix introduces a default limit of 21K on repeated/length-encoded field sizes. When the parser encounters a field with a greater size, it errors out with ParseException.

This is a quick solution for release 48.

In a future release, we'll extend the functionality as described at https://github.com/hashgraph/pbj/issues/209.

**Related issue(s)**:

Fixes #208 

**Notes for reviewer**:
All unit tests and all integration tests, including the fuzzTest, pass in all three PBJ sub-projects.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
