### PR TITLE
fix: stabilize hashCode() for Enums

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.8.1-SNAPSHOT
+version=0.8.2-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -247,11 +247,18 @@ public final class Common {
                                 result = 31 * result + $fieldName.hashCode();
                              }
                              """).replace("$fieldName", f.nameCamelFirstLower());
-                } else if (f.type() == Field.FieldType.ENUM ||
-						f.type() == Field.FieldType.STRING ||
-						f.parent() == null) { // process sub message
+                } else if (f.type() == Field.FieldType.ENUM) {
+                    // name().hashCode() and NOT Enum.hashCode() because the latter changes between runs
                     generatedCodeSoFar += (
                             """
+                             if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                                result = 31 * result + $fieldName.name().hashCode();
+                             }
+                             """).replace("$fieldName", f.nameCamelFirstLower());
+				} else if (f.type() == Field.FieldType.STRING ||
+						f.parent() == null) { // process sub message
+					generatedCodeSoFar += (
+							"""
                              if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                                 result = 31 * result + $fieldName.hashCode();
                              }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
@@ -44,7 +44,8 @@ public record ComparableOneOf<E extends Enum<E>>(E kind, Comparable value) imple
 
     @Override
     public int hashCode() {
-        return Objects.hash(kind, value);
+        // name().hashCode() and NOT Enum.hashCode() because the latter changes between runs
+        return (31 + kind.name().hashCode()) * 31 + (value == null ? 0 : value.hashCode());
     }
 
     @SuppressWarnings("unchecked")

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
@@ -47,7 +47,8 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) {
 
     @Override
     public int hashCode() {
-        return (31 + kind.hashCode()) * 31 + (value == null ? 0 : value.hashCode());
+        // name().hashCode() and NOT Enum.hashCode() because the latter changes between runs
+        return (31 + kind.name().hashCode()) * 31 + (value == null ? 0 : value.hashCode());
     }
 
 }

--- a/pbj-core/pbj-runtime/src/test/java/tests/ComparableOneOfTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/tests/ComparableOneOfTest.java
@@ -1,0 +1,54 @@
+package tests;
+
+import com.hedera.pbj.runtime.ComparableOneOf;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ComparableOneOfTest {
+    @Test
+    void nullNameIsOK() {
+        final var oneOf = new ComparableOneOf<>(TestEnum.KIND1, null);
+        assertNull(oneOf.value());
+    }
+
+    @Test
+    void nullTypeThrows() {
+        assertThrows(NullPointerException.class, () -> new ComparableOneOf<>(null, "Value"));
+    }
+
+    @Test
+    void asReturnsValue() {
+        final var oneOf = new ComparableOneOf<>(TestEnum.KIND1, "Value");
+        assertEquals("Value", oneOf.as());
+    }
+
+    @Test
+    void hashCodeReturnsHashCode() {
+        final var oneOf = new ComparableOneOf<>(TestEnum.KIND1, "Value");
+        assertEquals((31 + TestEnum.KIND1.name().hashCode()) * 31 + "Value".hashCode(), oneOf.hashCode());
+    }
+
+    @Test
+    void equalsWorks() {
+        final var oneOf = new ComparableOneOf<>(TestEnum.KIND1, "Value");
+        final var sameComparableOneOf = new ComparableOneOf<>(TestEnum.KIND1, "Value");
+        final var differentComparableOneOf = new ComparableOneOf<>(TestEnum.KIND2, "Value");
+        final var anotherDifferentComparableOneOf = new ComparableOneOf<>(TestEnum.KIND1, "AnotherValue");
+
+        assertEquals(true, oneOf.equals(oneOf));
+        assertEquals(true, oneOf.equals(sameComparableOneOf));
+        assertEquals(false, oneOf.equals(differentComparableOneOf));
+        assertEquals(false, oneOf.equals(anotherDifferentComparableOneOf));
+        assertEquals(false, oneOf.equals("Value"));
+        assertEquals(false, oneOf.equals(TestEnum.KIND1));
+    }
+
+    public enum TestEnum {
+        KIND1,
+        KIND2
+    }
+
+}

--- a/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
@@ -30,7 +30,7 @@ class OneOfTest {
     @Test
     void hashCodeReturnsHashCode() {
         final var oneOf = new OneOf<>(TestEnum.KIND1, "Value");
-        assertEquals((31 + TestEnum.KIND1.hashCode()) * 31 + "Value".hashCode(), oneOf.hashCode());
+        assertEquals((31 + TestEnum.KIND1.name().hashCode()) * 31 + "Value".hashCode(), oneOf.hashCode());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Apparently, `Enum.hashCode()` delegates to `Object.hashCode()` which makes the hash code value different in different VMs/between runs.

This fix replaces direct usages of `Enum.hashCode()` with `Enum.name().hashCode()`. The latter is computed on a `String` value which is stable because it only depends on the actual characters of the strings (i.e. names of enum constants) which are always the same for a given enum, regardless of a VM instance.

**Related issue(s)**:

Fixes #227 

**Notes for reviewer**:
* All tests in all three PBJ projects pass
* A new test for ComparableOneOf is added.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
