### PR TITLE
chore: add pbj-maintainers to License file in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,7 @@ gradlew.bat                                     @hashgraph/devops-ci @hashgraph/
 
 # Protect the repository root files
 /README.md                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/pbj-maintainers
-**/LICENSE                                      @hashgraph/release-engineering-managers
+**/LICENSE                                      @hashgraph/release-engineering-managers @hashgraph/pbj-maintainers
 
 # Git Ignore definitions
 **/.gitignore                                   @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/pbj-maintainers


### PR DESCRIPTION
**Description**:

The purpose of this change is to add the pbj-maintainers group to the License file as defined in the CODEOWNERS file.

**Related Issue(s)**:

Fixes #332 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
