### PR TITLE
fix(ReadableSequentialData): InputStream.read() should return non-neg…

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.8.6-SNAPSHOT
+version=0.8.7-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
@@ -504,7 +504,7 @@ public interface ReadableSequentialData extends SequentialData {
         @Override
         public int read() {
             try {
-                return sequentialData.readByte();
+                return sequentialData.readUnsignedByte();
             } catch (BufferUnderflowException e) {
                 return -1;
             }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
@@ -41,12 +41,17 @@ final class ReadableSequentialDataTest extends ReadableSequentialTestBase {
     @Test
     @DisplayName("Verify asInputStream()")
     void testAsInputStream() throws IOException {
-        ReadableSequentialData sequence = sequence(new byte[]{1, 2, 3});
+        ReadableSequentialData sequence = sequence(new byte[]{1, 2, 3, (byte) 254, (byte) 255});
         InputStream inputStream = sequence.asInputStream();
 
         assertThat(inputStream.read()).isEqualTo(1);
         assertThat(inputStream.read()).isEqualTo(2);
         assertThat(inputStream.read()).isEqualTo(3);
+        // NOTE: do NOT convert to byte. The returned integer value must be in 0..255.
+        // Converting to byte would interpret both literal 255 and -1 as (byte) 255,
+        // which is wrong because -1 means something else in InputStream.read().
+        assertThat(inputStream.read()).isEqualTo(254);
+        assertThat(inputStream.read()).isEqualTo(255);
         // Now we're at the end:
         assertThat(inputStream.read()).isEqualTo(-1);
         assertThat(inputStream.read()).isEqualTo(-1);


### PR DESCRIPTION
…ative integers for bytes

**Description**:
`InputStream.read()` implementation should return non-negative integers for bytes as long as there are bytes to read. The fix interprets the bytes as unsigned integers to address this. `-1` will only be returned once we run out of bytes to return.

**Related issue(s)**:

Fixes #246

**Notes for reviewer**:
Updated a unit test to verify this edge case.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
