### PR TITLE
build: update hiero-gradle-conventions to 0.3.0

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -135,20 +135,20 @@ jobs:
       - name: Gradle Update Version (As Specified)
         if: ${{ needs.prepare-release.outputs.mode == 'specified' && !cancelled() && !failure() }}
         working-directory: ${{ env.PBJ_CORE }}
-        run: ./gradlew versionAsSpecified -PnewVersion=${{ needs.prepare-release.outputs.version }} --scan
+        run: ./gradlew versionAsSpecified -PnewVersion=${{ needs.prepare-release.outputs.version }}
 
       - name: Gradle Update Version (Snapshot)
         if: ${{ needs.prepare-release.outputs.mode == 'snapshot' && !cancelled() && !failure() }}
         working-directory: ${{ env.PBJ_CORE }}
-        run: ./gradlew versionAsSnapshot --scan
+        run: ./gradlew versionAsSnapshot
 
       - name: Gradle Version Summary
         working-directory: ${{ env.PBJ_CORE }}
-        run: ./gradlew githubVersionSummary --scan
+        run: ./gradlew githubVersionSummary
 
       - name: Gradle Assemble
         working-directory: ${{ env.PBJ_CORE }}
-        run: ./gradlew assemble --scan
+        run: ./gradlew assemble
 
       - name: Gradle Release Maven Central
         if: ${{ !cancelled() && !failure() }}
@@ -158,7 +158,7 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         # The 'releaseMavenCentral' task will select if Release or Snapshot based on the version
         run: |
-          ./gradlew releaseMavenCentral -PpublishingPackageGroup=com.hedera.pbj -PpublishSigningEnabled=true --no-configuration-cache --scan
+          ./gradlew releaseMavenCentral -PpublishingPackageGroup=com.hedera.pbj -PpublishSigningEnabled=true --no-configuration-cache
 
       - name: Gradle Plugin Portal Release
         if: ${{ needs.prepare-release.outputs.mode == 'specified' && !cancelled() && !failure() }}
@@ -167,4 +167,4 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: |
-          ./gradlew publishPlugins -PpublishSigningEnabled=true --no-configuration-cache --scan
+          ./gradlew publishPlugins -PpublishSigningEnabled=true --no-configuration-cache

--- a/.github/workflows/zxc-compile-pbj-code.yaml
+++ b/.github/workflows/zxc-compile-pbj-code.yaml
@@ -101,7 +101,7 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           build-root-directory: ${{ env.PBJ_CORE }}
-          arguments: assemble --scan
+          arguments: assemble
 
       - name: Gradle Check (PBJ Core)
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
@@ -109,7 +109,7 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           build-root-directory: ${{ env.PBJ_CORE }}
-          arguments: check --scan
+          arguments: check
 
       - name: Publish JUnit Test Report (PBJ Core)
         uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
@@ -133,7 +133,7 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           build-root-directory: ${{ env.PBJ_INTEGRATION_TESTS }}
-          arguments: assemble --scan
+          arguments: assemble
 
       - name: Gradle Check (PBJ Integration)
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
@@ -141,7 +141,7 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           build-root-directory: ${{ env.PBJ_INTEGRATION_TESTS }}
-          arguments: check --scan
+          arguments: check
 
       - name: Publish Integration Test Report (PBJ Integration)
         uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.3.0
@@ -157,7 +157,7 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           build-root-directory: ${{ env.PBJ_INTEGRATION_TESTS }}
-          arguments: jmhJar --scan
+          arguments: jmhJar
 
       - name: Gradle JMH Benchmarks (PBJ Integration)
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
@@ -165,4 +165,4 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           build-root-directory: ${{ env.PBJ_INTEGRATION_TESTS }}
-          arguments: jmh --scan
+          arguments: jmh

--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("org.hiero.gradle.build") version "0.2.1" }
+plugins { id("org.hiero.gradle.build") version "0.3.0" }
 
 javaModules {
     directory(".") {

--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
     includeBuild("../pbj-core") // use locally built 'pbj-core' (Gradle plugin)
 }
 
-plugins { id("org.hiero.gradle.build") version "0.2.1" }
+plugins { id("org.hiero.gradle.build") version "0.3.0" }
 
 dependencyResolutionManagement {
     // To use locally built 'pbj-runtime'


### PR DESCRIPTION
**Description**:

- Generate code coverage reports automatically when running `check` (https://github.com/hiero-ledger/hiero-gradle-conventions/pull/74)
- Extends Yaml formatting by spotlessApply (https://github.com/hiero-ledger/hiero-gradle-conventions/issues/30)
- Automatically publishes build scans on CI so that we can remove `--scan` parameters (https://github.com/hiero-ledger/hiero-gradle-conventions/issues/32)