### PR TITLE
fix: avoid `BufferOverflowException` in generated JSON serialization unit tests

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
@@ -23,7 +23,7 @@ public final class ProtoTestTools {
     private static final int BUFFER_SIZE = 1024*1024;
 
     /** Size for reusable test char buffers */
-    private static final int CHAR_BUFFER_SIZE = 1024*1024;
+    private static final int CHAR_BUFFER_SIZE = 2*1024*1024;
 
     /** Instance should never be created */
     private ProtoTestTools() {}


### PR DESCRIPTION
**Description**:
 - Closes #269 