### PR TITLE
feat: add support for maps

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.8.7-SNAPSHOT
+version=0.9.0-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
+++ b/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
@@ -91,7 +91,7 @@ oneofField
 // Map field
 
 mapField
-  : MAP LT keyType COMMA type_ GT mapName
+  : docComment MAP LT keyType COMMA type_ GT mapName
         EQ fieldNumber ( LB fieldOptions RB )? SEMI
   ;
 keyType

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -254,6 +254,8 @@ public final class Common {
                                 result = 31 * result + Integer.hashCode($fieldName.protoOrdinal());
                              }
                              """).replace("$fieldName", f.nameCamelFirstLower());
+				} else if (f.type() == Field.FieldType.MAP) {
+					generatedCodeSoFar += getMapHashCodeGeneration(generatedCodeSoFar, f);
 				} else if (f.type() == Field.FieldType.STRING ||
 						f.parent() == null) { // process sub message
 					generatedCodeSoFar += (
@@ -351,6 +353,33 @@ public final class Common {
 	}
 
 	/**
+	 * Get the hashcode codegen for a map field.
+	 * @param generatedCodeSoFar The string that the codegen is generated into.
+	 * @param f The field for which to generate the hash code.
+	 * @return Updated codegen string.
+	 */
+	@NonNull
+	private static String getMapHashCodeGeneration(String generatedCodeSoFar, final Field f) {
+		generatedCodeSoFar += (
+				"""
+				for (Object k : ((PbjMap) $fieldName).getSortedKeys()) {
+					if (k != null) {
+						result = 31 * result + k.hashCode();
+					} else {
+						result = 31 * result;
+					}
+					Object v = $fieldName.get(k);
+					if (v != null) {
+						result = 31 * result + v.hashCode();
+					} else {
+						result = 31 * result;
+					}
+				}
+				""").replace("$fieldName", f.nameCamelFirstLower());
+		return generatedCodeSoFar;
+	}
+
+	/**
 	 * Recursively calculates `equals` statement for a message fields.
 	 *
 	 * @param fields The fields of this object.
@@ -417,6 +446,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.STRING ||
                         f.type() == Field.FieldType.BYTES ||
                         f.type() == Field.FieldType.ENUM ||
+                        f.type() == Field.FieldType.MAP ||
                         f.parent() == null /* Process a sub-message */) {
                     generatedCodeSoFar += (
                             """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
@@ -92,6 +92,17 @@ public class ContextualLookupHelper {
     }
 
     /**
+     * Get the Java package a class should be generated into for a given typeContext and file type.
+     *
+     * @param fileType The type of file we want the package for
+     * @param typeContext The field to get package for message type for
+     * @return java package to put model class in
+     */
+    public String getPackageFieldMessageType(final FileType fileType, final Type_Context typeContext) {
+        return lookupHelper.getPackage(srcProtoFileContext, fileType, typeContext.messageType());
+    }
+
+    /**
      * Get the PBJ Java package a class should be generated into for a given fieldContext and file type.
      *
      * @param fileType The type of file we want the package for

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
@@ -194,44 +194,48 @@ public interface Field {
 	 */
 	enum FieldType {
 		/** Protobuf message field type */
-		MESSAGE("Object", "null", TYPE_LENGTH_DELIMITED),
+		MESSAGE("Object", "Object", "null", TYPE_LENGTH_DELIMITED),
 		/** Protobuf enum(unsigned varint encoded int of ordinal) field type */
-		ENUM("int", "null", TYPE_VARINT),
+		ENUM("int", "Integer", "null", TYPE_VARINT),
 		/** Protobuf int32(signed varint encoded int) field type */
-		INT32("int", "0", TYPE_VARINT),
+		INT32("int", "Integer", "0", TYPE_VARINT),
 		/** Protobuf uint32(unsigned varint encoded int) field type */
-		UINT32("int", "0", TYPE_VARINT),
+		UINT32("int", "Integer", "0", TYPE_VARINT),
 		/** Protobuf sint32(signed zigzag varint encoded int) field type */
-		SINT32("int", "0", TYPE_VARINT),
+		SINT32("int", "Integer", "0", TYPE_VARINT),
 		/** Protobuf int64(signed varint encoded long) field type */
-		INT64("long", "0", TYPE_VARINT),
+		INT64("long", "Long", "0", TYPE_VARINT),
 		/** Protobuf uint64(unsigned varint encoded long)  field type */
-		UINT64("long", "0", TYPE_VARINT),
+		UINT64("long", "Long", "0", TYPE_VARINT),
 		/** Protobuf sint64(signed zigzag varint encoded long) field type */
-		SINT64("long", "0", TYPE_VARINT),
+		SINT64("long", "Long", "0", TYPE_VARINT),
 		/** Protobuf float field type */
-		FLOAT("float", "0", TYPE_FIXED32),
+		FLOAT("float", "Float", "0", TYPE_FIXED32),
 		/** Protobuf fixed int32(fixed encoding int) field type */
-		FIXED32("int", "0", TYPE_FIXED32),
+		FIXED32("int", "Integer", "0", TYPE_FIXED32),
 		/** Protobuf sfixed int32(signed fixed encoding int) field type */
-		SFIXED32("int", "0", TYPE_FIXED32),
+		SFIXED32("int", "Integer", "0", TYPE_FIXED32),
 		/** Protobuf double field type */
-		DOUBLE("double", "0", TYPE_FIXED64),
+		DOUBLE("double", "Double", "0", TYPE_FIXED64),
 		/** Protobuf sfixed64(fixed encoding long) field type */
-		FIXED64("long", "0", TYPE_FIXED64),
+		FIXED64("long", "Long", "0", TYPE_FIXED64),
 		/** Protobuf sfixed64(signed fixed encoding long) field type */
-		SFIXED64("long", "0", TYPE_FIXED64),
+		SFIXED64("long", "Long", "0", TYPE_FIXED64),
 		/** Protobuf string field type */
-		STRING("String", "\"\"", TYPE_LENGTH_DELIMITED),
+		STRING("String", "String", "\"\"", TYPE_LENGTH_DELIMITED),
 		/** Protobuf bool(boolean) field type */
-		BOOL("boolean", "false", TYPE_VARINT),
+		BOOL("boolean", "Boolean", "false", TYPE_VARINT),
 		/** Protobuf bytes field type */
-		BYTES("Bytes", "Bytes.EMPTY", TYPE_LENGTH_DELIMITED),
+		BYTES("Bytes", "Bytes", "Bytes.EMPTY", TYPE_LENGTH_DELIMITED),
 		/** Protobuf oneof field type, this is not a true field type in protobuf. Needed here for a few edge cases */
-		ONE_OF("OneOf", "null", 0 );// BAD TYPE
+		ONE_OF("OneOf", "OneOf", "null", 0 ),// BAD TYPE
+		// On the wire, a map is a repeated Message {key, value}, sorted in the natural order of keys for determinism.
+		MAP("Map", "Map", "Collections.EMPTY_MAP", TYPE_LENGTH_DELIMITED );
 
 		/** The type of field type in Java code */
 		public final String javaType;
+		/** The type of boxed field type in Java code */
+		public final String boxedType;
 		/** The field type default value in Java code */
 		public final String javaDefault;
 		/** The protobuf wire type for field type */
@@ -244,8 +248,9 @@ public interface Field {
 		 * @param javaDefault The field type default value in Java code
 		 * @param wireType The protobuf wire type for field type
 		 */
-		FieldType(String javaType, final String javaDefault, int wireType) {
+		FieldType(String javaType, final String boxedType, final String javaDefault, int wireType) {
 			this.javaType = javaType;
+			this.boxedType = boxedType;
 			this.javaDefault = javaDefault;
 			this.wireType = wireType;
 		}
@@ -335,6 +340,43 @@ public interface Field {
 				return FieldType.BYTES;
 			} else {
 				throw new IllegalArgumentException("Unknown field type: "+typeContext);
+			}
+		}
+
+		/**
+		 * Get the field type for a given map key type parser context
+		 *
+		 * @param typeContext The parser context to get field type for
+		 * @param lookupHelper Lookup helper with global context
+		 * @return The field type enum for parser context
+		 */
+		static FieldType of(Protobuf3Parser.KeyTypeContext typeContext,  final ContextualLookupHelper lookupHelper) {
+			if (typeContext.INT32() != null) {
+				return FieldType.INT32;
+			} else if (typeContext.UINT32() != null) {
+				return FieldType.UINT32;
+			} else if (typeContext.SINT32() != null) {
+				return FieldType.SINT32;
+			} else if (typeContext.INT64() != null) {
+				return FieldType.INT64;
+			} else if (typeContext.UINT64() != null) {
+				return FieldType.UINT64;
+			} else if (typeContext.SINT64() != null) {
+				return FieldType.SINT64;
+			} else if (typeContext.FIXED32() != null) {
+				return FieldType.FIXED32;
+			} else if (typeContext.SFIXED32() != null) {
+				return FieldType.SFIXED32;
+			} else if (typeContext.FIXED64() != null) {
+				return FieldType.FIXED64;
+			} else if (typeContext.SFIXED64() != null) {
+				return FieldType.SFIXED64;
+			} else if (typeContext.STRING() != null) {
+				return FieldType.STRING;
+			} else if (typeContext.BOOL() != null) {
+				return FieldType.BOOL;
+			} else {
+				throw new IllegalArgumentException("Unknown map key type: " + typeContext);
 			}
 		}
 	}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
@@ -190,6 +190,26 @@ public interface Field {
 	}
 
 	/**
+	 * Extract the name of the Java model class for a message type,
+	 * or null if the type is not a message.
+	 */
+	static String extractMessageTypeName(final Protobuf3Parser.Type_Context typeContext) {
+		return typeContext.messageType() == null ? null : typeContext.messageType().messageName().getText();
+	}
+
+	/**
+	 * Extract the name of the Java package for a given FileType for a message type,
+	 * or null if the type is not a message.
+	 */
+	static String extractMessageTypePackage(
+			final Protobuf3Parser.Type_Context typeContext,
+			final FileType fileType,
+			final ContextualLookupHelper lookupHelper) {
+		return typeContext.messageType() == null || typeContext.messageType().messageName().getText() == null ? null :
+				lookupHelper.getPackageFieldMessageType(fileType, typeContext);
+	}
+
+	/**
 	 * Field type enum for use in field classes
 	 */
 	enum FieldType {
@@ -245,6 +265,7 @@ public interface Field {
 		 * Construct a new FieldType enum
 		 *
 		 * @param javaType The type of field type in Java code
+		 * @param boxedType The boxed type of the field type, e.g. Integer for an int field.
 		 * @param javaDefault The field type default value in Java code
 		 * @param wireType The protobuf wire type for field type
 		 */

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
@@ -58,13 +58,10 @@ public record MapField(
                         FieldType.of(mapContext.type_(), lookupHelper),
                         2,
                         "___" + mapContext.mapName().getText() + "__value",
-                        mapContext.type_().messageType() == null ? null : mapContext.type_().messageType().messageName().getText(),
-                        mapContext.type_().messageType() == null || mapContext.type_().messageType().messageName().getText() == null ? null :
-                                lookupHelper.getPackageFieldMessageType(FileType.MODEL, mapContext.type_()),
-                        mapContext.type_().messageType() == null || mapContext.type_().messageType().messageName().getText() == null ? null :
-                                lookupHelper.getPackageFieldMessageType(FileType.CODEC, mapContext.type_()),
-                        mapContext.type_().messageType() == null || mapContext.type_().messageType().messageName().getText() == null ? null :
-                                lookupHelper.getPackageFieldMessageType(FileType.TEST, mapContext.type_()),
+                        Field.extractMessageTypeName(mapContext.type_()),
+                        Field.extractMessageTypePackage(mapContext.type_(), FileType.MODEL, lookupHelper),
+                        Field.extractMessageTypePackage(mapContext.type_(), FileType.CODEC, lookupHelper),
+                        Field.extractMessageTypePackage(mapContext.type_(), FileType.TEST, lookupHelper),
                         "An internal, private map entry value for " + mapContext.mapName().getText(),
                         false,
                         null),

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
@@ -1,0 +1,153 @@
+package com.hedera.pbj.compiler.impl;
+
+import java.util.Set;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
+import static com.hedera.pbj.compiler.impl.SingleField.getDeprecatedOption;
+
+/**
+ * A field of type map.
+ * <p>
+ * In protobuf, a map is essentially a repeated map entry message with two fields: key and value.
+ * However, we don't model the map entry message explicitly for performance reasons. Instead,
+ * we deal with the keys and values directly, and define synthetic Field objects for them here
+ * for convenience, so that we can reuse the majority of the code generation code.
+ * <p>
+ * In model implementations we use a custom implementation of the Map interface named PbjMap
+ * which is an immutable map that exposes a SortedKeys list which allows one to iterate
+ * the map deterministically which is useful for serializing, computing the hash code, etc.
+ */
+public record MapField(
+        /** A synthetic "key" field in a map entry. */
+        Field keyField,
+        /** A synthetic "value" field in a map entry. */
+        Field valueField,
+        // The rest of the fields below simply implement the Field interface:
+        boolean repeated,
+        int fieldNumber,
+        String name,
+        FieldType type,
+        String protobufFieldType,
+        String javaFieldTypeBase,
+        String methodNameType,
+        String parseCode,
+        String javaDefault,
+        String parserFieldsSetMethodCase,
+        String comment,
+        boolean deprecated
+) implements Field {
+
+    /**
+     * Construct a MapField instance out of a MapFieldContext and a lookup helper.
+     */
+    public MapField(Protobuf3Parser.MapFieldContext mapContext, final ContextualLookupHelper lookupHelper) {
+        this(
+                new SingleField(
+                        false,
+                        FieldType.of(mapContext.keyType(), lookupHelper),
+                        1,
+                        "___" + mapContext.mapName().getText() + "__key",
+                        null,
+                        null,
+                        null,
+                        null,
+                        "An internal, private map entry key for " + mapContext.mapName().getText(),
+                        false,
+                        null),
+                new SingleField(
+                        false,
+                        FieldType.of(mapContext.type_(), lookupHelper),
+                        2,
+                        "___" + mapContext.mapName().getText() + "__value",
+                        mapContext.type_().messageType() == null ? null : mapContext.type_().messageType().messageName().getText(),
+                        mapContext.type_().messageType() == null || mapContext.type_().messageType().messageName().getText() == null ? null :
+                                lookupHelper.getPackageFieldMessageType(FileType.MODEL, mapContext.type_()),
+                        mapContext.type_().messageType() == null || mapContext.type_().messageType().messageName().getText() == null ? null :
+                                lookupHelper.getPackageFieldMessageType(FileType.CODEC, mapContext.type_()),
+                        mapContext.type_().messageType() == null || mapContext.type_().messageType().messageName().getText() == null ? null :
+                                lookupHelper.getPackageFieldMessageType(FileType.TEST, mapContext.type_()),
+                        "An internal, private map entry value for " + mapContext.mapName().getText(),
+                        false,
+                        null),
+
+                false, // maps cannot be repeated
+                Integer.parseInt(mapContext.fieldNumber().getText()),
+                mapContext.mapName().getText(),
+                FieldType.MAP,
+                "",
+                "",
+                "",
+                null,
+                "PbjMap.EMPTY",
+                "",
+                Common.buildCleanFieldJavaDoc(Integer.parseInt(mapContext.fieldNumber().getText()), mapContext.docComment()),
+                getDeprecatedOption(mapContext.fieldOptions())
+        );
+    }
+
+    /**
+     * Composes the Java generic type of the map field, e.g. "<Integer, String>" for a Map<Integer, String>.
+     */
+    public String javaGenericType() {
+        return "<" + keyField.type().boxedType + ", " +
+                (valueField().type() == FieldType.MESSAGE ? ((SingleField)valueField()).messageType() : valueField().type().boxedType)
+                + ">";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String javaFieldType() {
+        return "Map" + javaGenericType();
+    }
+
+    private void composeFieldDef(StringBuilder sb, Field field) {
+        sb.append("""
+                    /**
+                     * $doc
+                     */
+                """
+                .replace("$doc", field.comment().replaceAll("\n","\n     * "))
+        );
+        sb.append("    public static final FieldDefinition %s = new FieldDefinition(\"%s\", FieldType.%s, %s, false, false, %d);\n"
+                .formatted(Common.camelToUpperSnake(field.name()), field.name(), field.type().fieldType(), field.repeated(), field.fieldNumber()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String schemaFieldsDef() {
+        StringBuilder sb = new StringBuilder();
+        composeFieldDef(sb, this);
+        composeFieldDef(sb, keyField);
+        composeFieldDef(sb, valueField);
+        return sb.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String schemaGetFieldsDefCase() {
+        return "case %d -> %s;".formatted(fieldNumber, Common.camelToUpperSnake(name));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addAllNeededImports(
+            final Set<String> imports,
+            final boolean modelImports,
+            final boolean codecImports,
+            final boolean testImports) {
+        if (modelImports) {
+            imports.add("java.util");
+        }
+        if (codecImports) {
+            imports.add("java.util.stream");
+            imports.add("com.hedera.pbj.runtime.test");
+        }
+    }
+}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
@@ -85,7 +85,7 @@ public record MapField(
     }
 
     /**
-     * Composes the Java generic type of the map field, e.g. "<Integer, String>" for a Map<Integer, String>.
+     * Composes the Java generic type of the map field, e.g. "&lt;Integer, String&gt;" for a Map&lt;Integer, String&gt;.
      */
     public String javaGenericType() {
         return "<" + keyField.type().boxedType + ", " +

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -33,14 +33,10 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 				FieldType.of(fieldContext.type_(), lookupHelper),
 				Integer.parseInt(fieldContext.fieldNumber().getText()),
 				fieldContext.fieldName().getText(),
-				(fieldContext.type_().messageType() == null) ? null :
-						fieldContext.type_().messageType().messageName().getText(),
-				(fieldContext.type_().messageType() == null || fieldContext.type_().messageType().messageName().getText() == null) ? null :
-						lookupHelper.getPackageFieldMessageType(FileType.MODEL, fieldContext),
-				(fieldContext.type_().messageType() == null || fieldContext.type_().messageType().messageName().getText() == null) ? null :
-						lookupHelper.getPackageFieldMessageType(FileType.CODEC, fieldContext),
-				(fieldContext.type_().messageType() == null || fieldContext.type_().messageType().messageName().getText() == null) ? null :
-						lookupHelper.getPackageFieldMessageType(FileType.TEST, fieldContext),
+				Field.extractMessageTypeName(fieldContext.type_()),
+				Field.extractMessageTypePackage(fieldContext.type_(), FileType.MODEL, lookupHelper),
+				Field.extractMessageTypePackage(fieldContext.type_(), FileType.CODEC, lookupHelper),
+				Field.extractMessageTypePackage(fieldContext.type_(), FileType.TEST, lookupHelper),
 				Common.buildCleanFieldJavaDoc(Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
 				getDeprecatedOption(fieldContext.fieldOptions()),
 				null

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -31,13 +31,15 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 	public SingleField(Protobuf3Parser.FieldContext fieldContext, final ContextualLookupHelper lookupHelper) {
 		this(fieldContext.REPEATED() != null,
 				FieldType.of(fieldContext.type_(), lookupHelper),
-				Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.fieldName().getText(),
+				Integer.parseInt(fieldContext.fieldNumber().getText()),
+				fieldContext.fieldName().getText(),
 				(fieldContext.type_().messageType() == null) ? null :
 						fieldContext.type_().messageType().messageName().getText(),
 				(fieldContext.type_().messageType() == null || fieldContext.type_().messageType().messageName().getText() == null) ? null :
 						lookupHelper.getPackageFieldMessageType(FileType.MODEL, fieldContext),
 				(fieldContext.type_().messageType() == null || fieldContext.type_().messageType().messageName().getText() == null) ? null :
-						lookupHelper.getPackageFieldMessageType(FileType.CODEC, fieldContext), (fieldContext.type_().messageType() == null || fieldContext.type_().messageType().messageName().getText() == null) ? null :
+						lookupHelper.getPackageFieldMessageType(FileType.CODEC, fieldContext),
+				(fieldContext.type_().messageType() == null || fieldContext.type_().messageType().messageName().getText() == null) ? null :
 						lookupHelper.getPackageFieldMessageType(FileType.TEST, fieldContext),
 				Common.buildCleanFieldJavaDoc(Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
 				getDeprecatedOption(fieldContext.fieldOptions()),
@@ -320,13 +322,13 @@ public record SingleField(boolean repeated, FieldType type, int fieldNumber, Str
 	 * @param optionContext protobuf options from parser
 	 * @return true if field has deprecated option, otherwise false
 	 */
-	private static boolean getDeprecatedOption(Protobuf3Parser.FieldOptionsContext optionContext) {
+	static boolean getDeprecatedOption(Protobuf3Parser.FieldOptionsContext optionContext) {
 		if (optionContext != null) {
 			for (var option : optionContext.fieldOption()) {
 				if ("deprecated".equals(option.optionName().getText())) {
 					return true;
 				} else {
-					System.err.println("Unhandled Option on enum: "+optionContext.getText());
+					System.err.println("Unhandled Option: " + optionContext.getText());
 				}
 			}
 		}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -15,6 +15,7 @@ import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
 import com.hedera.pbj.compiler.impl.Field;
 import com.hedera.pbj.compiler.impl.Field.FieldType;
 import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.MapField;
 import com.hedera.pbj.compiler.impl.OneOfField;
 import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
@@ -101,7 +102,9 @@ public final class ModelGenerator implements Generator {
 			} else if (item.oneof() != null) { // process one ofs
 				oneofGetters.addAll(generateCodeForOneOf(lookupHelper, item, javaRecordName, imports, oneofEnums, fields));
 			} else if (item.mapField() != null) { // process map fields
-				System.err.println("Encountered a mapField that was not handled in " + javaRecordName);
+				final MapField field = new MapField(item.mapField(), lookupHelper);
+				fields.add(field);
+				field.addAllNeededImports(imports, true, false, false);
 			} else if (item.field() != null && item.field().fieldName() != null) {
 				generateCodeForField(lookupHelper, item, fields, imports, hasMethods);
 			} else if (item.optionStatement() != null){
@@ -403,6 +406,12 @@ public final class ModelGenerator implements Generator {
 							sb.append("this.$name = $name != null ? $name : $default;"
 									.replace("$name", field.nameCamelFirstLower())
 									.replace("$default", getDefaultValue(field, msgDef, lookupHelper))
+							);
+							break;
+						}
+						case MAP: {
+							sb.append("this.$name = PbjMap.of($name);"
+									.replace("$name", field.nameCamelFirstLower())
 							);
 							break;
 						}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
@@ -37,7 +37,9 @@ public final class SchemaGenerator implements Generator {
 				fields.add(field);
 				field.addAllNeededImports(imports, true, false, false);
 			} else if (item.mapField() != null) { // process map flattenedFields
-				throw new IllegalStateException("Encountered a mapField that was not handled in parser");
+				final MapField field = new MapField(item.mapField(), lookupHelper);
+				fields.add(field);
+				field.addAllNeededImports(imports, true, false, false);
 			} else if (item.field() != null && item.field().fieldName() != null) {
 				final var field = new SingleField(item.field(), lookupHelper);
 				fields.add(field);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -42,7 +42,9 @@ public final class JsonCodecGenerator implements Generator {
 				fields.add(field);
 				field.addAllNeededImports(imports, true, true, false);
 			} else if (item.mapField() != null) { // process map fields
-				throw new IllegalStateException("Encountered a mapField that was not handled in "+ codecClassName);
+				final MapField field = new MapField(item.mapField(), lookupHelper);
+				fields.add(field);
+				field.addAllNeededImports(imports, true, true, false);
 			} else if (item.field() != null && item.field().fieldName() != null) {
 				final var field = new SingleField(item.field(), lookupHelper);
 				fields.add(field);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -39,7 +39,9 @@ public final class CodecGenerator implements Generator {
 				fields.add(field);
 				field.addAllNeededImports(imports, true, true, false);
 			} else if (item.mapField() != null) { // process map fields
-				throw new IllegalStateException("Encountered a mapField that was not handled in "+ codecClassName);
+				final MapField field = new MapField(item.mapField(), lookupHelper);
+				fields.add(field);
+				field.addAllNeededImports(imports, true, true, false);
 			} else if (item.field() != null && item.field().fieldName() != null) {
 				final var field = new SingleField(item.field(), lookupHelper);
 				fields.add(field);
@@ -69,7 +71,7 @@ public final class CodecGenerator implements Generator {
 					import static $schemaClass.*;
 					import static com.hedera.pbj.runtime.ProtoWriterTools.*;
 					import static com.hedera.pbj.runtime.ProtoParserTools.*;
-					import static com.hedera.pbj.runtime.ProtoConstants.TAG_WIRE_TYPE_MASK;
+					import static com.hedera.pbj.runtime.ProtoConstants.*;
 				
 					/**
 					 * Protobuf Codec for $modelClass model object. Generated based on protobuf schema.

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
@@ -4,11 +4,13 @@ import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 
 import com.hedera.pbj.compiler.impl.Common;
 import com.hedera.pbj.compiler.impl.Field;
+import com.hedera.pbj.compiler.impl.MapField;
 import com.hedera.pbj.compiler.impl.OneOfField;
 import com.hedera.pbj.compiler.impl.SingleField;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -19,11 +21,11 @@ import java.util.stream.Stream;
 class CodecMeasureRecordMethodGenerator {
 
     static String generateMeasureMethod(final String modelClassName, final List<Field> fields) {
-        final String fieldSizeOfLines = fields.stream()
-                .flatMap(field -> field.type() == Field.FieldType.ONE_OF ? ((OneOfField)field).fields().stream() : Stream.of(field))
-                .sorted(Comparator.comparingInt(Field::fieldNumber))
-                .map(field -> generateFieldSizeOfLines(field, modelClassName, "data.%s()".formatted(field.nameCamelFirstLower())))
-                .collect(Collectors.joining("\n")).indent(DEFAULT_INDENT);
+        final String fieldSizeOfLines = buildFieldSizeOfLines(
+                modelClassName,
+                fields,
+                field -> "data.%s()".formatted(field.nameCamelFirstLower()),
+                true);
         return """
                 /**
                  * Compute number of bytes that would be written when calling {@code write()} method.
@@ -42,15 +44,28 @@ class CodecMeasureRecordMethodGenerator {
                 .indent(DEFAULT_INDENT);
     }
 
+    static String buildFieldSizeOfLines(
+            final String modelClassName,
+            final List<Field> fields,
+            final Function<Field, String> getValueBuilder,
+            boolean skipDefault) {
+        return fields.stream()
+                .flatMap(field -> field.type() == Field.FieldType.ONE_OF ? ((OneOfField)field).fields().stream() : Stream.of(field))
+                .sorted(Comparator.comparingInt(Field::fieldNumber))
+                .map(field -> generateFieldSizeOfLines(field, modelClassName, getValueBuilder.apply(field), skipDefault))
+                .collect(Collectors.joining("\n")).indent(DEFAULT_INDENT);
+    }
+
     /**
      * Generate lines of code for measure method, that measure the size of each field and add to "size" variable.
      *
      * @param field The field to generate size of line
      * @param modelClassName The model class name for model class for message type we are generating writer for
      * @param getValueCode java code to get the value of field
+     * @param skipDefault true if default value of the field should result in size zero
      * @return java code for adding fields size to "size" variable
      */
-    private static String generateFieldSizeOfLines(final Field field, final String modelClassName, String getValueCode) {
+    private static String generateFieldSizeOfLines(final Field field, final String modelClassName, String getValueCode, boolean skipDefault) {
         final String fieldDef = Common.camelToUpperSnake(field.name());
         String prefix = "// ["+field.fieldNumber()+"] - "+field.name();
         prefix += "\n";
@@ -84,30 +99,63 @@ class CodecMeasureRecordMethodGenerator {
                 default -> throw new UnsupportedOperationException("Unhandled optional message type:"+field.messageType());
             };
         } else if (field.repeated()) {
-            return prefix + switch(field.type()) {
+            return prefix + switch (field.type()) {
                 case ENUM -> "size += sizeOfEnumList(%s, %s);"
                         .formatted(fieldDef, getValueCode);
                 case MESSAGE -> "size += sizeOfMessageList($fieldDef, $valueCode, $codec::measureRecord);"
                         .replace("$fieldDef", fieldDef)
                         .replace("$valueCode", getValueCode)
-                        .replace("$codec", ((SingleField)field).messageTypeModelPackage() + "." +
-                                Common.capitalizeFirstLetter(field.messageType())+ ".PROTOBUF");
+                        .replace("$codec", ((SingleField) field).messageTypeModelPackage() + "." +
+                                Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
                 default -> "size += sizeOf%sList(%s, %s);"
                         .formatted(writeMethodName, fieldDef, getValueCode);
             };
+        } else if (field.type() == Field.FieldType.MAP) {
+            final MapField mapField = (MapField) field;
+            final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
+            final Function<Field, String> getValueBuilder = mapEntryField ->
+                    mapEntryField == mapField.keyField() ? "k" : (mapEntryField == mapField.valueField() ? "v" : null);
+            final String fieldSizeOfLines = CodecMeasureRecordMethodGenerator.buildFieldSizeOfLines(
+                    field.name(),
+                    mapEntryFields,
+                    getValueBuilder,
+                    false);
+            return prefix + """
+                        if (!$map.isEmpty()) {
+                            final Pbj$javaFieldType pbjMap = (Pbj$javaFieldType) $map;
+                            final int mapSize = pbjMap.size();
+                            for (int i = 0; i < mapSize; i++) {
+                                size += sizeOfTag($fieldDef, WIRE_TYPE_DELIMITED);
+                                final int sizePre = size;
+                                $K k = pbjMap.getSortedKeys().get(i);
+                                $V v = pbjMap.get(k);
+                                $fieldSizeOfLines
+                                size += sizeOfVarInt32(size - sizePre);
+                            }
+                        }
+                        """
+                    .replace("$fieldDef", fieldDef)
+                    .replace("$map", getValueCode)
+                    .replace("$javaFieldType", mapField.javaFieldType())
+                    .replace("$K", mapField.keyField().type().boxedType)
+                    .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? ((SingleField)mapField.valueField()).messageType() : mapField.valueField().type().boxedType)
+                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
+                    ;
         } else {
             return prefix + switch(field.type()) {
                 case ENUM -> "size += sizeOfEnum(%s, %s);"
                         .formatted(fieldDef, getValueCode);
-                case STRING -> "size += sizeOfString(%s, %s);"
-                        .formatted(fieldDef,getValueCode);
+                case STRING -> "size += sizeOfString(%s, %s, %s);"
+                        .formatted(fieldDef, getValueCode, skipDefault);
                 case MESSAGE -> "size += sizeOfMessage($fieldDef, $valueCode, $codec::measureRecord);"
                         .replace("$fieldDef", fieldDef)
                         .replace("$valueCode", getValueCode)
                         .replace("$codec", ((SingleField)field).messageTypeModelPackage() + "." +
                                 Common.capitalizeFirstLetter(field.messageType())+ ".PROTOBUF");
-                case BOOL -> "size += sizeOfBoolean(%s, %s);"
-                        .formatted(fieldDef,getValueCode);
+                case BOOL -> "size += sizeOfBoolean(%s, %s, %s);"
+                        .formatted(fieldDef, getValueCode, skipDefault);
+                case INT32, UINT32, SINT32, FIXED32, SFIXED32, INT64, SINT64, UINT64, FIXED64, SFIXED64, BYTES -> "size += sizeOf%s(%s, %s, %s);"
+                        .formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
                 default -> "size += sizeOf%s(%s, %s);"
                         .formatted(writeMethodName, fieldDef, getValueCode);
             };

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -4,11 +4,13 @@ import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 
 import com.hedera.pbj.compiler.impl.Common;
 import com.hedera.pbj.compiler.impl.Field;
+import com.hedera.pbj.compiler.impl.MapField;
 import com.hedera.pbj.compiler.impl.OneOfField;
 import com.hedera.pbj.compiler.impl.SingleField;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,12 +20,11 @@ import java.util.stream.Stream;
 final class CodecWriteMethodGenerator {
 
     static String generateWriteMethod(final String modelClassName, final List<Field> fields) {
-        final String fieldWriteLines = fields.stream()
-                .flatMap(field -> field.type() == Field.FieldType.ONE_OF ? ((OneOfField)field).fields().stream() : Stream.of(field))
-                .sorted(Comparator.comparingInt(Field::fieldNumber))
-                .map(field -> generateFieldWriteLines(field, modelClassName, "data.%s()".formatted(field.nameCamelFirstLower())))
-                .collect(Collectors.joining("\n"))
-                .indent(DEFAULT_INDENT);
+        final String fieldWriteLines = buildFieldWriteLines(
+                modelClassName,
+                fields,
+                field -> "data.%s()".formatted(field.nameCamelFirstLower()),
+                true);
 
         return """     
             /**
@@ -42,6 +43,18 @@ final class CodecWriteMethodGenerator {
             .indent(DEFAULT_INDENT);
     }
 
+    private static String buildFieldWriteLines(
+            final String modelClassName,
+            final List<Field> fields,
+            final Function<Field, String> getValueBuilder,
+            final boolean skipDefault) {
+        return fields.stream()
+                .flatMap(field -> field.type() == Field.FieldType.ONE_OF ? ((OneOfField)field).fields().stream() : Stream.of(field))
+                .sorted(Comparator.comparingInt(Field::fieldNumber))
+                .map(field -> generateFieldWriteLines(field, modelClassName, getValueBuilder.apply(field), skipDefault))
+                .collect(Collectors.joining("\n"))
+                .indent(DEFAULT_INDENT);
+    }
 
     /**
      * Generate lines of code for writing field
@@ -49,9 +62,10 @@ final class CodecWriteMethodGenerator {
      * @param field The field to generate writing line of code for
      * @param modelClassName The model class name for model class for message type we are generating writer for
      * @param getValueCode java code to get the value of field
+     * @param skipDefault skip writing the field if it has default value (for non-oneOf only)
      * @return java code to write field to output
      */
-    private static String generateFieldWriteLines(final Field field, final String modelClassName, String getValueCode) {
+    private static String generateFieldWriteLines(final Field field, final String modelClassName, String getValueCode, boolean skipDefault) {
         final String fieldDef = Common.camelToUpperSnake(field.name());
         String prefix = "// ["+field.fieldNumber()+"] - "+field.name();
         prefix += "\n";
@@ -96,19 +110,70 @@ final class CodecWriteMethodGenerator {
                 default -> "write%sList(out, %s, %s);"
                         .formatted(writeMethodName, fieldDef, getValueCode);
             };
+        } else if (field.type() == Field.FieldType.MAP) {
+            // https://protobuf.dev/programming-guides/proto3/#maps
+            // On the wire, a map is equivalent to:
+            //    message MapFieldEntry {
+            //      key_type key = 1;
+            //      value_type value = 2;
+            //    }
+            //    repeated MapFieldEntry map_field = N;
+            // NOTE: we serialize the map in the natural order of keys by design,
+            //       so that the binary representation of the map is deterministic.
+            // NOTE: protoc serializes default values (e.g. "") in maps, so we should too.
+            final MapField mapField = (MapField) field;
+            final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
+            final Function<Field, String> getValueBuilder = mapEntryField ->
+                    mapEntryField == mapField.keyField() ? "k" : (mapEntryField == mapField.valueField() ? "v" : null);
+            final String fieldWriteLines = buildFieldWriteLines(
+                    field.name(),
+                    mapEntryFields,
+                    getValueBuilder,
+                    false);
+            final String fieldSizeOfLines = CodecMeasureRecordMethodGenerator.buildFieldSizeOfLines(
+                    field.name(),
+                    mapEntryFields,
+                    getValueBuilder,
+                    false);
+            return prefix + """
+                        if (!$map.isEmpty()) {
+                            final Pbj$javaFieldType pbjMap = (Pbj$javaFieldType) $map;
+                            final int mapSize = pbjMap.size();
+                            for (int i = 0; i < mapSize; i++) {
+                                writeTag(out, $fieldDef, WIRE_TYPE_DELIMITED);
+                                $K k = pbjMap.getSortedKeys().get(i);
+                                $V v = pbjMap.get(k);
+                                int size = 0;
+                                $fieldSizeOfLines
+                                out.writeVarInt(size, false);
+                                $fieldWriteLines
+                            }
+                        }
+                        """
+                    .replace("$fieldDef", fieldDef)
+                    .replace("$map", getValueCode)
+                    .replace("$javaFieldType", mapField.javaFieldType())
+                    .replace("$K", mapField.keyField().type().boxedType)
+                    .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? ((SingleField)mapField.valueField()).messageType() : mapField.valueField().type().boxedType)
+                    .replace("$fieldWriteLines", fieldWriteLines.indent(DEFAULT_INDENT))
+                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
+
+                    ;
         } else {
             return prefix + switch(field.type()) {
                 case ENUM -> "writeEnum(out, %s, %s);"
                         .formatted(fieldDef, getValueCode);
-                case STRING -> "writeString(out, %s, %s);"
-                        .formatted(fieldDef,getValueCode);
+                case STRING -> "writeString(out, %s, %s, %s);"
+                        .formatted(fieldDef, getValueCode, skipDefault);
                 case MESSAGE -> "writeMessage(out, $fieldDef, $valueCode, $codec::write, $codec::measureRecord);"
                         .replace("$fieldDef", fieldDef)
                         .replace("$valueCode", getValueCode)
                         .replace("$codec", ((SingleField)field).messageTypeModelPackage() + "." +
                                 Common.capitalizeFirstLetter(field.messageType())+ ".PROTOBUF");
-                case BOOL -> "writeBoolean(out, %s, %s);"
-                        .formatted(fieldDef,getValueCode);
+                case BOOL -> "writeBoolean(out, %s, %s, %s);"
+                        .formatted(fieldDef, getValueCode, skipDefault);
+                case INT32, UINT32, SINT32, FIXED32, SFIXED32, INT64, SINT64, UINT64, FIXED64, SFIXED64, BYTES -> "write%s(out, %s, %s, %s);"
+                        .formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
                 default -> "write%s(out, %s, %s);"
                         .formatted(writeMethodName, fieldDef, getValueCode);
             };

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/FieldType.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/FieldType.java
@@ -37,7 +37,9 @@ public enum FieldType {
 	/** Protobuf enum type */
 	ENUM,
 	/** Protobuf sub-message type */
-	MESSAGE;
+	MESSAGE,
+	/** Protobuf map type */
+	MAP;
 
 	/**
 	 * Optional values have an inner field, with a standard definition for every FieldType. We create singleton

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjMap.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjMap.java
@@ -1,0 +1,137 @@
+package com.hedera.pbj.runtime;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Implements an immutable map that exposes a list of keys sorted in their natural order.
+ * <p>
+ * This Map implementation allows one to iterate the entries in a deterministic order
+ * which is useful for serializing, hash computation, etc.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class PbjMap<K, V> implements Map<K, V> {
+    /** An empty PbjMap. */
+    public static final PbjMap EMPTY = new PbjMap(Collections.EMPTY_MAP);
+
+    private final Map<K, V> map;
+    private final List<K> sortedKeys;
+
+    private PbjMap(final Map<K, V> map) {
+        this.map = Collections.unmodifiableMap(map);
+        this.sortedKeys = Collections.unmodifiableList(map.keySet().stream().sorted().toList());
+    }
+
+    /**
+     * A public factory method for PbjMap objects.
+     * It returns the PbjMap.EMPTY if the input map is empty.
+     * It returns the map itself if the input map is an instance of PbjMap (because it's immutable anyway.)
+     * Otherwise, it returns a new PbjMap instance delegating to the provided input map.
+     * NOTE: the caller code is expected to never modify the input map after this factory method is called,
+     * otherwise the behavior is undefined.
+     * @param map an input map
+     * @return a PbjMap instance corresponding to the input map
+     * @param <K> key type
+     * @param <V> value type
+     */
+    public static <K, V> PbjMap<K, V> of(final Map<K, V> map) {
+        if (map == null || map.isEmpty()) return (PbjMap<K, V>) EMPTY;
+        if (map instanceof PbjMap) return (PbjMap<K, V>) map;
+        return new PbjMap<>(map);
+    }
+
+    /**
+     * Return a list of keys sorted in their natural order.
+     * @return the sorted keys list
+     */
+    public List<K> getSortedKeys() {
+        return sortedKeys;
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return map.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        throw new UnsupportedOperationException("The map is immutable");
+    }
+
+    @Override
+    public V remove(Object key) {
+        throw new UnsupportedOperationException("The map is immutable");
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        throw new UnsupportedOperationException("The map is immutable");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("The map is immutable");
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return map.values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return map.entrySet();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PbjMap<?, ?> pbjMap = (PbjMap<?, ?>) o;
+        return Objects.equals(map, pbjMap.map) && Objects.equals(sortedKeys, pbjMap.sortedKeys);
+    }
+
+    @Override
+    public int hashCode() {
+        // This is a convenience hashCode() implementation that delegates to Java hashCode,
+        // and it's implemented here solely to support the above equals() method override.
+        // Generated protobuf models compute map fields' hash codes differently and deterministically.
+        return 31 * map.hashCode() + sortedKeys.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return map.toString() + " with sortedKeys: " + getSortedKeys();
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -12,7 +12,9 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class is full of parse helper methods, they depend on a DataInput as input with position and limit set
@@ -46,6 +48,25 @@ public final class ProtoParserTools {
         }
         list.add(newItem);
         return list;
+    }
+
+    /**
+     * Add an entry to a map returning a new map with the entry or the same map with the entry added. If the map is
+     * Collections.EMPTY_MAP then a new map is created and returned with the entry added.
+     *
+     * @param map The map to add entry to or Collections.EMPTY_MAP
+     * @param key The key
+     * @param value The value
+     * @return The map passed in if mutable or new map
+     * @param <K> The type of keys
+     * @param <V> The type of values
+     */
+    public static <K, V> Map<K, V> addToMap(Map<K, V> map, final K key, final V value) {
+        if (map == PbjMap.EMPTY) {
+            map = new HashMap<>();
+        }
+        map.put(key, value);
+        return map;
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
@@ -8,6 +8,7 @@ import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Static tools and test cases used by generated test classes.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -8,6 +8,7 @@ import static com.hedera.pbj.runtime.ProtoConstants.WIRE_TYPE_VARINT_OR_ZIGZAG;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.buffer.RandomAccessData;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.io.IOException;
@@ -46,7 +47,7 @@ public final class ProtoWriterTools {
             case FIXED32, SFIXED32 -> WIRE_TYPE_FIXED_32_BIT;
             case FIXED64, SFIXED64 -> WIRE_TYPE_FIXED_64_BIT;
             case BOOL -> WIRE_TYPE_VARINT_OR_ZIGZAG;
-            case BYTES, MESSAGE, STRING -> WIRE_TYPE_DELIMITED;
+            case BYTES, MESSAGE, STRING, MAP -> WIRE_TYPE_DELIMITED;
             case ENUM -> WIRE_TYPE_VARINT_OR_ZIGZAG;
         };
     }
@@ -87,15 +88,16 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
      * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
      */
-    public static void writeInteger(WritableSequentialData out, FieldDefinition field, int value) {
+    public static void writeInteger(WritableSequentialData out, FieldDefinition field, int value, boolean skipDefault) {
         assert switch(field.type()) {
             case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
             default -> false;
         } : "Not an integer type " + field;
         assert !field.repeated() : "Use writeIntegerList with repeated types";
 
-        if (!field.oneOf() && value == 0) {
+        if (skipDefault && !field.oneOf() && value == 0) {
             return;
         }
         switch (field.type()) {
@@ -127,14 +129,15 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
      * @param value the long value to write
+     * @param skipDefault default value results in no-op for non-oneOf
      */
-    public static void writeLong(WritableSequentialData out, FieldDefinition field, long value) {
+    public static void writeLong(WritableSequentialData out, FieldDefinition field, long value, boolean skipDefault) {
         assert switch(field.type()) {
             case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> true;
             default -> false;
         } : "Not a long type " + field;
         assert !field.repeated() : "Use writeLongList with repeated types";
-        if (!field.oneOf() && value == 0) {
+        if (skipDefault && !field.oneOf() && value == 0) {
             return;
         }
         switch (field.type()) {
@@ -198,12 +201,13 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
      * @param value the boolean value to write
+     * @param skipDefault default value results in no-op for non-oneOf
      */
-    public static void writeBoolean(WritableSequentialData out, FieldDefinition field, boolean value) {
+    public static void writeBoolean(WritableSequentialData out, FieldDefinition field, boolean value, boolean skipDefault) {
         assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
         assert !field.repeated() : "Use writeBooleanList with repeated types";
         // In the case of oneOf we write the value even if it is default value of false
-        if (value || field.oneOf()) {
+        if (value || field.oneOf() || !skipDefault) {
             writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
             out.writeByte(value ? (byte)1 : 0);
         }
@@ -233,13 +237,14 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing, the field must be non-repeated
      * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
      * @throws IOException If a I/O error occurs
      */
     public static void writeString(final WritableSequentialData out, final FieldDefinition field,
-            final String value) throws IOException {
+            final String value, boolean skipDefault) throws IOException {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert !field.repeated() : "Use writeStringList with repeated types";
-        writeStringNoChecks(out, field, value);
+        writeStringNoChecks(out, field, value, skipDefault);
     }
 
     /**
@@ -256,7 +261,7 @@ public final class ProtoWriterTools {
             final String value) throws IOException {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert field.repeated() : "writeOneRepeatedString can only be used with repeated fields";
-        writeStringNoChecks(out, field, value);
+        writeStringNoChecks(out, field, value, true);
     }
 
     /**
@@ -265,17 +270,18 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
      * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
      * @throws IOException If a I/O error occurs
      */
     private static void writeStringNoChecks(final WritableSequentialData out, final FieldDefinition field,
-            final String value) throws IOException {
+            final String value, boolean skipDefault) throws IOException {
         // When not a oneOf don't write default value
-        if (!field.oneOf() && (value == null || value.isEmpty())) {
+        if (skipDefault && !field.oneOf() && (value == null || value.isEmpty())) {
             return;
         }
         writeTag(out, field, WIRE_TYPE_DELIMITED);
         out.writeVarInt(sizeOfStringNoTag(value), false);
-        Utf8Tools.encodeUtf8(value,out);
+        Utf8Tools.encodeUtf8(value, out);
     }
 
     /**
@@ -285,13 +291,14 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing, the field must not be repeated
      * @param value the bytes value to write
+     * @param skipDefault default value results in no-op for non-oneOf
      * @throws IOException If a I/O error occurs
      */
     public static void writeBytes(final WritableSequentialData out, final FieldDefinition field,
-            final RandomAccessData value) throws IOException {
+            final RandomAccessData value, boolean skipDefault) throws IOException {
         assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
         assert !field.repeated() : "Use writeBytesList with repeated types";
-        writeBytesNoChecks(out, field, value, true);
+        writeBytesNoChecks(out, field, value, skipDefault);
     }
 
     /**
@@ -403,6 +410,38 @@ public final class ProtoWriterTools {
         }
     }
 
+    public static <K, V> void writeMap(
+            final WritableSequentialData out,
+            final FieldDefinition field,
+            @NonNull final PbjMap<K, V> map,
+            final ProtoWriter<K> kWriter,
+            final ProtoWriter<V> vWriter,
+            final ToIntFunction<K> sizeOfK,
+            final ToIntFunction<V> sizeOfV
+    ) throws IOException {
+        // https://protobuf.dev/programming-guides/proto3/#maps
+        // On the wire, a map is equivalent to:
+        //    message MapFieldEntry {
+        //      key_type key = 1;
+        //      value_type value = 2;
+        //    }
+        //    repeated MapFieldEntry map_field = N;
+        if (map.isEmpty()) {
+            return;
+        }
+        final int size = map.size();
+        for (int i = 0; i < size; i++) {
+            K k = map.getSortedKeys().get(i);
+            V v = map.get(k);
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final int sizeK = sizeOfK.applyAsInt(k);
+            final int sizeV = sizeOfV.applyAsInt(v);
+            out.writeVarInt(sizeK + sizeV, false);
+            kWriter.write(k, out);
+            vWriter.write(v, out);
+        }
+    }
+
     // ================================================================================================================
     // OPTIONAL VERSIONS OF WRITE METHODS
 
@@ -417,8 +456,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfInteger(newField, value), false);
-            writeInteger(out,newField,value);
+            out.writeVarInt(sizeOfInteger(newField, value, true), false);
+            writeInteger(out, newField, value, true);
         }
     }
 
@@ -433,8 +472,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfLong(newField, value), false);
-            writeLong(out,newField,value);
+            out.writeVarInt(sizeOfLong(newField, value, true), false);
+            writeLong(out, newField, value, true);
         }
     }
 
@@ -481,8 +520,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfBoolean(newField, value), false);
-            writeBoolean(out,newField,value);
+            out.writeVarInt(sizeOfBoolean(newField, value, true), false);
+            writeBoolean(out, newField, value, true);
         }
     }
 
@@ -498,8 +537,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfString(newField, value), false);
-            writeString(out,newField,value);
+            out.writeVarInt(sizeOfString(newField, value, true), false);
+            writeString(out, newField, value, true);
         }
     }
 
@@ -515,10 +554,10 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            final int size = sizeOfBytes(newField, value);
+            final int size = sizeOfBytes(newField, value, true);
             out.writeVarInt(size, false);
             if (size > 0) {
-                writeBytes(out,newField, value);
+                writeBytes(out,newField, value, true);
             }
         }
     }
@@ -960,7 +999,7 @@ public final class ProtoWriterTools {
     public static int sizeOfOptionalInteger(FieldDefinition field, @Nullable Integer value) {
         if (value != null) {
             final int intValue = value;
-            int size = sizeOfInteger(field.type().optionalFieldDefinition, intValue);
+            int size = sizeOfInteger(field.type().optionalFieldDefinition, intValue, true);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
@@ -976,7 +1015,7 @@ public final class ProtoWriterTools {
     public static int sizeOfOptionalLong(FieldDefinition field, @Nullable Long value) {
         if (value != null) {
             final long longValue = value;
-            final int size =  sizeOfLong(field.type().optionalFieldDefinition, longValue);
+            final int size =  sizeOfLong(field.type().optionalFieldDefinition, longValue, true);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
@@ -1036,7 +1075,7 @@ public final class ProtoWriterTools {
      */
     public static int sizeOfOptionalString(FieldDefinition field, @Nullable String value) {
         if (value != null) {
-            final int size = sizeOfString(field.type().optionalFieldDefinition,value);
+            final int size = sizeOfString(field.type().optionalFieldDefinition, value, true);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
@@ -1051,7 +1090,7 @@ public final class ProtoWriterTools {
      */
     public static int sizeOfOptionalBytes(FieldDefinition field, @Nullable RandomAccessData value) {
         if (value != null) {
-            final int size = sizeOfBytes(field.type().optionalFieldDefinition, value);
+            final int size = sizeOfBytes(field.type().optionalFieldDefinition, value, true);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
@@ -1062,10 +1101,11 @@ public final class ProtoWriterTools {
      *
      * @param field descriptor of field
      * @param value integer value to get encoded size for
+     * @param skipDefault default value results in zero size
      * @return the number of bytes for encoded value
      */
-    public static int sizeOfInteger(FieldDefinition field, int value) {
-        if (!field.oneOf() && value == 0) return 0;
+    public static int sizeOfInteger(FieldDefinition field, int value, boolean skipDefault) {
+        if (skipDefault && !field.oneOf() && value == 0) return 0;
         return switch (field.type()) {
             case INT32 -> sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfVarInt32(value);
             case UINT32 -> sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfUnsignedVarInt32(value);
@@ -1080,10 +1120,11 @@ public final class ProtoWriterTools {
      *
      * @param field descriptor of field
      * @param value long value to get encoded size for
+     * @param skipDefault default value results in zero size
      * @return the number of bytes for encoded value
      */
-    public static int sizeOfLong(FieldDefinition field, long value) {
-        if (!field.oneOf() && value == 0) return 0;
+    public static int sizeOfLong(FieldDefinition field, long value, boolean skipDefault) {
+        if (skipDefault && !field.oneOf() && value == 0) return 0;
         return switch (field.type()) {
             case INT64, UINT64 -> sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfUnsignedVarInt64(value);
             case SINT64 -> sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfUnsignedVarInt64((value << 1) ^ (value >> 63));
@@ -1121,10 +1162,11 @@ public final class ProtoWriterTools {
      *
      * @param field descriptor of field
      * @param value boolean value to get encoded size for
+     * @param skipDefault default value results in zero size
      * @return the number of bytes for encoded value
      */
-    public static int sizeOfBoolean(FieldDefinition field, boolean value) {
-        return (value || field.oneOf()) ? sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + 1 : 0;
+    public static int sizeOfBoolean(FieldDefinition field, boolean value, boolean skipDefault) {
+        return (value || field.oneOf() || !skipDefault) ? sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + 1 : 0;
     }
 
 
@@ -1147,11 +1189,12 @@ public final class ProtoWriterTools {
      *
      * @param field descriptor of field
      * @param value string value to get encoded size for
+     * @param skipDefault default value results in zero size
      * @return the number of bytes for encoded value
      */
-    public static int sizeOfString(FieldDefinition field, String value) {
+    public static int sizeOfString(FieldDefinition field, String value, boolean skipDefault) {
         // When not a oneOf don't write default value
-        if (!field.oneOf() && (value == null || value.isEmpty())) {
+        if (skipDefault && !field.oneOf() && (value == null || value.isEmpty())) {
             return 0;
         }
         return sizeOfDelimited(field, sizeOfStringNoTag(value));
@@ -1180,11 +1223,12 @@ public final class ProtoWriterTools {
      *
      * @param field descriptor of field
      * @param value bytes value to get encoded size for
+     * @param skipDefault default value results in zero size
      * @return the number of bytes for encoded value
      */
-    public static int sizeOfBytes(FieldDefinition field, RandomAccessData value) {
+    public static int sizeOfBytes(FieldDefinition field, RandomAccessData value, boolean skipDefault) {
         // When not a oneOf don't write default value
-        if (!field.oneOf() && (value.length() == 0)) {
+        if (skipDefault && !field.oneOf() && (value.length() == 0)) {
             return 0;
         }
         return sizeOfDelimited(field, (int) value.length());

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -88,6 +88,17 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
      * @param value the int value to write
+     */
+    public static void writeInteger(WritableSequentialData out, FieldDefinition field, int value) {
+        writeInteger(out, field, value, true);
+    }
+
+    /**
+     * Write a integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
      * @param skipDefault default value results in no-op for non-oneOf
      */
     public static void writeInteger(WritableSequentialData out, FieldDefinition field, int value, boolean skipDefault) {
@@ -121,6 +132,17 @@ public final class ProtoWriterTools {
             }
             default -> throw unsupported();
         }
+    }
+
+    /**
+     * Write a long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the long value to write
+     */
+    public static void writeLong(WritableSequentialData out, FieldDefinition field, long value) {
+        writeLong(out, field, value, true);
     }
 
     /**
@@ -201,6 +223,17 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
      * @param value the boolean value to write
+     */
+    public static void writeBoolean(WritableSequentialData out, FieldDefinition field, boolean value) {
+        writeBoolean(out, field, value, true);
+    }
+
+    /**
+     * Write a boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
      * @param skipDefault default value results in no-op for non-oneOf
      */
     public static void writeBoolean(WritableSequentialData out, FieldDefinition field, boolean value, boolean skipDefault) {
@@ -237,6 +270,19 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing, the field must be non-repeated
      * @param value the string value to write
+     * @throws IOException If a I/O error occurs
+     */
+    public static void writeString(final WritableSequentialData out, final FieldDefinition field,
+                                   final String value) throws IOException {
+        writeString(out, field, value, true);
+    }
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
      * @param skipDefault default value results in no-op for non-oneOf
      * @throws IOException If a I/O error occurs
      */
@@ -261,6 +307,19 @@ public final class ProtoWriterTools {
             final String value) throws IOException {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert field.repeated() : "writeOneRepeatedString can only be used with repeated fields";
+        writeStringNoChecks(out, field, value);
+    }
+
+    /**
+     * Write a integer to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     * @throws IOException If a I/O error occurs
+     */
+    private static void writeStringNoChecks(final WritableSequentialData out, final FieldDefinition field,
+                                            final String value) throws IOException {
         writeStringNoChecks(out, field, value, true);
     }
 
@@ -282,6 +341,20 @@ public final class ProtoWriterTools {
         writeTag(out, field, WIRE_TYPE_DELIMITED);
         out.writeVarInt(sizeOfStringNoTag(value), false);
         Utf8Tools.encodeUtf8(value, out);
+    }
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     * @throws IOException If a I/O error occurs
+     */
+    public static void writeBytes(final WritableSequentialData out, final FieldDefinition field,
+                                  final RandomAccessData value) throws IOException {
+        writeBytes(out, field, value, true);
     }
 
     /**
@@ -456,8 +529,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfInteger(newField, value, true), false);
-            writeInteger(out, newField, value, true);
+            out.writeVarInt(sizeOfInteger(newField, value), false);
+            writeInteger(out, newField, value);
         }
     }
 
@@ -472,8 +545,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfLong(newField, value, true), false);
-            writeLong(out, newField, value, true);
+            out.writeVarInt(sizeOfLong(newField, value), false);
+            writeLong(out, newField, value);
         }
     }
 
@@ -520,8 +593,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfBoolean(newField, value, true), false);
-            writeBoolean(out, newField, value, true);
+            out.writeVarInt(sizeOfBoolean(newField, value), false);
+            writeBoolean(out, newField, value);
         }
     }
 
@@ -537,8 +610,8 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfString(newField, value, true), false);
-            writeString(out, newField, value, true);
+            out.writeVarInt(sizeOfString(newField, value), false);
+            writeString(out, newField, value);
         }
     }
 
@@ -554,10 +627,10 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            final int size = sizeOfBytes(newField, value, true);
+            final int size = sizeOfBytes(newField, value);
             out.writeVarInt(size, false);
             if (size > 0) {
-                writeBytes(out,newField, value, true);
+                writeBytes(out,newField, value);
             }
         }
     }
@@ -999,7 +1072,7 @@ public final class ProtoWriterTools {
     public static int sizeOfOptionalInteger(FieldDefinition field, @Nullable Integer value) {
         if (value != null) {
             final int intValue = value;
-            int size = sizeOfInteger(field.type().optionalFieldDefinition, intValue, true);
+            int size = sizeOfInteger(field.type().optionalFieldDefinition, intValue);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
@@ -1015,7 +1088,7 @@ public final class ProtoWriterTools {
     public static int sizeOfOptionalLong(FieldDefinition field, @Nullable Long value) {
         if (value != null) {
             final long longValue = value;
-            final int size =  sizeOfLong(field.type().optionalFieldDefinition, longValue, true);
+            final int size =  sizeOfLong(field.type().optionalFieldDefinition, longValue);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
@@ -1075,7 +1148,7 @@ public final class ProtoWriterTools {
      */
     public static int sizeOfOptionalString(FieldDefinition field, @Nullable String value) {
         if (value != null) {
-            final int size = sizeOfString(field.type().optionalFieldDefinition, value, true);
+            final int size = sizeOfString(field.type().optionalFieldDefinition, value);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
@@ -1090,10 +1163,21 @@ public final class ProtoWriterTools {
      */
     public static int sizeOfOptionalBytes(FieldDefinition field, @Nullable RandomAccessData value) {
         if (value != null) {
-            final int size = sizeOfBytes(field.type().optionalFieldDefinition, value, true);
+            final int size = sizeOfBytes(field.type().optionalFieldDefinition, value);
             return sizeOfTag(field, WIRE_TYPE_DELIMITED) + sizeOfUnsignedVarInt32(size) + size;
         }
         return 0;
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode an integer field
+     *
+     * @param field descriptor of field
+     * @param value integer value to get encoded size for
+     * @return the number of bytes for encoded value
+     */
+    public static int sizeOfInteger(FieldDefinition field, int value) {
+        return sizeOfInteger(field, value, true);
     }
 
     /**
@@ -1113,6 +1197,17 @@ public final class ProtoWriterTools {
             case SFIXED32, FIXED32 -> sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + FIXED32_SIZE;
             default -> throw unsupported();
         };
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode a long field
+     *
+     * @param field descriptor of field
+     * @param value long value to get encoded size for
+     * @return the number of bytes for encoded value
+     */
+    public static int sizeOfLong(FieldDefinition field, long value) {
+        return sizeOfLong(field, value, true);
     }
 
     /**
@@ -1162,6 +1257,17 @@ public final class ProtoWriterTools {
      *
      * @param field descriptor of field
      * @param value boolean value to get encoded size for
+     * @return the number of bytes for encoded value
+     */
+    public static int sizeOfBoolean(FieldDefinition field, boolean value) {
+        return sizeOfBoolean(field, value, true);
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode a boolean field
+     *
+     * @param field descriptor of field
+     * @param value boolean value to get encoded size for
      * @param skipDefault default value results in zero size
      * @return the number of bytes for encoded value
      */
@@ -1182,6 +1288,17 @@ public final class ProtoWriterTools {
             return 0;
         }
         return sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfVarInt32(enumValue.protoOrdinal());
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode a string field
+     *
+     * @param field descriptor of field
+     * @param value string value to get encoded size for
+     * @return the number of bytes for encoded value
+     */
+    public static int sizeOfString(FieldDefinition field, String value) {
+        return sizeOfString(field, value, true);
     }
 
     /**
@@ -1216,6 +1333,17 @@ public final class ProtoWriterTools {
         } catch (IOException e) { // fall back to JDK
             return value.getBytes(StandardCharsets.UTF_8).length;
         }
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode a bytes field
+     *
+     * @param field descriptor of field
+     * @param value bytes value to get encoded size for
+     * @return the number of bytes for encoded value
+     */
+    public static int sizeOfBytes(FieldDefinition field, RandomAccessData value) {
+        return sizeOfBytes(field, value, true);
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -273,12 +273,12 @@ class ProtoParserToolsTest {
     void testSkipField() throws IOException {
         final String valToRead = randomVarSizeString();
         final BufferedData data = BufferedData.allocate(1000);
-        writeLong(data, createFieldDefinition(FIXED64), rng.nextLong());
-        writeInteger(data, createFieldDefinition(FIXED32), rng.nextInt());
+        writeLong(data, createFieldDefinition(FIXED64), rng.nextLong(), true);
+        writeInteger(data, createFieldDefinition(FIXED32), rng.nextInt(), true);
         int value = rng.nextInt(0, Integer.MAX_VALUE);
-        writeInteger(data, createFieldDefinition(INT32), value);
-        writeString(data, createFieldDefinition(STRING), randomVarSizeString());
-        writeString(data, createFieldDefinition(STRING), valToRead);
+        writeInteger(data, createFieldDefinition(INT32), value, true);
+        writeString(data, createFieldDefinition(STRING), randomVarSizeString(), true);
+        writeString(data, createFieldDefinition(STRING), valToRead, true);
 
         data.flip();
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -273,12 +273,12 @@ class ProtoParserToolsTest {
     void testSkipField() throws IOException {
         final String valToRead = randomVarSizeString();
         final BufferedData data = BufferedData.allocate(1000);
-        writeLong(data, createFieldDefinition(FIXED64), rng.nextLong(), true);
-        writeInteger(data, createFieldDefinition(FIXED32), rng.nextInt(), true);
+        writeLong(data, createFieldDefinition(FIXED64), rng.nextLong());
+        writeInteger(data, createFieldDefinition(FIXED32), rng.nextInt());
         int value = rng.nextInt(0, Integer.MAX_VALUE);
-        writeInteger(data, createFieldDefinition(INT32), value, true);
-        writeString(data, createFieldDefinition(STRING), randomVarSizeString(), true);
-        writeString(data, createFieldDefinition(STRING), valToRead, true);
+        writeInteger(data, createFieldDefinition(INT32), value);
+        writeString(data, createFieldDefinition(STRING), randomVarSizeString());
+        writeString(data, createFieldDefinition(STRING), valToRead);
 
         data.flip();
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
@@ -157,7 +157,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(INT32);
         final int valToWrite = 0;
         final long positionBefore = bufferedData.position();
-        writeInteger(bufferedData, definition, valToWrite, true);
+        writeInteger(bufferedData, definition, valToWrite);
         final long positionAfter = bufferedData.position();
         assertEquals(positionBefore, positionAfter);
     }
@@ -172,7 +172,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_int32() {
         FieldDefinition definition = createFieldDefinition(INT32);
         final int valToWrite = nextNonZeroRandomInt();
-        writeInteger(bufferedData, definition, valToWrite, true);
+        writeInteger(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarInt(false));
@@ -182,7 +182,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_uint32() {
         FieldDefinition definition = createFieldDefinition(UINT32);
         int valToWrite = RNG.nextInt(1, Integer.MAX_VALUE);
-        writeInteger(bufferedData, definition, valToWrite, true);
+        writeInteger(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(false));
@@ -192,7 +192,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_sint32() {
         FieldDefinition definition = createFieldDefinition(SINT32);
         final int valToWrite = nextNonZeroRandomInt();
-        writeInteger(bufferedData, definition, valToWrite, true);
+        writeInteger(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarInt(true));
@@ -203,7 +203,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_fixed32(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         final int valToWrite = nextNonZeroRandomInt();
-        writeInteger(bufferedData, definition, valToWrite, true);
+        writeInteger(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertFixed32Tag(definition);
         assertEquals(valToWrite, bufferedData.readInt(ByteOrder.LITTLE_ENDIAN));
@@ -216,7 +216,7 @@ class ProtoWriterToolsTest {
             "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testWriteInteger_unsupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> writeInteger(bufferedData, definition, RNG.nextInt(), true));
+        assertThrows(RuntimeException.class, () -> writeInteger(bufferedData, definition, RNG.nextInt()));
     }
 
     @Test
@@ -224,7 +224,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(INT64);
         final long valToWrite = 0L;
         final long positionBefore = bufferedData.position();
-        writeLong(bufferedData, definition, valToWrite, true);
+        writeLong(bufferedData, definition, valToWrite);
         final long positionAfter = bufferedData.position();
         assertEquals(positionBefore, positionAfter);
     }
@@ -239,7 +239,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_int64() {
         FieldDefinition definition = createFieldDefinition(INT64);
         final long valToWrite = nextNonZeroRandomLong();
-        writeLong(bufferedData, definition, valToWrite, true);
+        writeLong(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(false));
@@ -249,7 +249,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_uint64() {
         FieldDefinition definition = createFieldDefinition(UINT64);
         final long valToWrite = RNG.nextLong(1, Long.MAX_VALUE);
-        writeLong(bufferedData, definition, valToWrite, true);
+        writeLong(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(false));
@@ -259,7 +259,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_sint64() {
         FieldDefinition definition = createFieldDefinition(SINT64);
         final int valToWrite = nextNonZeroRandomInt();
-        writeLong(bufferedData, definition, valToWrite, true);
+        writeLong(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(true));
@@ -270,7 +270,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_fixed64(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         final long valToWrite = nextNonZeroRandomLong();
-        writeLong(bufferedData, definition, valToWrite, true);
+        writeLong(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertEquals((definition.number() << TAG_TYPE_BITS) | WIRE_TYPE_FIXED_64_BIT.ordinal(), bufferedData.readVarInt(false));
         assertEquals(valToWrite, bufferedData.readLong(ByteOrder.LITTLE_ENDIAN));
@@ -283,7 +283,7 @@ class ProtoWriterToolsTest {
             "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testWriteLong_unsupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> writeLong(bufferedData, definition, RNG.nextInt(), true));
+        assertThrows(RuntimeException.class, () -> writeLong(bufferedData, definition, RNG.nextInt()));
     }
 
     private static float nextNonZeroRandomFloat() {
@@ -321,7 +321,7 @@ class ProtoWriterToolsTest {
     @Test
     void testWriteBoolean_true() {
         FieldDefinition definition = createFieldDefinition(BOOL);
-        ProtoWriterTools.writeBoolean(bufferedData, definition, true, true);
+        ProtoWriterTools.writeBoolean(bufferedData, definition, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(1, bufferedData.readVarInt(false));
@@ -330,7 +330,7 @@ class ProtoWriterToolsTest {
     @Test
     void testWriteBoolean_false() {
         FieldDefinition definition = createFieldDefinition(BOOL);
-        ProtoWriterTools.writeBoolean(bufferedData, definition, false, true);
+        ProtoWriterTools.writeBoolean(bufferedData, definition, false);
         bufferedData.flip();
         assertEquals(0, bufferedData.length());
     }
@@ -368,7 +368,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(STRING);
         String valToWrite = "";
         final long positionBefore = bufferedData.position();
-        writeString(bufferedData, definition, valToWrite, true);
+        writeString(bufferedData, definition, valToWrite);
         final long positionAfter = bufferedData.position();
         assertEquals(positionAfter, positionBefore);
     }
@@ -377,7 +377,7 @@ class ProtoWriterToolsTest {
     void testWriteString() throws IOException {
         FieldDefinition definition = createFieldDefinition(STRING);
         String valToWrite = RANDOM_STRING.nextString();
-        writeString(bufferedData, definition, valToWrite, true);
+        writeString(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertEquals((definition.number() << TAG_TYPE_BITS) | WIRE_TYPE_DELIMITED.ordinal(), bufferedData.readVarInt(false));
         int length = bufferedData.readVarInt(false);
@@ -404,7 +404,7 @@ class ProtoWriterToolsTest {
         BufferedData bd = BufferedData.allocate(1);
         FieldDefinition definition = createFieldDefinition(BYTES);
         Bytes valToWrite = Bytes.wrap(new byte[] {1, 2});
-        assertThrows(BufferOverflowException.class, () -> writeBytes(bd, definition, valToWrite, true));
+        assertThrows(BufferOverflowException.class, () -> writeBytes(bd, definition, valToWrite));
     }
 
     @Test
@@ -412,7 +412,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(BYTES);
         Bytes valToWrite = Bytes.wrap(new byte[0]);
         final long positionBefore = bufferedData.position();
-        writeBytes(bufferedData, definition, valToWrite, true);
+        writeBytes(bufferedData, definition, valToWrite);
         final long positionAfter = bufferedData.position();
         assertEquals(positionAfter, positionBefore);
     }
@@ -421,7 +421,7 @@ class ProtoWriterToolsTest {
     void testWriteBytes() throws IOException {
         FieldDefinition definition = createFieldDefinition(BYTES);
         Bytes valToWrite = Bytes.wrap(RANDOM_STRING.nextString());
-        writeBytes(bufferedData, definition, valToWrite, true);
+        writeBytes(bufferedData, definition, valToWrite);
         bufferedData.flip();
         assertEquals((definition.number() << TAG_TYPE_BITS) | WIRE_TYPE_DELIMITED.ordinal(), bufferedData.readVarInt(false));
         int length = bufferedData.readVarInt(false);
@@ -683,21 +683,21 @@ class ProtoWriterToolsTest {
     void testSizeOfLong_int32() {
         FieldDefinition definition = createFieldDefinition(INT32);
         assertEquals(TAG_SIZE + MAX_VAR_INT_SIZE,
-                sizeOfInteger(definition, randomLargeInt(), true));
+                sizeOfInteger(definition, randomLargeInt()));
     }
 
     @Test
     void testSizeOfLong_uint32() {
         FieldDefinition definition = createFieldDefinition(UINT32);
         assertEquals(TAG_SIZE + MAX_VAR_INT_SIZE,
-                sizeOfInteger(definition, randomLargeInt(), true));
+                sizeOfInteger(definition, randomLargeInt()));
     }
 
     @Test
     void testSizeOfLong_sint32() {
         FieldDefinition definition = createFieldDefinition(SINT32);
         assertEquals(TAG_SIZE + MAX_VAR_INT_SIZE,
-                sizeOfInteger(definition, randomLargeNegativeInt(), true));
+                sizeOfInteger(definition, randomLargeNegativeInt()));
     }
 
     @ParameterizedTest
@@ -705,7 +705,7 @@ class ProtoWriterToolsTest {
     void testSizeOfLong_fixed32(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         assertEquals(TAG_SIZE + Integer.BYTES,
-                sizeOfInteger(definition, randomLargeNegativeInt(), true));
+                sizeOfInteger(definition, randomLargeNegativeInt()));
     }
 
     @ParameterizedTest
@@ -713,21 +713,21 @@ class ProtoWriterToolsTest {
             "FIXED64", "SFIXED64", "BOOL", "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testSizeOfInteger_notSupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> sizeOfInteger(definition, RNG.nextInt(), true));
+        assertThrows(RuntimeException.class, () -> sizeOfInteger(definition, RNG.nextInt()));
     }
 
     @Test
     void testSizeOfLong_int64() {
         FieldDefinition definition = createFieldDefinition(INT64);
         assertEquals(TAG_SIZE + MAX_VAR_LONG_SIZE,
-                sizeOfLong(definition, randomLargeLong(), true));
+                sizeOfLong(definition, randomLargeLong()));
     }
 
     @Test
     void testSizeOfLong_uint64() {
         FieldDefinition definition = createFieldDefinition(UINT64);
         assertEquals(TAG_SIZE + MAX_VAR_LONG_SIZE,
-                sizeOfLong(definition, randomLargeLong(), true));
+                sizeOfLong(definition, randomLargeLong()));
     }
 
     @Test
@@ -735,7 +735,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(SINT64);
         long value = randomLargeNegativeLong();
         assertEquals(TAG_SIZE + MAX_VAR_LONG_SIZE + 1 /* zigzag encoding */,
-                sizeOfLong(definition, value, true));
+                sizeOfLong(definition, value));
     }
 
     @ParameterizedTest
@@ -743,7 +743,7 @@ class ProtoWriterToolsTest {
     void testSizeOfLong_fixed64(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         assertEquals(TAG_SIZE + Long.BYTES,
-                sizeOfLong(definition, randomLargeNegativeInt(), true));
+                sizeOfLong(definition, randomLargeNegativeInt()));
     }
 
     @ParameterizedTest
@@ -751,7 +751,7 @@ class ProtoWriterToolsTest {
             "FIXED32", "SFIXED32", "BOOL", "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testSizeOfLong_notSupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> sizeOfLong(definition, RNG.nextLong(), true));
+        assertThrows(RuntimeException.class, () -> sizeOfLong(definition, RNG.nextLong()));
     }
 
     @Test
@@ -1049,19 +1049,19 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createFieldDefinition(STRING);
         final String str = randomVarSizeString();
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str, true));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str));
     }
 
     @Test
     void testSizeOfString_null() {
         final FieldDefinition definition = createFieldDefinition(STRING);
-        assertEquals(0, sizeOfString(definition, null, true));
+        assertEquals(0, sizeOfString(definition, null));
     }
 
     @Test
     void testSizeOfString_default() {
         final FieldDefinition definition = createFieldDefinition(STRING);
-        assertEquals(0, sizeOfString(definition, "", true));
+        assertEquals(0, sizeOfString(definition, ""));
     }
 
     @Test
@@ -1069,13 +1069,13 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createOneOfFieldDefinition(STRING);
         final String str = randomVarSizeString();
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str, true));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str));
     }
 
     @Test
     void testSizeOfString_oneOf_null(){
         final FieldDefinition definition = createOneOfFieldDefinition(STRING);
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE, sizeOfString(definition, null, true));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE, sizeOfString(definition, null));
     }
 
     @Test
@@ -1083,7 +1083,7 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createFieldDefinition(BYTES);
         final Bytes bytes = Bytes.wrap(randomVarSizeString());
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes, true));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes));
     }
 
     @Test
@@ -1091,7 +1091,7 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createFieldDefinition(BYTES);
         final Bytes bytes = Bytes.wrap("");
 
-        assertEquals(0, sizeOfBytes(definition, bytes, true));
+        assertEquals(0, sizeOfBytes(definition, bytes));
     }
 
     @Test
@@ -1099,7 +1099,7 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createOneOfFieldDefinition(BYTES);
         final Bytes bytes = Bytes.wrap(randomVarSizeString());
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes, true));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes));
     }
 
     @Test

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
@@ -157,7 +157,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(INT32);
         final int valToWrite = 0;
         final long positionBefore = bufferedData.position();
-        writeInteger(bufferedData, definition, valToWrite);
+        writeInteger(bufferedData, definition, valToWrite, true);
         final long positionAfter = bufferedData.position();
         assertEquals(positionBefore, positionAfter);
     }
@@ -172,7 +172,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_int32() {
         FieldDefinition definition = createFieldDefinition(INT32);
         final int valToWrite = nextNonZeroRandomInt();
-        writeInteger(bufferedData, definition, valToWrite);
+        writeInteger(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarInt(false));
@@ -182,7 +182,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_uint32() {
         FieldDefinition definition = createFieldDefinition(UINT32);
         int valToWrite = RNG.nextInt(1, Integer.MAX_VALUE);
-        writeInteger(bufferedData, definition, valToWrite);
+        writeInteger(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(false));
@@ -192,7 +192,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_sint32() {
         FieldDefinition definition = createFieldDefinition(SINT32);
         final int valToWrite = nextNonZeroRandomInt();
-        writeInteger(bufferedData, definition, valToWrite);
+        writeInteger(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarInt(true));
@@ -203,7 +203,7 @@ class ProtoWriterToolsTest {
     void testWriteInteger_fixed32(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         final int valToWrite = nextNonZeroRandomInt();
-        writeInteger(bufferedData, definition, valToWrite);
+        writeInteger(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertFixed32Tag(definition);
         assertEquals(valToWrite, bufferedData.readInt(ByteOrder.LITTLE_ENDIAN));
@@ -216,7 +216,7 @@ class ProtoWriterToolsTest {
             "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testWriteInteger_unsupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> writeInteger(bufferedData, definition, RNG.nextInt()));
+        assertThrows(RuntimeException.class, () -> writeInteger(bufferedData, definition, RNG.nextInt(), true));
     }
 
     @Test
@@ -224,7 +224,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(INT64);
         final long valToWrite = 0L;
         final long positionBefore = bufferedData.position();
-        writeLong(bufferedData, definition, valToWrite);
+        writeLong(bufferedData, definition, valToWrite, true);
         final long positionAfter = bufferedData.position();
         assertEquals(positionBefore, positionAfter);
     }
@@ -239,7 +239,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_int64() {
         FieldDefinition definition = createFieldDefinition(INT64);
         final long valToWrite = nextNonZeroRandomLong();
-        writeLong(bufferedData, definition, valToWrite);
+        writeLong(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(false));
@@ -249,7 +249,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_uint64() {
         FieldDefinition definition = createFieldDefinition(UINT64);
         final long valToWrite = RNG.nextLong(1, Long.MAX_VALUE);
-        writeLong(bufferedData, definition, valToWrite);
+        writeLong(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(false));
@@ -259,7 +259,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_sint64() {
         FieldDefinition definition = createFieldDefinition(SINT64);
         final int valToWrite = nextNonZeroRandomInt();
-        writeLong(bufferedData, definition, valToWrite);
+        writeLong(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(valToWrite, bufferedData.readVarLong(true));
@@ -270,7 +270,7 @@ class ProtoWriterToolsTest {
     void testWriteLong_fixed64(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         final long valToWrite = nextNonZeroRandomLong();
-        writeLong(bufferedData, definition, valToWrite);
+        writeLong(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertEquals((definition.number() << TAG_TYPE_BITS) | WIRE_TYPE_FIXED_64_BIT.ordinal(), bufferedData.readVarInt(false));
         assertEquals(valToWrite, bufferedData.readLong(ByteOrder.LITTLE_ENDIAN));
@@ -283,7 +283,7 @@ class ProtoWriterToolsTest {
             "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testWriteLong_unsupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> writeLong(bufferedData, definition, RNG.nextInt()));
+        assertThrows(RuntimeException.class, () -> writeLong(bufferedData, definition, RNG.nextInt(), true));
     }
 
     private static float nextNonZeroRandomFloat() {
@@ -321,7 +321,7 @@ class ProtoWriterToolsTest {
     @Test
     void testWriteBoolean_true() {
         FieldDefinition definition = createFieldDefinition(BOOL);
-        ProtoWriterTools.writeBoolean(bufferedData, definition, true);
+        ProtoWriterTools.writeBoolean(bufferedData, definition, true, true);
         bufferedData.flip();
         assertVarIntTag(definition);
         assertEquals(1, bufferedData.readVarInt(false));
@@ -330,7 +330,7 @@ class ProtoWriterToolsTest {
     @Test
     void testWriteBoolean_false() {
         FieldDefinition definition = createFieldDefinition(BOOL);
-        ProtoWriterTools.writeBoolean(bufferedData, definition, false);
+        ProtoWriterTools.writeBoolean(bufferedData, definition, false, true);
         bufferedData.flip();
         assertEquals(0, bufferedData.length());
     }
@@ -368,7 +368,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(STRING);
         String valToWrite = "";
         final long positionBefore = bufferedData.position();
-        writeString(bufferedData, definition, valToWrite);
+        writeString(bufferedData, definition, valToWrite, true);
         final long positionAfter = bufferedData.position();
         assertEquals(positionAfter, positionBefore);
     }
@@ -377,7 +377,7 @@ class ProtoWriterToolsTest {
     void testWriteString() throws IOException {
         FieldDefinition definition = createFieldDefinition(STRING);
         String valToWrite = RANDOM_STRING.nextString();
-        writeString(bufferedData, definition, valToWrite);
+        writeString(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertEquals((definition.number() << TAG_TYPE_BITS) | WIRE_TYPE_DELIMITED.ordinal(), bufferedData.readVarInt(false));
         int length = bufferedData.readVarInt(false);
@@ -404,7 +404,7 @@ class ProtoWriterToolsTest {
         BufferedData bd = BufferedData.allocate(1);
         FieldDefinition definition = createFieldDefinition(BYTES);
         Bytes valToWrite = Bytes.wrap(new byte[] {1, 2});
-        assertThrows(BufferOverflowException.class, () -> writeBytes(bd, definition, valToWrite));
+        assertThrows(BufferOverflowException.class, () -> writeBytes(bd, definition, valToWrite, true));
     }
 
     @Test
@@ -412,7 +412,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(BYTES);
         Bytes valToWrite = Bytes.wrap(new byte[0]);
         final long positionBefore = bufferedData.position();
-        writeBytes(bufferedData, definition, valToWrite);
+        writeBytes(bufferedData, definition, valToWrite, true);
         final long positionAfter = bufferedData.position();
         assertEquals(positionAfter, positionBefore);
     }
@@ -421,7 +421,7 @@ class ProtoWriterToolsTest {
     void testWriteBytes() throws IOException {
         FieldDefinition definition = createFieldDefinition(BYTES);
         Bytes valToWrite = Bytes.wrap(RANDOM_STRING.nextString());
-        writeBytes(bufferedData, definition, valToWrite);
+        writeBytes(bufferedData, definition, valToWrite, true);
         bufferedData.flip();
         assertEquals((definition.number() << TAG_TYPE_BITS) | WIRE_TYPE_DELIMITED.ordinal(), bufferedData.readVarInt(false));
         int length = bufferedData.readVarInt(false);
@@ -683,21 +683,21 @@ class ProtoWriterToolsTest {
     void testSizeOfLong_int32() {
         FieldDefinition definition = createFieldDefinition(INT32);
         assertEquals(TAG_SIZE + MAX_VAR_INT_SIZE,
-                sizeOfInteger(definition, randomLargeInt()));
+                sizeOfInteger(definition, randomLargeInt(), true));
     }
 
     @Test
     void testSizeOfLong_uint32() {
         FieldDefinition definition = createFieldDefinition(UINT32);
         assertEquals(TAG_SIZE + MAX_VAR_INT_SIZE,
-                sizeOfInteger(definition, randomLargeInt()));
+                sizeOfInteger(definition, randomLargeInt(), true));
     }
 
     @Test
     void testSizeOfLong_sint32() {
         FieldDefinition definition = createFieldDefinition(SINT32);
         assertEquals(TAG_SIZE + MAX_VAR_INT_SIZE,
-                sizeOfInteger(definition, randomLargeNegativeInt()));
+                sizeOfInteger(definition, randomLargeNegativeInt(), true));
     }
 
     @ParameterizedTest
@@ -705,7 +705,7 @@ class ProtoWriterToolsTest {
     void testSizeOfLong_fixed32(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         assertEquals(TAG_SIZE + Integer.BYTES,
-                sizeOfInteger(definition, randomLargeNegativeInt()));
+                sizeOfInteger(definition, randomLargeNegativeInt(), true));
     }
 
     @ParameterizedTest
@@ -713,21 +713,21 @@ class ProtoWriterToolsTest {
             "FIXED64", "SFIXED64", "BOOL", "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testSizeOfInteger_notSupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> sizeOfInteger(definition, RNG.nextInt()));
+        assertThrows(RuntimeException.class, () -> sizeOfInteger(definition, RNG.nextInt(), true));
     }
 
     @Test
     void testSizeOfLong_int64() {
         FieldDefinition definition = createFieldDefinition(INT64);
         assertEquals(TAG_SIZE + MAX_VAR_LONG_SIZE,
-                sizeOfLong(definition, randomLargeLong()));
+                sizeOfLong(definition, randomLargeLong(), true));
     }
 
     @Test
     void testSizeOfLong_uint64() {
         FieldDefinition definition = createFieldDefinition(UINT64);
         assertEquals(TAG_SIZE + MAX_VAR_LONG_SIZE,
-                sizeOfLong(definition, randomLargeLong()));
+                sizeOfLong(definition, randomLargeLong(), true));
     }
 
     @Test
@@ -735,7 +735,7 @@ class ProtoWriterToolsTest {
         FieldDefinition definition = createFieldDefinition(SINT64);
         long value = randomLargeNegativeLong();
         assertEquals(TAG_SIZE + MAX_VAR_LONG_SIZE + 1 /* zigzag encoding */,
-                sizeOfLong(definition, value));
+                sizeOfLong(definition, value, true));
     }
 
     @ParameterizedTest
@@ -743,7 +743,7 @@ class ProtoWriterToolsTest {
     void testSizeOfLong_fixed64(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
         assertEquals(TAG_SIZE + Long.BYTES,
-                sizeOfLong(definition, randomLargeNegativeInt()));
+                sizeOfLong(definition, randomLargeNegativeInt(), true));
     }
 
     @ParameterizedTest
@@ -751,7 +751,7 @@ class ProtoWriterToolsTest {
             "FIXED32", "SFIXED32", "BOOL", "STRING", "BYTES", "ENUM", "MESSAGE"})
     void testSizeOfLong_notSupported(FieldType type) {
         FieldDefinition definition = createFieldDefinition(type);
-        assertThrows(RuntimeException.class, () -> sizeOfLong(definition, RNG.nextLong()));
+        assertThrows(RuntimeException.class, () -> sizeOfLong(definition, RNG.nextLong(), true));
     }
 
     @Test
@@ -1049,19 +1049,19 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createFieldDefinition(STRING);
         final String str = randomVarSizeString();
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str, true));
     }
 
     @Test
     void testSizeOfString_null() {
         final FieldDefinition definition = createFieldDefinition(STRING);
-        assertEquals(0, sizeOfString(definition, null));
+        assertEquals(0, sizeOfString(definition, null, true));
     }
 
     @Test
     void testSizeOfString_default() {
         final FieldDefinition definition = createFieldDefinition(STRING);
-        assertEquals(0, sizeOfString(definition, ""));
+        assertEquals(0, sizeOfString(definition, "", true));
     }
 
     @Test
@@ -1069,13 +1069,13 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createOneOfFieldDefinition(STRING);
         final String str = randomVarSizeString();
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + str.length(), sizeOfString(definition, str, true));
     }
 
     @Test
     void testSizeOfString_oneOf_null(){
         final FieldDefinition definition = createOneOfFieldDefinition(STRING);
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE, sizeOfString(definition, null));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE, sizeOfString(definition, null, true));
     }
 
     @Test
@@ -1083,7 +1083,7 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createFieldDefinition(BYTES);
         final Bytes bytes = Bytes.wrap(randomVarSizeString());
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes, true));
     }
 
     @Test
@@ -1091,7 +1091,7 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createFieldDefinition(BYTES);
         final Bytes bytes = Bytes.wrap("");
 
-        assertEquals(0, sizeOfBytes(definition, bytes));
+        assertEquals(0, sizeOfBytes(definition, bytes, true));
     }
 
     @Test
@@ -1099,7 +1099,7 @@ class ProtoWriterToolsTest {
         final FieldDefinition definition = createOneOfFieldDefinition(BYTES);
         final Bytes bytes = Bytes.wrap(randomVarSizeString());
 
-        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes));
+        assertEquals(MIN_LENGTH_VAR_SIZE + TAG_SIZE + bytes.length(), sizeOfBytes(definition, bytes, true));
     }
 
     @Test

--- a/pbj-integration-tests/src/main/proto/everything.proto
+++ b/pbj-integration-tests/src/main/proto/everything.proto
@@ -33,6 +33,12 @@ message Everything {
 
   InnerEverything innerEverything = 50;
 
+  map<int32, string> mapInt32ToString = 71;
+  map<bool, double> mapBoolToDouble = 72;
+  map<string, InnerEverything> mapStringToMessage = 73;
+  map<uint64, bytes> mapUInt64ToBytes = 74;
+  map<int64, bool> mapInt64ToBool = 75;
+
   repeated int32 int32NumberList = 100;
   repeated sint32 sint32NumberList = 102;
   repeated uint32 uint32NumberList = 103;

--- a/pbj-integration-tests/src/main/proto/map.proto
+++ b/pbj-integration-tests/src/main/proto/map.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+/**
+ * Sample protobuf containing maps.
+ */
+message MessageWithMaps {
+  /** A test map. */
+  map<int32, string> mapInt32ToString = 1;
+}
+
+/**
+ * Sample protobuf containing multiple different maps.
+ */
+message MessageWithManyMaps {
+  map<int32, string> mapInt32ToString = 1;
+  map<bool, double> mapBoolToDouble = 2;
+  map<string, MessageWithMaps> mapStringToMessage = 3;
+  map<uint64, bytes> mapUInt64ToBytes = 4;
+  map<int64, bool> mapInt64ToBool = 5;
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/SampleFuzzTest.java
@@ -70,7 +70,7 @@ public class SampleFuzzTest {
      * if the mean value of all the individual DESERIALIZATION_FAILED
      * shares is greater than this threshold.
      */
-    private static final double DESERIALIZATION_FAILED_MEAN_THRESHOLD = .983;
+    private static final double DESERIALIZATION_FAILED_MEAN_THRESHOLD = .9829;
 
     /**
      * Fuzz tests are tagged with this tag to allow Gradle/JUnit


### PR DESCRIPTION
**Description**:
Introducing support for map fields in PBJ.

I apologize for the size of the PR but it would be close to impossible to break it up into reasonable pieces because all the code is deeply interconnected and needs to be updated all at once when adding a new field type.

Short summary:
1. The compiler is updated to generate Protobuf and JSON models/codecs for messages with map fields.
2. In models, the maps are present as instances of a new `PbjMap` class that implements an immutable map and provides access to a list of sorted keys to support deterministic iteration over the map entries.
3. Per the spec and the implementation of maps in protoc, they are... strange. In general, on the wire they're presented as repeated entry messages with key/value fields. However, unlike normal protobuf messages, the entries always serialize key and value values, even when the values are "default" (e.g. "" for a string, or 0 for an int, etc.) This peculiarity required quite a bit of refactoring in the codec generator. All those `skipDefault`-related changes are here to support just this.


**Related issue(s)**:

Fixes #254 

**Notes for reviewer**:
1. All the tests, including the integration and fuzz tests pass.
2. A new test model `map.proto` is added to test various maps.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
