### PR TITLE
feat: make repeated fields @NonNull and default to empty lists

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -769,7 +769,8 @@ public final class ModelGenerator implements Generator {
 		if (field.repeated()) {
 			// Need to re-define the prefix and postfix for repeated fields because they don't use `values` directly
 			// but wrap it in List.of(values) instead, so the simple definitions above don't work here.
-			final String repeatedPrefix, repeatedPostfix;
+			final String repeatedPrefix;
+			final String repeatedPostfix;
 			if (parentOneOfField != null) {
 				repeatedPrefix = prefix + " values == null ? " + getDefaultValue(field, msgDef, lookupHelper) + " : ";
 				repeatedPostfix = postfix;

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -236,6 +236,8 @@ public final class ModelGenerator implements Generator {
 	 * @return an empty string, or a string with Java annotations ending with a space
 	 */
 	private static String getFieldAnnotations(final Field field) {
+		if (field.repeated()) return NON_NULL_ANNOTATION + " ";
+
 		return switch (field.type()) {
 			case MESSAGE -> "@Nullable ";
 			case BYTES, STRING -> NON_NULL_ANNOTATION + " ";
@@ -405,7 +407,11 @@ public final class ModelGenerator implements Generator {
 							break;
 						}
 						default:
-							sb.append("this.$name = $name;".replace("$name", field.nameCamelFirstLower()));
+							if (field.repeated()) {
+								sb.append("this.$name = $name == null ? Collections.emptyList() : $name;".replace("$name", field.nameCamelFirstLower()));
+							} else {
+								sb.append("this.$name = $name;".replace("$name", field.nameCamelFirstLower()));
+							}
 							break;
 					}
 					return sb.toString();
@@ -514,7 +520,9 @@ public final class ModelGenerator implements Generator {
 		final SingleField field = new SingleField(item.field(), lookupHelper);
 		fields.add(field);
 		field.addAllNeededImports(imports, true, false, false);
-		if (field.type() == FieldType.MESSAGE) {
+		// Note that repeated fields default to empty list, so technically they always have a non-null value,
+		// and therefore the additional convenience methods, especially when they throw an NPE, don't make sense.
+		if (field.type() == FieldType.MESSAGE && !field.repeated()) {
 			hasMethods.add("""
 					/**
 					 * Convenience method to check if the $fieldName has a value
@@ -759,6 +767,19 @@ public final class ModelGenerator implements Generator {
 
 		// add nice method for message fields with list types for varargs
 		if (field.repeated()) {
+			// Need to re-define the prefix and postfix for repeated fields because they don't use `values` directly
+			// but wrap it in List.of(values) instead, so the simple definitions above don't work here.
+			final String repeatedPrefix, repeatedPostfix;
+			if (parentOneOfField != null) {
+				repeatedPrefix = prefix + " values == null ? " + getDefaultValue(field, msgDef, lookupHelper) + " : ";
+				repeatedPostfix = postfix;
+			} else if (fieldAnnotations.contains(NON_NULL_ANNOTATION)) {
+				repeatedPrefix = "values == null ? " + getDefaultValue(field, msgDef, lookupHelper) + " : ";
+				repeatedPostfix = "";
+			} else {
+				repeatedPrefix = prefix;
+				repeatedPostfix = postfix;
+			}
 			builderMethods.add("""
 						/**
 						 * $fieldDoc
@@ -767,7 +788,7 @@ public final class ModelGenerator implements Generator {
 						 * @return builder to continue building with
 						 */
 						public Builder $fieldName($baseType ... values) {
-						    this.$fieldToSet = $prefix List.of(values) $postfix;
+						    this.$fieldToSet = $repeatedPrefix List.of(values) $repeatedPostfix;
 						    return this;
 						}"""
 					.replace("$baseType",field.javaFieldType().substring("List<".length(),field.javaFieldType().length()-1))
@@ -776,8 +797,8 @@ public final class ModelGenerator implements Generator {
 					.replace("$fieldName", fieldName)
 					.replace("$fieldToSet",fieldToSet)
 					.replace("$fieldType",field.javaFieldType())
-					.replace("$prefix",prefix)
-					.replace("$postfix",postfix)
+					.replace("$repeatedPrefix",repeatedPrefix)
+					.replace("$repeatedPostfix",repeatedPostfix)
 					.indent(DEFAULT_INDENT)
 			);
 		}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/FieldsNonNullTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/FieldsNonNullTest.java
@@ -1,5 +1,7 @@
 package com.hedera.pbj.intergration.test;
 
+import com.hedera.hapi.node.base.FeeSchedule;
+import com.hedera.hapi.node.base.TransactionFeeSchedule;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.test.proto.pbj.MessageWithBytes;
 import com.hedera.pbj.test.proto.pbj.MessageWithString;
@@ -7,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FieldsNonNullTest {
     @Test
@@ -49,5 +52,26 @@ public class FieldsNonNullTest {
         msg = MessageWithString.newBuilder().aTestString(null).build();
         assertNotNull(msg.aTestString());
         assertEquals("", msg.aTestString());
+    }
+
+    @Test
+    void testRepeatedNeverNull() {
+        FeeSchedule msg;
+
+        msg = FeeSchedule.DEFAULT;
+        assertNotNull(msg.transactionFeeSchedule());
+        assertTrue(msg.transactionFeeSchedule().isEmpty());
+
+        msg = new FeeSchedule(null, null);
+        assertNotNull(msg.transactionFeeSchedule());
+        assertTrue(msg.transactionFeeSchedule().isEmpty());
+
+        msg = new FeeSchedule.Builder(null, null).build();
+        assertNotNull(msg.transactionFeeSchedule());
+        assertTrue(msg.transactionFeeSchedule().isEmpty());
+
+        msg = FeeSchedule.newBuilder().transactionFeeSchedule((TransactionFeeSchedule[])null).build();
+        assertNotNull(msg.transactionFeeSchedule());
+        assertTrue(msg.transactionFeeSchedule().isEmpty());
     }
 }


### PR DESCRIPTION
**Description**:
PBJ already defaults repeated fields to empty lists in the parser and the builder. This fix makes model constructors do the same, and generally makes the repeated fields non-nullable.

**Related issue(s)**:

Fixes #238

**Notes for reviewer**:
* Unit test
* `gr test` at hedera-services in hedera-file-service-impl which uses the FeeSchedule which was the main testing model.

The generated FeeSchedule ctor:
```
    public FeeSchedule(List<TransactionFeeSchedule> transactionFeeSchedule, TimestampSeconds expiryTime) {
        this.transactionFeeSchedule = transactionFeeSchedule == null ? Collections.emptyList() : transactionFeeSchedule;
        this.expiryTime = expiryTime;
    }
```

The generated Builder convenience method:
```
        public Builder transactionFeeSchedule(TransactionFeeSchedule ... values) {
            this.transactionFeeSchedule = values == null ? Collections.emptyList() :  List.of(values) ;
            return this;
        }
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
