### PR TITLE
chore: add signature support to `Bytes`

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -317,19 +317,6 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     }
 
     /**
-     * A helper method for efficient copy of our data into a Signature without creating a defensive copy of the data.
-     * The implementation relies on a well-behaved Signature that doesn't modify the buffer data.
-     *
-     * @param signature the Signature to copy into
-     * @param offset    The offset from the start of this {@link Bytes} object to get the bytes from.
-     * @param length    The number of bytes to extract.
-     */
-    public void writeTo(@NonNull final Signature signature, final int offset, final int length)
-            throws SignatureException {
-        signature.update(buffer, offset, length);
-    }
-
-    /**
      * Create and return a new {@link ReadableSequentialData} that is backed by this {@link Bytes}.
      *
      * @return A {@link ReadableSequentialData} backed by this {@link Bytes}.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -14,6 +14,8 @@ import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.security.Signature;
+import java.security.SignatureException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HexFormat;
@@ -302,6 +304,29 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
      */
     public void writeTo(@NonNull final MessageDigest digest, final int offset, final int length) {
         digest.update(buffer, offset, length);
+    }
+
+    /**
+     * A helper method for efficient copy of our data into a Signature without creating a defensive copy of the data.
+     * The implementation relies on a well-behaved Signature that doesn't modify the buffer data.
+     *
+     * @param signature the Signature to copy into
+     */
+    public void writeTo(@NonNull final Signature signature) throws SignatureException {
+        signature.update(buffer, start, length);
+    }
+
+    /**
+     * A helper method for efficient copy of our data into a Signature without creating a defensive copy of the data.
+     * The implementation relies on a well-behaved Signature that doesn't modify the buffer data.
+     *
+     * @param signature the Signature to copy into
+     * @param offset    The offset from the start of this {@link Bytes} object to get the bytes from.
+     * @param length    The number of bytes to extract.
+     */
+    public void writeTo(@NonNull final Signature signature, final int offset, final int length)
+            throws SignatureException {
+        signature.update(buffer, offset, length);
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
@@ -4,6 +4,10 @@ import com.hedera.pbj.runtime.io.DataEncodingException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.InvalidKeyException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -409,6 +414,34 @@ final class BytesTest {
 
         MessageDigest md = MessageDigest.getInstance("MD5");
         bytes.writeTo(md, 10, 6);
+        res = md.digest();
+        byte[] exp = {-47, 90, -27, 57, 49, -120, 15, -41, -73, 36, -35, 120, -120, -76, -76, -19};
+        assertArrayEquals(exp, res);
+    }
+
+    @Test
+    @DisplayName("Write to Signature")
+    void writeToMessageSignature() throws SignatureException, InvalidKeyException {
+        byte[] byteArray = {0, 1, 2, 3, 4, 5};
+        final Bytes bytes = Bytes.wrap(byteArray);
+
+        final Signature signature = Mockito.mock(Signature.class);
+        signature.initVerify(Mockito.mock(PublicKey.class));
+        bytes.writeTo(signature);
+        Mockito.verify(signature).initVerify(Mockito.any(PublicKey.class));
+        Mockito.verify(signature).update(byteArray, 0, 6);
+        Mockito.verifyNoMoreInteractions(signature);
+    }
+
+    @Test
+    @DisplayName("Write to Signature no 0 Offset")
+    void writeToMessageSignatureNo0Offset() throws NoSuchAlgorithmException {
+        final byte[] byteArray = {9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 0, 1, 2, 3, 4, 5};
+        final Bytes bytes = Bytes.wrap(byteArray, 10, 6);
+        byte[] res;
+
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        bytes.writeTo(md);
         res = md.digest();
         byte[] exp = {-47, 90, -27, 57, 49, -120, 15, -41, -73, 36, -35, 120, -120, -76, -76, -19};
         assertArrayEquals(exp, res);

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
@@ -421,11 +421,12 @@ final class BytesTest {
 
     @Test
     @DisplayName("Write to Signature")
-    void writeToMessageSignature() throws SignatureException, InvalidKeyException {
+    void writeToSignature() throws SignatureException, InvalidKeyException {
         byte[] byteArray = {0, 1, 2, 3, 4, 5};
         final Bytes bytes = Bytes.wrap(byteArray);
 
         final Signature signature = Mockito.mock(Signature.class);
+        // Signature.writeTo() throws unless we call initVerify() first
         signature.initVerify(Mockito.mock(PublicKey.class));
         bytes.writeTo(signature);
         Mockito.verify(signature).initVerify(Mockito.any(PublicKey.class));
@@ -435,16 +436,17 @@ final class BytesTest {
 
     @Test
     @DisplayName("Write to Signature no 0 Offset")
-    void writeToMessageSignatureNo0Offset() throws NoSuchAlgorithmException {
+    void writeToSignatureNo0Offset() throws InvalidKeyException, SignatureException {
         final byte[] byteArray = {9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 0, 1, 2, 3, 4, 5};
         final Bytes bytes = Bytes.wrap(byteArray, 10, 6);
-        byte[] res;
 
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        bytes.writeTo(md);
-        res = md.digest();
-        byte[] exp = {-47, 90, -27, 57, 49, -120, 15, -41, -73, 36, -35, 120, -120, -76, -76, -19};
-        assertArrayEquals(exp, res);
+        final Signature signature = Mockito.mock(Signature.class);
+        // Signature.writeTo() throws unless we call initVerify() first
+        signature.initVerify(Mockito.mock(PublicKey.class));
+        bytes.writeTo(signature);
+        Mockito.verify(signature).initVerify(Mockito.any(PublicKey.class));
+        Mockito.verify(signature).update(byteArray, 10, 6);
+        Mockito.verifyNoMoreInteractions(signature);
     }
 
     // asUtf8String throws with null (no offset here? That's wierd. Should have offset, or we should have non-offset


### PR DESCRIPTION
closes https://github.com/hashgraph/hedera-services/issues/12331