### PR TITLE
fix: 284: writeByte() may be improved for byte array based BufferedData

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Utf8Tools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Utf8Tools.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.WritableSequentialData;
-
-import java.io.IOException;
-
 import static java.lang.Character.*;
+
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import java.io.IOException;
 
 /**
  * UTF8 tools based on protobuf standard library, so we are byte for byte identical
@@ -75,7 +90,6 @@ public final class Utf8Tools {
         return utf8Length;
     }
 
-
     /**
      * Encodes the input character sequence to a {@link WritableSequentialData} using the same algorithm as protoc, so we are
      * byte for byte the same.
@@ -91,16 +105,16 @@ public final class Utf8Tools {
                 // Two bytes (110x xxxx 10xx xxxx)
 
                 // Benchmarks show put performs better than putShort here (for HotSpot).
-                out.writeByte((byte) (0xC0 | (c >>> 6)));
-                out.writeByte((byte) (0x80 | (0x3F & c)));
+                out.writeByte2((byte) (0xC0 | (c >>> 6)), (byte) (0x80 | (0x3F & c)));
             } else if (c < MIN_SURROGATE || MAX_SURROGATE < c) {
                 // Three bytes (1110 xxxx 10xx xxxx 10xx xxxx)
                 // Maximum single-char code point is 0xFFFF, 16 bits.
 
                 // Benchmarks show put performs better than putShort here (for HotSpot).
-                out.writeByte((byte) (0xE0 | (c >>> 12)));
-                out.writeByte((byte) (0x80 | (0x3F & (c >>> 6))));
-                out.writeByte((byte) (0x80 | (0x3F & c)));
+                out.writeByte3(
+                        (byte) (0xE0 | (c >>> 12)),
+                        (byte) (0x80 | (0x3F & (c >>> 6))),
+                        (byte) (0x80 | (0x3F & c)));
             } else {
                 // Four bytes (1111 xxxx 10xx xxxx 10xx xxxx 10xx xxxx)
                 // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
@@ -109,10 +123,11 @@ public final class Utf8Tools {
                     throw new MalformedProtobufException("Unpaired surrogate at index " + inIx + " of " + inLength);
                 }
                 int codePoint = toCodePoint(c, low);
-                out.writeByte((byte) ((0xF << 4) | (codePoint >>> 18)));
-                out.writeByte((byte) (0x80 | (0x3F & (codePoint >>> 12))));
-                out.writeByte((byte) (0x80 | (0x3F & (codePoint >>> 6))));
-                out.writeByte((byte) (0x80 | (0x3F & codePoint)));
+                out.writeByte4(
+                        (byte) ((0xF << 4) | (codePoint >>> 18)),
+                        (byte) (0x80 | (0x3F & (codePoint >>> 12))),
+                        (byte) (0x80 | (0x3F & (codePoint >>> 6))),
+                        (byte) (0x80 | (0x3F & codePoint)));
             }
         }
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/WritableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/WritableSequentialData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.pbj.runtime.io;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
@@ -27,6 +43,36 @@ public interface WritableSequentialData extends SequentialData {
      * @throws UncheckedIOException if an I/O error occurs
      */
     void writeByte(byte b) throws BufferOverflowException, UncheckedIOException;
+
+    /**
+     * Writes two bytes. Some implementations may implement this method more efficiently than two
+     * calls to {@link #writeByte(byte)} or a call to {@link #writeBytes(byte[])}.
+     */
+    default void writeByte2(byte b1, byte b2) {
+        writeByte(b1);
+        writeByte(b2);
+    }
+
+    /**
+     * Writes three bytes. Some implementations may implement this method more efficiently than two
+     * calls to {@link #writeByte(byte)} or a call to {@link #writeBytes(byte[])}.
+     */
+    default void writeByte3(byte b1, byte b2, byte b3) {
+        writeByte(b1);
+        writeByte(b2);
+        writeByte(b3);
+    }
+
+    /**
+     * Writes grou bytes. Some implementations may implement this method more efficiently than two
+     * calls to {@link #writeByte(byte)} or a call to {@link #writeBytes(byte[])}.
+     */
+    default void writeByte4(byte b1, byte b2, byte b3, byte b4) {
+        writeByte(b1);
+        writeByte(b2);
+        writeByte(b3);
+        writeByte(b4);
+    }
 
     /**
      * Writes the given unsigned byte at the current {@link #position()}, and then increments the {@link #position()}.
@@ -72,7 +118,7 @@ public interface WritableSequentialData extends SequentialData {
             throw new IllegalArgumentException("length must be >= 0");
         }
 
-        for (int i = offset; i < (offset+length); i++) {
+        for (int i = offset; i < (offset + length); i++) {
             writeByte(src[i]);
         }
     }
@@ -92,7 +138,7 @@ public interface WritableSequentialData extends SequentialData {
             throw new BufferOverflowException();
         }
 
-        while(src.hasRemaining()) {
+        while (src.hasRemaining()) {
             writeByte(src.get());
         }
     }
@@ -111,7 +157,7 @@ public interface WritableSequentialData extends SequentialData {
             throw new BufferOverflowException();
         }
 
-        while(src.hasRemaining()) {
+        while (src.hasRemaining()) {
             writeByte(src.readByte());
         }
     }
@@ -209,10 +255,7 @@ public interface WritableSequentialData extends SequentialData {
         if (remaining() < Integer.BYTES) {
             throw new BufferOverflowException();
         }
-        writeByte((byte)(value >>> 24));
-        writeByte((byte)(value >>> 16));
-        writeByte((byte)(value >>>  8));
-        writeByte((byte)(value));
+        writeByte4((byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) (value));
     }
 
     /**
@@ -232,10 +275,7 @@ public interface WritableSequentialData extends SequentialData {
             if (remaining() < Integer.BYTES) {
                 throw new BufferOverflowException();
             }
-            writeByte((byte) (value));
-            writeByte((byte) (value >>> 8));
-            writeByte((byte) (value >>> 16));
-            writeByte((byte) (value >>> 24));
+            writeByte4((byte) (value), (byte) (value >>> 8), (byte) (value >>> 16), (byte) (value >>> 24));
         }
     }
 
@@ -251,10 +291,7 @@ public interface WritableSequentialData extends SequentialData {
         if (remaining() < Integer.BYTES) {
             throw new BufferOverflowException();
         }
-        writeByte((byte)(value >>> 24));
-        writeByte((byte)(value >>> 16));
-        writeByte((byte)(value >>>  8));
-        writeByte((byte)(value));
+        writeByte4((byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) (value));
     }
 
     /**
@@ -274,10 +311,7 @@ public interface WritableSequentialData extends SequentialData {
             if (remaining() < Integer.BYTES) {
                 throw new BufferOverflowException();
             }
-            writeByte((byte) (value));
-            writeByte((byte) (value >>> 8));
-            writeByte((byte) (value >>> 16));
-            writeByte((byte) (value >>> 24));
+            writeByte4((byte) (value), (byte) (value >>> 8), (byte) (value >>> 16), (byte) (value >>> 24));
         }
     }
 
@@ -293,14 +327,8 @@ public interface WritableSequentialData extends SequentialData {
         if (remaining() < Long.BYTES) {
             throw new BufferOverflowException();
         }
-        writeByte((byte)(value >>> 56));
-        writeByte((byte)(value >>> 48));
-        writeByte((byte)(value >>> 40));
-        writeByte((byte)(value >>> 32));
-        writeByte((byte)(value >>> 24));
-        writeByte((byte)(value >>> 16));
-        writeByte((byte)(value >>>  8));
-        writeByte((byte)(value));
+        writeByte4((byte) (value >>> 56), (byte) (value >>> 48), (byte) (value >>> 40), (byte) (value >>> 32));
+        writeByte4((byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) (value));
     }
 
     /**
@@ -320,14 +348,8 @@ public interface WritableSequentialData extends SequentialData {
             if (remaining() < Long.BYTES) {
                 throw new BufferOverflowException();
             }
-            writeByte((byte) (value));
-            writeByte((byte) (value >>> 8));
-            writeByte((byte) (value >>> 16));
-            writeByte((byte) (value >>> 24));
-            writeByte((byte) (value >>> 32));
-            writeByte((byte) (value >>> 40));
-            writeByte((byte) (value >>> 48));
-            writeByte((byte) (value >>> 56));
+            writeByte4((byte) (value), (byte) (value >>> 8), (byte) (value >>> 16), (byte) (value >>> 24));
+            writeByte4((byte) (value >>> 32), (byte) (value >>> 40), (byte) (value >>> 48), (byte) (value >>> 56));
         }
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.pbj.runtime.io.buffer;
 
 import com.hedera.pbj.runtime.io.DataEncodingException;
@@ -281,9 +297,37 @@ final class ByteArrayBufferedData extends BufferedData {
         buffer.position(pos + 1);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
+    public void writeByte2(final byte b1, final byte b2) {
+        validateCanWrite(2);
+        final int pos = buffer.position();
+        array[arrayOffset + pos] = b1;
+        array[arrayOffset + pos + 1] = b2;
+        buffer.position(pos + 2);
+    }
+
+    @Override
+    public void writeByte3(final byte b1, final byte b2, final byte b3) {
+        validateCanWrite(3);
+        final int pos = buffer.position();
+        array[arrayOffset + pos] = b1;
+        array[arrayOffset + pos + 1] = b2;
+        array[arrayOffset + pos + 2] = b3;
+        buffer.position(pos + 3);
+    }
+
+    @Override
+    public void writeByte4(final byte b1, final byte b2, final byte b3, final byte b4) {
+        validateCanWrite(4);
+        final int pos = buffer.position();
+        array[arrayOffset + pos] = b1;
+        array[arrayOffset + pos + 1] = b2;
+        array[arrayOffset + pos + 2] = b3;
+        array[arrayOffset + pos + 3] = b4;
+        buffer.position(pos + 4);
+    }
+
+    /** {@inheritDoc} */
     @Override
     public void writeBytes(@NonNull final byte[] src, final int offset, final int len) {
         validateLen(len);


### PR DESCRIPTION
Fix summary:

* Introduced `writeByte2()`, `writeByte3()`, and `writeByte4()` methods to `WritableSequentialData`
* By default, the methods just call `writeByte()` the right number of times
* In `ByteArrayBufferedData` the methods are implemented more efficiently than N calls to `writeByte()`

Performance:

* In `ProtobufObjectBench`, writing `Everything` to byte array output is about 12% faster than previously

Fixes: https://github.com/hashgraph/pbj/issues/284
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
