### PR TITLE
fix: upgraded helidon, grpc and protoc versions to work with Block Node

### DIFF
--- a/pbj-core/gradle/plugins/src/main/kotlin/com.hedera.pbj.protoc.gradle.kts
+++ b/pbj-core/gradle/plugins/src/main/kotlin/com.hedera.pbj.protoc.gradle.kts
@@ -20,11 +20,11 @@ protobuf {
     // Configure the protoc executable
     protoc {
         // Download from repositories
-        artifact = "com.google.protobuf:protoc:3.21.10"
+        artifact = "com.google.protobuf:protoc:4.28.2"
     }
     plugins {
         create("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.64.0"
+            artifact = "io.grpc:protoc-gen-grpc-java:1.65.1"
         }
     }
 

--- a/pbj-core/pbj-grpc-helidon-config/src/main/java/com/hedera/pbj/grpc/helidon/config/PbjConfigBlueprint.java
+++ b/pbj-core/pbj-grpc-helidon-config/src/main/java/com/hedera/pbj/grpc/helidon/config/PbjConfigBlueprint.java
@@ -21,7 +21,7 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.webserver.spi.ProtocolConfig;
 
 @Prototype.Blueprint
-@Prototype.Configured
+@Prototype.Configured("pbj")
 @Prototype.Provides(ProtocolConfig.class)
 interface PbjConfigBlueprint extends ProtocolConfig {
     /**

--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -33,9 +33,9 @@ gradleEnterprise {
     }
 }
 
-var helidonVersion = "4.0.8"
-var grpcVersion = "1.61.1"
-var protobufVersion = "3.21.10"
+var helidonVersion = "4.1.1"
+var grpcVersion = "1.65.1"
+var protobufVersion = "4.28.2"
 
 dependencyResolutionManagement {
     versionCatalogs {


### PR DESCRIPTION
**Description**:
Upgraded Helidon, grpc and protoc versions to integrate with the latest version of Block Node

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
