### PR TITLE
fix: stabilize hashCode() for Enums using proto ordinals

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -248,11 +248,10 @@ public final class Common {
                              }
                              """).replace("$fieldName", f.nameCamelFirstLower());
                 } else if (f.type() == Field.FieldType.ENUM) {
-                    // name().hashCode() and NOT Enum.hashCode() because the latter changes between runs
                     generatedCodeSoFar += (
                             """
                              if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-                                result = 31 * result + $fieldName.name().hashCode();
+                                result = 31 * result + Integer.hashCode($fieldName.protoOrdinal());
                              }
                              """).replace("$fieldName", f.nameCamelFirstLower());
 				} else if (f.type() == Field.FieldType.STRING ||

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
@@ -44,8 +44,8 @@ public record ComparableOneOf<E extends Enum<E>>(E kind, Comparable value) imple
 
     @Override
     public int hashCode() {
-        // name().hashCode() and NOT Enum.hashCode() because the latter changes between runs
-        return (31 + kind.name().hashCode()) * 31 + (value == null ? 0 : value.hashCode());
+        return (31 + Integer.hashCode(((EnumWithProtoMetadata)kind).protoOrdinal())) * 31
+                + (value == null ? 0 : value.hashCode());
     }
 
     @SuppressWarnings("unchecked")

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ComparableOneOf.java
@@ -22,6 +22,7 @@ public record ComparableOneOf<E extends Enum<E>>(E kind, Comparable value) imple
         if (kind == null) {
             throw new NullPointerException("An enum 'kind' must be supplied");
         }
+        assert kind instanceof EnumWithProtoMetadata : "OneOf 'kind' must implement EnumWithProtoMetadata";
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/OneOf.java
@@ -25,6 +25,7 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) {
         if (kind == null) {
             throw new NullPointerException("An enum 'kind' must be supplied");
         }
+        assert kind instanceof EnumWithProtoMetadata : "OneOf 'kind' must implement EnumWithProtoMetadata";
     }
 
     /**
@@ -47,8 +48,8 @@ public record OneOf<E extends Enum<E>>(E kind, Object value) {
 
     @Override
     public int hashCode() {
-        // name().hashCode() and NOT Enum.hashCode() because the latter changes between runs
-        return (31 + kind.name().hashCode()) * 31 + (value == null ? 0 : value.hashCode());
+        return (31 + Integer.hashCode(((EnumWithProtoMetadata)kind).protoOrdinal())) * 31
+                + (value == null ? 0 : value.hashCode());
     }
 
 }

--- a/pbj-core/pbj-runtime/src/test/java/tests/ComparableOneOfTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/tests/ComparableOneOfTest.java
@@ -1,6 +1,7 @@
 package tests;
 
 import com.hedera.pbj.runtime.ComparableOneOf;
+import com.hedera.pbj.runtime.EnumWithProtoMetadata;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,7 +29,8 @@ class ComparableOneOfTest {
     @Test
     void hashCodeReturnsHashCode() {
         final var oneOf = new ComparableOneOf<>(TestEnum.KIND1, "Value");
-        assertEquals((31 + TestEnum.KIND1.name().hashCode()) * 31 + "Value".hashCode(), oneOf.hashCode());
+        assertEquals((31 + Integer.hashCode(TestEnum.KIND1.protoOrdinal())) * 31
+                + "Value".hashCode(), oneOf.hashCode());
     }
 
     @Test
@@ -46,9 +48,19 @@ class ComparableOneOfTest {
         assertEquals(false, oneOf.equals(TestEnum.KIND1));
     }
 
-    public enum TestEnum {
+    public enum TestEnum implements EnumWithProtoMetadata {
         KIND1,
-        KIND2
+        KIND2;
+
+        @Override
+        public int protoOrdinal() {
+            return ordinal();
+        }
+
+        @Override
+        public String protoName() {
+            return name();
+        }
     }
 
 }

--- a/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/tests/OneOfTest.java
@@ -1,5 +1,6 @@
 package tests;
 
+import com.hedera.pbj.runtime.EnumWithProtoMetadata;
 import com.hedera.pbj.runtime.OneOf;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,7 @@ class OneOfTest {
     @Test
     void hashCodeReturnsHashCode() {
         final var oneOf = new OneOf<>(TestEnum.KIND1, "Value");
-        assertEquals((31 + TestEnum.KIND1.name().hashCode()) * 31 + "Value".hashCode(), oneOf.hashCode());
+        assertEquals((31 + Integer.hashCode(TestEnum.KIND1.protoOrdinal())) * 31 + "Value".hashCode(), oneOf.hashCode());
     }
 
     @Test
@@ -48,9 +49,19 @@ class OneOfTest {
         assertEquals(false, oneOf.equals(TestEnum.KIND1));
     }
 
-    public enum TestEnum {
+    public enum TestEnum implements EnumWithProtoMetadata {
         KIND1,
-        KIND2
+        KIND2;
+
+        @Override
+        public int protoOrdinal() {
+            return ordinal();
+        }
+
+        @Override
+        public String protoName() {
+            return name();
+        }
     }
 
 }


### PR DESCRIPTION
**Description**:
Modifying the original implementation at https://github.com/hashgraph/pbj/pull/228 by switching from using `Enum.name().hashCode()` to `Integer.hashCode(EnumWithProtoMetadata.protoOrdinal())`.

**Related issue(s)**:

Fixes #227 

**Notes for reviewer**:
* All tests in all three PBJ sub-projects pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
