### PR TITLE
fix: 298: ReadableStreamingData.skip() doesn't check the number of actually skipped bytes 

### DIFF
--- a/pbj-core/gradle.properties
+++ b/pbj-core/gradle.properties
@@ -1,5 +1,5 @@
 # Version number
-version=0.9.4-SNAPSHOT
+version=0.9.5-SNAPSHOT
 
 # Need increased heap for running Gradle itself, or SonarQube will run the JVM out of metaspace
 org.gradle.jvmargs=-Xmx2048m

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SequentialData.java
@@ -79,8 +79,7 @@ public interface SequentialData {
      * {@link #limit()}, then a buffer overflow or underflow exception is thrown.
      *
      * @param count number of bytes to skip. If 0 or negative, then no bytes are skipped.
-     * @return the actual number of bytes skipped.
      * @throws UncheckedIOException if an I/O error occurs
      */
-    long skip(long count) throws UncheckedIOException;
+    void skip(long count) throws UncheckedIOException;
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
@@ -296,16 +296,15 @@ public sealed class BufferedData
      * {@inheritDoc}
      */
     @Override
-    public long skip(final long count) {
+    public void skip(final long count) {
         if (count > Integer.MAX_VALUE || (int) count > buffer.remaining()) {
             throw new BufferUnderflowException();
         }
         if (count <= 0) {
-            return 0;
+            return;
         }
 
         buffer.position(buffer.position() + (int) count);
-        return count;
     }
 
     // ================================================================================================================

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessSequenceAdapter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessSequenceAdapter.java
@@ -83,16 +83,15 @@ final class RandomAccessSequenceAdapter implements ReadableSequentialData {
 
     /** {@inheritDoc} */
     @Override
-    public long skip(final long count) {
+    public void skip(final long count) {
         if (count > remaining()) {
             throw new BufferUnderflowException();
         }
         if (count <= 0) {
-            return 0;
+            return;
         }
 
         position += count;
-        return count;
     }
 
     // ================================================================================================================

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -151,21 +151,27 @@ public class ReadableStreamingData implements ReadableSequentialData, Closeable 
         }
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * @throws BufferUnderflowException if {@code count} would move the position past the {@link #limit()}.
+     */
     @Override
-    public long skip(final long n) {
+    public void skip(final long n) {
         if (position + n > limit) {
             throw new BufferUnderflowException();
         }
 
         if (n <= 0) {
-            return 0;
+            return;
         }
 
         try {
-            long numSkipped = in.skip(n);
-            position += numSkipped;
-            return numSkipped;
+            long toSkip = n;
+            while (toSkip > 0) {
+                toSkip -= in.skip(toSkip);
+            }
+            position += n;
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/CharBufferToWritableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/test/CharBufferToWritableSequentialData.java
@@ -39,16 +39,15 @@ public class CharBufferToWritableSequentialData implements WritableSequentialDat
     }
 
     @Override
-    public long skip(long count) {
+    public void skip(long count) {
         if (count > charBuffer.remaining()) {
             throw new BufferUnderflowException();
         }
         if (count <= 0) {
-            return 0;
+            return;
         }
         // Note: skip() should be relative. But it's okay, this is a test implementation.
         charBuffer.position((int) count);
-        return count;
     }
 
     @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialDataTest.java
@@ -112,15 +112,14 @@ final class ReadableSequentialDataTest extends ReadableSequentialTestBase {
         }
 
         @Override
-        public long skip(long count) {
+        public void skip(long count) {
             if (count > limit - position) {
                 throw new BufferUnderflowException();
             }
             if (count <= 0) {
-                return 0;
+                return;
             }
             position += count;
-            return count;
         }
 
         @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
@@ -61,7 +61,7 @@ public abstract class ReadableSequentialTestBase extends ReadableTestBase {
         stream.readBytes(bytes, 0, 4);
         assertThat(stream.position()).isEqualTo(4);
         assertThat(bytes).containsExactly('W', 'h', 'a', 't', 0);
-        assertThat(stream.skip(3)).isEqualTo(3);
+        stream.skip(3);
         assertThat(stream.position()).isEqualTo(7);
         stream.readBytes(bytes);
         assertThat(stream.position()).isEqualTo(12);
@@ -73,7 +73,7 @@ public abstract class ReadableSequentialTestBase extends ReadableTestBase {
     @DisplayName("Skip some bytes, read some bytes")
     void skipSomeReadSomeTest() {
         final var stream = sequence("What a dream!!".getBytes(StandardCharsets.UTF_8));
-        assertThat(stream.skip(7)).isEqualTo(7);
+        stream.skip(7);
         final var bytes = new byte[5];
         stream.readBytes(bytes);
         assertThat(stream.position()).isEqualTo(12);

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableTestBase.java
@@ -678,7 +678,7 @@ public abstract class ReadableTestBase extends SequentialTestBase {
             // Given a sequence of bytes where the position is 10 bytes from the end
             final var seq = sequence(TEST_BYTES);
             final var startIndex = TEST_BYTES.length - 10;
-            assertThat(seq.skip(startIndex)).isEqualTo(16);
+            seq.skip(startIndex);
             assertThat(seq.position()).isEqualTo(16);
             // When we create a view with a length of 10 bytes
             final var view = seq.view(10);

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/SequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/SequentialDataTest.java
@@ -48,7 +48,7 @@ final class SequentialDataTest {
         }
 
         @Override
-        public long skip(long count) {
+        public void skip(long count) {
             throw new UnsupportedOperationException("Not implemented in this test");
         }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/SequentialTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/SequentialTestBase.java
@@ -123,7 +123,7 @@ public abstract class SequentialTestBase {
             final var seq = sequence();
             // When we set the limit to be between the position and capacity, and we skip those bytes
             seq.limit(5);
-            assertThat(seq.skip(skip)).isEqualTo(expected);
+            seq.skip(skip);
             // Then the position matches the number of bytes actually skipped, taking into account
             // whether the number of bytes skipped was clamped due to encountering the limit
             // or not (The "expected" arg tells us where we should have landed after skipping bytes)

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableSequentialDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableSequentialDataTest.java
@@ -60,15 +60,14 @@ final class WritableSequentialDataTest extends WritableTestBase {
         }
 
         @Override
-        public long skip(long count) {
+        public void skip(long count) {
             if (count > limit - position) {
                 throw new BufferUnderflowException();
             }
             if (count <= 0) {
-                return 0;
+                return;
             }
             position += count;
-            return count;
         }
 
         @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingDataTest.java
@@ -195,7 +195,7 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
         };
 
         final var stream = new ReadableStreamingData(inputStream);
-        assertThat(stream.skip(5)).isEqualTo(5);
+        stream.skip(5);
 
         throwNow.set(true);
         assertThatThrownBy(stream::readByte)
@@ -386,8 +386,8 @@ final class ReadableStreamingDataTest extends ReadableSequentialTestBase {
         }
 
         @Override
-        public long skip(long count) {
-            return readableStreamingData.skip(count);
+        public void skip(long count) {
+            readableStreamingData.skip(count);
         }
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/ParserNeverWrapsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/intergration/test/ParserNeverWrapsTest.java
@@ -58,10 +58,9 @@ public class ParserNeverWrapsTest {
         }
 
         @Override
-        public long skip(long count) {
+        public void skip(long count) {
             // This doesn't matter in this test
             position += count;
-            return count;
         }
 
         @Override


### PR DESCRIPTION
Fix summary:
* `SequentialData.skip()` is updated to always skip the requested number of bytes
* `ReadableStreamingData.skip()` is improved to call `skip()` on the underlying input stream in a loop, till the requested number of bytes is skipped

Fixes: https://github.com/hashgraph/pbj/issues/298
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
