### PR TITLE
fix: Make server keep connection open after receiving ES

### DIFF
--- a/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/GreeterService.java
+++ b/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/GreeterService.java
@@ -18,6 +18,7 @@ package com.hedera.pbj.grpc.helidon;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.Pipelines;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -46,14 +47,14 @@ public interface GreeterService extends ServiceInterface {
     HelloReply sayHello(HelloRequest request);
 
     // A stream of messages coming from the client, with a single response from the server.
-    Flow.Subscriber<? super HelloRequest> sayHelloStreamRequest(
+    Pipeline<? super HelloRequest> sayHelloStreamRequest(
             Flow.Subscriber<? super HelloReply> replies);
 
     // A single request from the client, with a stream of responses from the server.
     void sayHelloStreamReply(HelloRequest request, Flow.Subscriber<? super HelloReply> replies);
 
     // A bidirectional stream of requests and responses between the client and the server.
-    Flow.Subscriber<? super HelloRequest> sayHelloStreamBidi(
+    Pipeline<? super HelloRequest> sayHelloStreamBidi(
             Flow.Subscriber<? super HelloReply> replies);
 
     @NonNull
@@ -73,7 +74,7 @@ public interface GreeterService extends ServiceInterface {
 
     @Override
     @NonNull
-    default Flow.Subscriber<? super Bytes> open(
+    default Pipeline<? super Bytes> open(
             final @NonNull Method method,
             final @NonNull RequestOptions options,
             final @NonNull Flow.Subscriber<? super Bytes> replies) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipeline.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipeline.java
@@ -1,0 +1,15 @@
+package com.hedera.pbj.runtime.grpc;
+
+import java.util.concurrent.Flow;
+
+/**
+ * Represents a pipeline of data that is being processed by a gRPC service.
+ *
+ * @param <T> The subscribed item type
+ */
+public interface Pipeline<T> extends Flow.Subscriber<T> {
+    /**
+     * Called when an END_STREAM frame is received from the client.
+     */
+    void clientEndStreamReceived();
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipelines.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipelines.java
@@ -442,6 +442,13 @@ public final class Pipelines {
         @Override
         public void onComplete() {
             completed = true;
+        }
+
+        /**
+         * Implementing classes may choose to call this method and complete replies, but they have
+         * the option to not complete the replies.
+         */
+        protected void completeReplies() {
             if (replies != null) {
                 replies.onComplete();
             }
@@ -509,6 +516,12 @@ public final class Pipelines {
 
             replies.onSubscribe(this);
             return this;
+        }
+
+        @Override
+        public void onComplete() {
+            completeReplies();
+            super.onComplete();
         }
 
         @Override
@@ -614,6 +627,7 @@ public final class Pipelines {
         @Override
         public void onComplete() {
             incoming.onComplete();
+            completeReplies();
             super.onComplete();
         }
     }
@@ -691,6 +705,10 @@ public final class Pipelines {
 
         @Override
         public void onComplete() {
+            // the client streaming implementation specifically does NOT complete the replies.
+            // even if the client has closed their half of the stream, the server may continue
+            // sending responses to the subscribed client indefinitely.
+
             incoming.onComplete();
             super.onComplete();
         }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
@@ -141,7 +141,7 @@ public interface ServiceInterface {
      * @param responses The subscriber used by the service to push responses back to the client.
      */
     @NonNull
-    Flow.Subscriber<? super Bytes> open(
+    Pipeline<? super Bytes> open(
             @NonNull Method method, @NonNull RequestOptions opts, @NonNull Flow.Subscriber<? super Bytes> responses)
             throws GrpcException;
 }


### PR DESCRIPTION
- closes #300 
- tweaks how the `PbjProtocolHandler` progresses through stream state
    - uses `CLOSED` and `HALF_CLOSED_REMOTE` as specified by the [http2 spec](https://httpwg.org/specs/rfc7540.html#DATA), rather than using `HALF_CLOSED_LOCAL` for all cases of the stream ending
- modifies how the closing of protocol method calls affects method call responses
    - a client completing a stream subscription request should NOT result in the responses being immediately closed. The whole idea of the subscription is that the request can be made, and the server continues to stream responses indefinitely.
