### PR TITLE
fix: 212: limit max depth

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.7.20-SNAPSHOT
+version=0.8.0-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -182,7 +182,7 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 	@Override
 	public String parseCode() {
 		if (type == FieldType.MESSAGE) {
-			return "strictMode ? %s.PROTOBUF.parseStrict(input) : %s.PROTOBUF.parse(input)"
+			return "%s.PROTOBUF.parse(input, strictMode, maxDepth - 1)"
 					.formatted(messageType, messageType);
 		} else {
 			return "input";

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -139,9 +139,11 @@ public final class TestGenerator implements Generator {
 				""".formatted(
 					modelClassName,
 					fields.stream()
+							.filter(field -> !field.javaFieldType().equals(modelClassName))
 							.map(f -> "final var %sList = %s;".formatted(f.nameCamelFirstLower(), generateTestData(modelClassName, f, f.optionalValueType(), f.repeated())))
 							.collect(Collectors.joining("\n")).indent(DEFAULT_INDENT),
 					fields.stream()
+							.filter(field -> !field.javaFieldType().equals(modelClassName))
 							.map(f -> f.nameCamelFirstLower()+"List.size()")
 							.collect(Collectors.collectingAndThen(
 									Collectors.toList(),
@@ -149,11 +151,11 @@ public final class TestGenerator implements Generator {
 							))
 							.collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 2),
 					modelClassName,
-					fields.stream().map(field -> "%sList.get(Math.min(i, %sList.size()-1))".formatted(
-								field.nameCamelFirstLower(),
-								field.nameCamelFirstLower()
-						))
-							.collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 4),
+					fields.stream().map(field ->
+							field.javaFieldType().equals(modelClassName)
+									? field.javaFieldType() + ".newBuilder().build()"
+									: "$nameList.get(Math.min(i, $nameList.size()-1))".replace("$name", field.nameCamelFirstLower())
+					).collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 4),
 					modelClassName,
 					modelClassName
 				);
@@ -339,7 +341,7 @@ public final class TestGenerator implements Generator {
 				    assertEquals(charBuffer2, charBuffer);
 				    
 				    // Test JSON Reading
-				    final $modelClassName jsonReadPbj = $modelClassName.JSON.parse(JsonTools.parseJson(charBuffer), false);
+				    final $modelClassName jsonReadPbj = $modelClassName.JSON.parse(JsonTools.parseJson(charBuffer), false, Integer.MAX_VALUE);
 				    assertEquals(modelObj, jsonReadPbj);
 				}
 				

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -77,15 +77,10 @@ public final class CodecGenerator implements Generator {
 					public final class $codecClass implements Codec<$modelClass> {
 					    $unsetOneOfConstants
 					    $parseMethod
-					    $parseStrictMethod
 					    $writeMethod
 					    $measureDataMethod
 					    $measureRecordMethod
 					    $fastEqualsMethod
-					    
-					    // ------ Private Implementation
-					    
-					    $parseInternal
 					}
 					"""
 					.replace("$package", codecPackage)
@@ -98,12 +93,10 @@ public final class CodecGenerator implements Generator {
 					.replace("$codecClass", codecClassName)
 					.replace("$unsetOneOfConstants", CodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
 					.replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(modelClassName, fields))
-					.replace("$parseStrictMethod", CodecParseMethodGenerator.generateParseStrictMethod(modelClassName, fields))
 					.replace("$writeMethod", writeMethod)
 					.replace("$measureDataMethod", CodecMeasureDataMethodGenerator.generateMeasureMethod(modelClassName, fields))
 					.replace("$measureRecordMethod", CodecMeasureRecordMethodGenerator.generateMeasureMethod(modelClassName, fields))
 					.replace("$fastEqualsMethod", CodecFastEqualsMethodGenerator.generateFastEqualsMethod(modelClassName, fields))
-					.replace("$parseInternal", CodecParseMethodGenerator.generateParseInternalMethod(modelClassName, fields))
 			);
 		}
 	}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -44,70 +44,24 @@ class CodecParseMethodGenerator {
     static String generateParseMethod(final String modelClassName, final List<Field> fields) {
         return """
                 /**
-                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}
-                 *
-                 * @param input The data input to parse data from, it is assumed to be in a state ready to read with position at start
-                 *              of data to read and limit set at the end of data to read. The data inputs limit will be changed by this
-                 *              method. If null, the method returns immediately. If there are no bytes remaining in the data input,
-                 *              then the method also returns immediately.
-                 * @return Parsed $modelClassName model object or null if data input was null or empty
-                 * @throws ParseException If parsing fails
-                 */
-                public @NonNull $modelClassName parse(@NonNull final ReadableSequentialData input)
-                        throws ParseException {
-                    return parseInternal(input, false);
-                }
-                """
-        .replace("$modelClassName",modelClassName)
-        .replace("$fieldDefs",fields.stream().map(field -> "    %s temp_%s = %s;".formatted(field.javaFieldType(),
-                field.name(), field.javaDefault())).collect(Collectors.joining("\n")))
-        .replace("$fieldsList",fields.stream().map(field -> "temp_"+field.name()).collect(Collectors.joining(", ")))
-        .replace("$caseStatements",generateCaseStatements(fields))
-        .replaceAll("\n", "\n" + Common.FIELD_INDENT);
-    }
-
-    static String generateParseStrictMethod(final String modelClassName, final List<Field> fields) {
-        return """
-                /**
-                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData} in strict mode, such that
-                 * parsing will fail if the encoded protobuf object contains any fields that are unknown to this
-                 * version of the parser.
-                 *
-                 * @param input The data input to parse data from, it is assumed to be in a state ready to read with position at start
-                 *              of data to read and limit set at the end of data to read. The data inputs limit will be changed by this
-                 *              method. If null, the method returns immediately. If there are no bytes remaining in the data input,
-                 *              then the method also returns immediately.
-                 * @return Parsed $modelClassName model object or null if data input was null or empty
-                 * @throws ParseException If parsing fails
-                 */
-                public @NonNull $modelClassName parseStrict(@NonNull final ReadableSequentialData input)
-                        throws ParseException {
-                    return parseInternal(input, true);
-                }
-                """
-        .replace("$modelClassName",modelClassName)
-        .replace("$fieldDefs",fields.stream().map(field -> "    %s temp_%s = %s;".formatted(field.javaFieldType(),
-                field.name(), field.javaDefault())).collect(Collectors.joining("\n")))
-        .replace("$fieldsList",fields.stream().map(field -> "temp_"+field.name()).collect(Collectors.joining(", ")))
-        .replace("$caseStatements",generateCaseStatements(fields))
-        .indent(DEFAULT_INDENT);
-    }
-
-    static String generateParseInternalMethod(final String modelClassName, final List<Field> fields) {
-        return """
-                /**
                  * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
                  *
                  * @param input The data input to parse data from, it is assumed to be in a state ready to read with position at start
                  *              of data to read and limit set at the end of data to read. The data inputs limit will be changed by this
-                 *              method. If null, the method returns immediately. If there are no bytes remaining in the data input,
+                 *              method. If there are no bytes remaining in the data input,
                  *              then the method also returns immediately.
+                 * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+                 * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
                  * @return Parsed $modelClassName model object or null if data input was null or empty
                  * @throws ParseException If parsing fails
                  */
-                private @NonNull $modelClassName parseInternal(
+                public @NonNull $modelClassName parse(
                         @NonNull final ReadableSequentialData input,
-                        final boolean strictMode) throws ParseException {
+                        final boolean strictMode,
+                        final int maxDepth) throws ParseException {
+                    if (maxDepth < 0) {
+                        throw new ParseException("Reached maximum allowed depth of nested messages");
+                    }
                     try {
                         // -- TEMP STATE FIELDS --------------------------------------
                         $fieldDefs
@@ -329,8 +283,9 @@ class CodecParseMethodGenerator {
 							// we will not throw.
 							final var startPos = input.position();
 							try {
-								if ((startPos + messageLength) > limitBefore)
+								if ((startPos + messageLength) > limitBefore) {
 									throw new BufferUnderflowException();
+								}
 								input.limit(startPos + messageLength);
 								value = $readMethod;
 								// Make sure we read the full number of bytes. for the types

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -23,12 +23,56 @@ public interface Codec<T /*extends Record*/> {
 
     /**
      * Parses an object from the {@link ReadableSequentialData} and returns it.
+     * <p>
+     * If {@code strictMode} is {@code true}, then throws an exception if fields
+     * have been defined on the encoded object that are not supported by the parser. This
+     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
+     * which is sometimes requires to avoid parsing an object that is newer than the code
+     * parsing it is prepared to handle.
+     * <p>
+     * The {@code maxDepth} specifies the maximum allowed depth of nested messages. The parsing
+     * will fail with a ParseException if the maximum depth is reached.
+     *
+     * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
+     * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+     * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull T parse(@NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth) throws ParseException;
+
+    /**
+     * Parses an object from the {@link Bytes} and returns it.
+     * <p>
+     * If {@code strictMode} is {@code true}, then throws an exception if fields
+     * have been defined on the encoded object that are not supported by the parser. This
+     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
+     * which is sometimes requires to avoid parsing an object that is newer than the code
+     * parsing it is prepared to handle.
+     * <p>
+     * The {@code maxDepth} specifies the maximum allowed depth of nested messages. The parsing
+     * will fail with a ParseException if the maximum depth is reached.
+     *
+     * @param bytes The {@link Bytes} from which to read the data to construct an object
+     * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+     * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull default T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
+        return parse(bytes.toReadableSequentialData(), strictMode, maxDepth);
+    }
+
+    /**
+     * Parses an object from the {@link ReadableSequentialData} and returns it.
      *
      * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
      * @return The parsed object. It must not return null.
      * @throws ParseException If parsing fails
      */
-    @NonNull T parse(@NonNull ReadableSequentialData input) throws ParseException;
+    @NonNull default T parse(@NonNull ReadableSequentialData input) throws ParseException {
+        return parse(input, false, Integer.MAX_VALUE);
+    }
 
     /**
      * Parses an object from the {@link Bytes} and returns it.
@@ -52,7 +96,9 @@ public interface Codec<T /*extends Record*/> {
      * @return The parsed object. It must not return null.
      * @throws ParseException If parsing fails
      */
-    @NonNull T parseStrict(@NonNull ReadableSequentialData input) throws ParseException;
+    @NonNull default T parseStrict(@NonNull ReadableSequentialData input) throws ParseException {
+        return parse(input, true, Integer.MAX_VALUE);
+    }
 
     /**
      * Parses an object from the {@link Bytes} and returns it. Throws an exception if fields

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -21,39 +21,11 @@ public interface JsonCodec<T /*extends Record*/> extends Codec<T> {
     // then we should strongly enforce Codec works with Records. This will reduce bugs
     // where people try to use a mutable object.
 
-    /**
-     * Parses an object from the {@link ReadableSequentialData} and returns it.
-     *
-     * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
-     * @return The parsed object. It must not return null.
-     * @throws ParseException If parsing fails
-     */
-    @NonNull
-    @Override
-    default T parse(@NonNull ReadableSequentialData input) throws ParseException {
-        try {
-            return parse(JsonTools.parseJson(input), false);
-        } catch (IOException ex) {
-            throw new ParseException(ex);
-        }
-    }
 
-    /**
-     * Parses an object from the {@link ReadableSequentialData} and returns it. Throws an exception if fields
-     * have been defined on the encoded object that are not supported by the parser. This
-     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
-     * which is sometimes requires to avoid parsing an object that is newer than the code
-     * parsing it is prepared to handle.
-     *
-     * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
-     * @return The parsed object. It must not return null.
-     * @throws ParseException If parsing fails
-     */
-    @NonNull
-    @Override
-    default T parseStrict(@NonNull ReadableSequentialData input) throws ParseException {
+    /** @inheritDoc */
+    default @NonNull T parse(@NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth) throws ParseException {
         try {
-            return parse(JsonTools.parseJson(input), true);
+            return parse(JsonTools.parseJson(input), strictMode, maxDepth);
         } catch (IOException ex) {
             throw new ParseException(ex);
         }
@@ -68,7 +40,8 @@ public interface JsonCodec<T /*extends Record*/> extends Codec<T> {
      */
     @NonNull T parse(
             @Nullable final JSONParser.ObjContext root,
-            final boolean strictMode) throws ParseException;
+            final boolean strictMode,
+            final int maxDepth) throws ParseException;
 
     /**
      * Writes an item to the given {@link WritableSequentialData}.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -22,7 +22,7 @@ public interface JsonCodec<T /*extends Record*/> extends Codec<T> {
     // where people try to use a mutable object.
 
 
-    /** @inheritDoc */
+    /** {@inheritDoc} */
     default @NonNull T parse(@NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth) throws ParseException {
         try {
             return parse(JsonTools.parseJson(input), strictMode, maxDepth);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -124,11 +124,11 @@ public final class JsonTools {
      * @return the list of parsed objects
      * @param <T> the type of the objects to parse
      */
-    public static <T> List<T> parseObjArray(JSONParser.ArrContext arrContext, JsonCodec<T> codec) {
+    public static <T> List<T> parseObjArray(JSONParser.ArrContext arrContext, JsonCodec<T> codec, final int maxDepth) {
         return arrContext.value().stream()
                 .map(v -> {
                     try {
-                        return codec.parse(v.obj(), false);
+                        return codec.parse(v.obj(), false, maxDepth - 1);
                     } catch (ParseException e) {
                         throw new UncheckedParseException(e);
                     }

--- a/pbj-integration-tests/src/main/proto/message.proto
+++ b/pbj-integration-tests/src/main/proto/message.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+/**
+ * Sample protobuf containing itself.
+ */
+message MessageWithMessage {
+  MessageWithMessage message = 1;
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/MaxDepthTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/MaxDepthTest.java
@@ -1,0 +1,93 @@
+package com.hedera.pbj.intergration.test;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.test.proto.pbj.MessageWithMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MaxDepthTest {
+    @Test
+    void testMaxDepth_depth0() throws Exception {
+        MessageWithMessage msg;
+
+        msg = MessageWithMessage.newBuilder().build();
+        BufferedData bd = BufferedData.allocate(MessageWithMessage.PROTOBUF.measureRecord(msg));
+        MessageWithMessage.PROTOBUF.write(msg, bd);
+
+        // None should throw
+        MessageWithMessage.PROTOBUF.parse(bd, false, 0);
+        MessageWithMessage.PROTOBUF.parse(bd, false, 1);
+        MessageWithMessage.PROTOBUF.parse(bd, false, 2);
+    }
+
+    @Test
+    void testMaxDepth_depth1_actually0() throws Exception {
+        MessageWithMessage msg;
+
+        msg = MessageWithMessage.newBuilder()
+                // NOTE: this is a "default" message, and its serialized size is zero,
+                // so parse() wouldn't be called to read it, and hence the actual depth is still 0
+                .message(MessageWithMessage.newBuilder().build())
+                .build();
+        BufferedData bd = BufferedData.allocate(MessageWithMessage.PROTOBUF.measureRecord(msg));
+        MessageWithMessage.PROTOBUF.write(msg, bd);
+
+        // None should throw
+        bd.reset();
+        MessageWithMessage.PROTOBUF.parse(bd, false, 0);
+        bd.reset();
+        MessageWithMessage.PROTOBUF.parse(bd, false, 1);
+        bd.reset();
+        MessageWithMessage.PROTOBUF.parse(bd, false, 2);
+    }
+
+    @Test
+    void testMaxDepth_depth2_actually1() throws Exception {
+        MessageWithMessage msg;
+
+        msg = MessageWithMessage.newBuilder()
+                .message(MessageWithMessage.newBuilder()
+                        // NOTE: this is a "default" message, and its serialized size is zero,
+                        // so parse() wouldn't be called to read it, and hence the actual depth is only 1
+                        .message(MessageWithMessage.newBuilder().build())
+                        .build())
+                .build();
+        BufferedData bd = BufferedData.allocate(MessageWithMessage.PROTOBUF.measureRecord(msg));
+        MessageWithMessage.PROTOBUF.write(msg, bd);
+
+        // 0 should throw
+        bd.reset();
+        assertThrows(ParseException.class, () -> MessageWithMessage.PROTOBUF.parse(bd, false, 0));
+        bd.reset();
+        MessageWithMessage.PROTOBUF.parse(bd, false, 1);
+        bd.reset();
+        MessageWithMessage.PROTOBUF.parse(bd, false, 2);
+    }
+
+    @Test
+    void testMaxDepth_depth3_actually2() throws Exception {
+        MessageWithMessage msg;
+
+        msg = MessageWithMessage.newBuilder()
+                .message(MessageWithMessage.newBuilder()
+                        .message(MessageWithMessage.newBuilder()
+                                // NOTE: this is a "default" message, and its serialized size is zero,
+                                // so parse() wouldn't be called to read it, and hence the actual depth is only 2
+                                .message(MessageWithMessage.newBuilder().build())
+                                .build())
+                        .build())
+                .build();
+        BufferedData bd = BufferedData.allocate(MessageWithMessage.PROTOBUF.measureRecord(msg));
+        MessageWithMessage.PROTOBUF.write(msg, bd);
+
+        // 0 and 1 should throw
+        bd.reset();
+        assertThrows(ParseException.class, () -> MessageWithMessage.PROTOBUF.parse(bd, false, 0));
+        bd.reset();
+        assertThrows(ParseException.class, () -> MessageWithMessage.PROTOBUF.parse(bd, false, 1));
+        bd.reset();
+        MessageWithMessage.PROTOBUF.parse(bd, false, 2);
+    }
+}


### PR DESCRIPTION
**Description**:
The fix allows the parser to limit the depth of nested objects parsed from the input. The parser would throw a ParseException when the limit is reached.

To accomplish this, I'm pulling the previously private parseInternal() method to the public scope in the Codec interface. This has a few advantages:
1. Avoiding a conditional when parsing nested messages (and also avoiding an extra nested call) which should all improve the performance.
2. Avoiding having to introduce multiple versions of parse/parseStrict methods with different sets of arguments to support legacy usages and the new ones.

The public parse() method now includes an extra argument that specifies the maximum depth of nested messages allowed.

I'm bumping the PBJ version to 0.8.0 as this is a relatively drastic change to the API. 

I'll be working on making necessary changes in hedera-services while this fix is being reviewed to make sure it doesn't break anything when we upgrade PBJ dependency to 0.8.0 in services (in a separate, future PR.) Note that choosing a proper maxDepth value and switching over to new calls to supply this parameter will be done by the services team separately once hedera-services is upgraded to use PBJ 0.8.0. This is outside of scope of the Platform Data changes.

**Related issue(s)**:

Fixes #212 

**Notes for reviewer**:
* New unit tests added to verify the maxDepth behavior.
* `gr test` in all PBJ sub-projects passes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
