### PR TITLE
fix: 221: increase Field.DEFAULT_MAX_SIZE to 2M

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
@@ -14,7 +14,7 @@ import static com.hedera.pbj.compiler.impl.Common.*;
 public interface Field {
 
 	/** The default maximum size of a repeated or length-encoded field (Bytes, String, Message, etc.). */
-	public static final long DEFAULT_MAX_SIZE = 21 * 1024;
+	public static final long DEFAULT_MAX_SIZE = 2 * 1024 * 1024;
 
 	/**
 	 * Is this field a repeated field. Repeated fields are lists of values rather than a single value.


### PR DESCRIPTION
**Description**:
Increasing the maximum field size from 21K to 2M.

**Related issue(s)**:

Fixes #221

**Notes for reviewer**:
`gr test` passes in all the three PBJ sub-projects.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
