### PR TITLE
ci: update the runs-on labels for improved clarity

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   prepare-release:
     name: Release / Prepare
-    runs-on: network-node-linux-medium
+    runs-on: network-node-auxiliary-linux-medium
     outputs:
       mode: ${{ steps.info.outputs.mode }}
       version: ${{ steps.info.outputs.version }}
@@ -78,7 +78,7 @@ jobs:
 
   maven-central-release:
     name: Release / Maven Central
-    runs-on: network-node-linux-medium
+    runs-on: network-node-auxiliary-linux-medium
     needs:
       - prepare-release
     if: |

--- a/.github/workflows/zxc-compile-pbj-code.yaml
+++ b/.github/workflows/zxc-compile-pbj-code.yaml
@@ -71,7 +71,7 @@ env:
 jobs:
   compile:
     name: ${{ inputs.custom-job-label || 'Compiles' }}
-    runs-on: network-node-linux-medium
+    runs-on: network-node-auxiliary-linux-medium
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
**Description**:

This pull request changes the CI runner labels for improved clarity and distinction between the Dallas and Chicago clusters.

**Related issue(s)**:

Fixes #276

