### PR TITLE
chore: Pre-fix some files that may need to be excluded from spotless.

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -19,196 +19,211 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings({"DuplicatedCode", "EscapedSpace", "StringConcatenationInLoop"})
 public final class Common {
-	/** The indent for fields, default 4 spaces */
-	public static final String FIELD_INDENT = " ".repeat(4);
+    /** The indent for fields, default 4 spaces */
+    public static final String FIELD_INDENT = " ".repeat(4);
 
-	public static final int DEFAULT_INDENT = 4;
-	/** Number of bits used to represent the tag type */
-	static final int TAG_TYPE_BITS = 3;
-
-	/** Wire format code for var int */
-	public static final int TYPE_VARINT = 0;
-	/** Wire format code for fixed 64bit number */
-	public static final int TYPE_FIXED64 = 1;
-	/** Wire format code for length delimited, all the complex types */
-	public static final int TYPE_LENGTH_DELIMITED = 2;
-	/** Wire format code for fixed 32bit number */
-	public static final int TYPE_FIXED32 = 5;
+    public static final int DEFAULT_INDENT = 4;
+    /** Wire format code for var int */
+    public static final int TYPE_VARINT = 0;
+    /** Wire format code for fixed 64bit number */
+    public static final int TYPE_FIXED64 = 1;
+    /** Wire format code for length delimited, all the complex types */
+    public static final int TYPE_LENGTH_DELIMITED = 2;
+    /** Wire format code for fixed 32bit number */
+    public static final int TYPE_FIXED32 = 5;
+    /** Number of bits used to represent the tag type */
+    static final int TAG_TYPE_BITS = 3;
     private static final Pattern COMPARABLE_PATTERN = Pattern.compile("[)] implements Comparable<\\w+> [{]");
 
+    /**
+     * Makes a tag value given a field number and wire type.
+     *
+     * @param wireType the wire type part of tag
+     * @param fieldNumber the field number part of tag
+     *
+     * @return packed encoded tag
+     */
+    public static int getTag(final int wireType, final int fieldNumber) {
+        return (fieldNumber << TAG_TYPE_BITS) | wireType;
+    }
 
     /**
-	 * Makes a tag value given a field number and wire type.
-	 *
-	 * @param wireType the wire type part of tag
-	 * @param fieldNumber the field number part of tag
-	 * @return packed encoded tag
-	 */
-	public static int getTag(final int wireType, final int fieldNumber) {
-		return (fieldNumber << TAG_TYPE_BITS) | wireType;
-	}
+     * Make sure first character of a string is upper case
+     *
+     * @param name string input who's first character can be upper or lower case
+     *
+     * @return name with first character converted to upper case
+     */
+    public static String capitalizeFirstLetter(String name) {
+        if (!name.isEmpty()) {
+            if (name.chars().allMatch(Character::isUpperCase)) {
+                return Character.toUpperCase(name.charAt(0)) + name.substring(1).toLowerCase();
+            } else {
+                return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+            }
+        }
+        return name;
+    }
 
-	/**
-	 * Make sure first character of a string is upper case
-	 *
-	 * @param name string input who's first character can be upper or lower case
-	 * @return name with first character converted to upper case
-	 */
-	public static String capitalizeFirstLetter(String name) {
-		if (!name.isEmpty()) {
-			if (name.chars().allMatch(Character::isUpperCase)) {
-				return Character.toUpperCase(name.charAt(0)) + name.substring(1).toLowerCase();
-			} else {
-				return Character.toUpperCase(name.charAt(0)) + name.substring(1);
-			}
-		}
-		return name;
-	}
+    /**
+     * Convert names like "hello_world" to "HelloWorld" or "helloWorld" depending on firstUpper. Also handles special
+     * case
+     * like "HELLO_WORLD" to same output as "hello_world", while "HelloWorld_Two" still becomes "helloWorldTwo".
+     *
+     * @param name input name in snake case
+     * @param firstUpper if true then first char is upper case otherwise it is lower
+     *
+     * @return out name in camel case
+     */
+    @NonNull
+    public static String snakeToCamel(@NonNull String name, boolean firstUpper) {
+        final String out = Arrays.stream(name.split("_")).map(Common::capitalizeFirstLetter).collect(
+                Collectors.joining(""));
+        return (firstUpper ? Character.toUpperCase(out.charAt(0)) : Character.toLowerCase(out.charAt(0)))
+                + out.substring(1);
+    }
 
-	/**
-	 * Convert names like "hello_world" to "HelloWorld" or "helloWorld" depending on firstUpper. Also handles special case
-	 * like "HELLO_WORLD" to same output as "hello_world", while "HelloWorld_Two" still becomes "helloWorldTwo".
-	 *
-	 * @param name input name in snake case
-	 * @param firstUpper if true then first char is upper case otherwise it is lower
-	 * @return out name in camel case
-	 */
-	@NonNull
-	public static String snakeToCamel(@NonNull String name, boolean firstUpper) {
-		final String out =  Arrays.stream(name.split("_")).map(Common::capitalizeFirstLetter).collect(
-				Collectors.joining(""));
-		return (firstUpper ? Character.toUpperCase(out.charAt(0)) : Character.toLowerCase(out.charAt(0)) )
-				+ out.substring(1);
-	}
+    /**
+     * Convert a camel case name to upper case snake case
+     *
+     * @param name the input name in camel case
+     *
+     * @return output name in upper snake case
+     */
+    public static String camelToUpperSnake(String name) {
+        // check if already camel upper
+        if (name.chars().allMatch(c -> Character.isUpperCase(c) || Character.isDigit(c) || c == '_')) {
+            return name;
+        }
+        // check if already has underscores, then just capitalize
+        if (name.contains("_")) {
+            return name.toUpperCase();
+        }
+        // else convert
+        final StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < name.length(); i++) {
+            final char c = name.charAt(i);
+            if (Character.isUpperCase(c) && i > 0) {
+                buf.append("_");
+                buf.append(c);
+            } else {
+                buf.append(Character.toUpperCase(c));
+            }
+        }
+        // fix special case for capital ID
+        return buf.toString().replaceAll("_I_D", "_ID");
+    }
 
-	/**
-	 * Convert a camel case name to upper case snake case
-	 *
-	 * @param name the input name in camel case
-	 * @return output name in upper snake case
-	 */
-	public static String camelToUpperSnake(String name) {
-		// check if already camel upper
-		if (name.chars().allMatch(c -> Character.isUpperCase(c) || Character.isDigit(c) || c == '_')) return name;
-		// check if already has underscores, then just capitalize
-		if (name.contains("_")) return name.toUpperCase();
-		// else convert
-		final StringBuilder buf = new StringBuilder();
-		for (int i = 0; i < name.length(); i++) {
-			final char c = name.charAt(i);
-			if (Character.isUpperCase(c) && i > 0) {
-				buf.append("_");
-				buf.append(c);
-			} else {
-				buf.append(Character.toUpperCase(c));
-			}
-		}
-		// fix special case for capital ID
-		return buf.toString().replaceAll("_I_D", "_ID");
-	}
+    /**
+     * Build a clean java doc comment for a field
+     *
+     * @param fieldNumber The field proto number
+     * @param docContext The parsed field comment contact
+     *
+     * @return clean comment
+     */
+    public static String buildCleanFieldJavaDoc(int fieldNumber, Protobuf3Parser.DocCommentContext docContext) {
+        final String cleanedComment = docContext == null ? "" : cleanJavaDocComment(docContext.getText());
+        final String fieldNumComment = "<b>(" + fieldNumber + ")</b> ";
+        return fieldNumComment + cleanedComment;
+    }
 
-	/**
-	 * Build a clean java doc comment for a field
-	 *
-	 * @param fieldNumber The field proto number
-	 * @param docContext The parsed field comment contact
-	 * @return clean comment
-	 */
-	public static String buildCleanFieldJavaDoc(int fieldNumber, Protobuf3Parser.DocCommentContext docContext) {
-		final String cleanedComment = docContext == null ? "" : cleanJavaDocComment(docContext.getText());
-		final String fieldNumComment = "<b>("+fieldNumber+")</b> ";
-		return fieldNumComment + cleanedComment;
-	}
+    /**
+     * Build a clean java doc comment for an oneof field
+     *
+     * @param fieldNumbers The field proto numbers for all fields in oneof
+     * @param docContext The parsed field comment contact
+     *
+     * @return clean comment
+     */
+    public static String buildCleanFieldJavaDoc(List<Integer> fieldNumbers,
+            Protobuf3Parser.DocCommentContext docContext) {
+        final String cleanedComment = docContext == null ? "" : cleanJavaDocComment(docContext.getText());
+        final String fieldNumComment =
+                "<b>(" + fieldNumbers.stream().map(Objects::toString).collect(Collectors.joining(", ")) + ")</b> ";
+        return fieldNumComment + cleanedComment;
+    }
 
-	/**
-	 * Build a clean java doc comment for an oneof field
-	 *
-	 * @param fieldNumbers The field proto numbers for all fields in oneof
-	 * @param docContext The parsed field comment contact
-	 * @return clean comment
-	 */
-	public static String buildCleanFieldJavaDoc(List<Integer> fieldNumbers, Protobuf3Parser.DocCommentContext docContext) {
-		final String cleanedComment = docContext == null ? "" : cleanJavaDocComment(docContext.getText());
-		final String fieldNumComment =
-				"<b>("+fieldNumbers.stream().map(Objects::toString).collect(Collectors.joining(", "))+")</b> ";
-		return fieldNumComment + cleanedComment;
-	}
+    /**
+     * Clean up a java doc style comment removing all the "*" etc.
+     *
+     * @param fieldComment raw Java doc style comment
+     *
+     * @return clean multi-line content of the comment
+     */
+    public static String cleanJavaDocComment(String fieldComment) {
+        return cleanDocStr(fieldComment
+                .replaceAll("/\\*\\*[\n\r\s\t]*\\*[\t\s]*|[\n\r\s\t]*\\*/", "") // remove java doc
+                .replaceAll("\n\s+\\*\s+", "\n") // remove indenting and *
+                .replaceAll("\n\s+\\*\s*\n", "\n\n") // remove indenting and *
+                .replaceAll("/\\*\\*", "") // remove indenting and /** at beginning of comment.
+                .trim() // Remove leading and trailing spaces.
+        );
+    }
 
-	/**
-	 * Clean up a java doc style comment removing all the "*" etc.
-	 *
-	 * @param fieldComment raw Java doc style comment
-	 * @return clean multi-line content of the comment
-	 */
-	public static String cleanJavaDocComment(String fieldComment) {
-		return cleanDocStr(fieldComment
-				.replaceAll("/\\*\\*[\n\r\s\t]*\\*[\t\s]*|[\n\r\s\t]*\\*/","") // remove java doc
-				.replaceAll("\n\s+\\*\s+","\n") // remove indenting and *
-				.replaceAll("\n\s+\\*\s*\n","\n\n") // remove indenting and *
-				.replaceAll("/\\*\\*","") // remove indenting and /** at beginning of comment.
-				.trim() // Remove leading and trailing spaces.
-		);
-	}
-
-	/**
-	 * Clean a string so that it can be included in JavaDoc. Does things like replace unsupported HTML tags.
-	 *
-	 * @param docStr The string to clean
-	 * @return cleaned output
-	 */
-	@SuppressWarnings("RegExpSingleCharAlternation")
+    /**
+     * Clean a string so that it can be included in JavaDoc. Does things like replace unsupported HTML tags.
+     *
+     * @param docStr The string to clean
+     *
+     * @return cleaned output
+     */
+    @SuppressWarnings("RegExpSingleCharAlternation")
     public static String cleanDocStr(String docStr) {
-		return docStr
-				.replaceAll("<(/?)tt>", "<$1code>") // tt tags are not supported in javadoc
-				.replaceAll(" < ", " &lt; ") // escape loose less than
-				.replaceAll(" > ", " &gt; ") // escape loose less than
-				.replaceAll(" & ", " &amp; ") //
-				.replaceAll("<p>([^<]*?)</p>", "%%%%%$1%%%%") // replace closed paragraphs temporarily
-				.replaceAll("<p>((\\s|\\n)*?)($|<[^>]+>)","$1$2$3") // remove <p> at end of paragraph
-				.replaceAll("<p>((.|\\n)*?)([\\s\\n]*)(%%%%%|<p>|\\n@\\w+ |$|<[^>]+>)","<p>$1</p>$3$4") // clean up loose paragraphs
-				// Do second pass as we can miss some <p> that were caught as closers in first pass
-				.replaceAll("<p>([^<]*?)</p>", "%%%%%$1%%%%") // replace closed paragraphs temporarily
-				.replaceAll("<p>((.|\\n)*?)([\\s\\n]*)(%%%%%|<p>|\\n@\\w+ |$|<[^>]+>)","<p>$1</p>$3$4") // clean up loose paragraphs
-				// restore completed paragraphs
-				.replaceAll("%%%%%", "<p>") // replace back to paragraphs
-				.replaceAll("%%%%", "</p>") // replace back to paragraphs
-		;
-	}
+        return docStr
+                .replaceAll("<(/?)tt>", "<$1code>") // tt tags are not supported in javadoc
+                .replaceAll(" < ", " &lt; ") // escape loose less than
+                .replaceAll(" > ", " &gt; ") // escape loose less than
+                .replaceAll(" & ", " &amp; ") //
+                .replaceAll("<p>([^<]*?)</p>", "%%%%%$1%%%%") // replace closed paragraphs temporarily
+                .replaceAll("<p>((\\s|\\n)*?)($|<[^>]+>)", "$1$2$3") // remove <p> at end of paragraph
+                .replaceAll("<p>((.|\\n)*?)([\\s\\n]*)(%%%%%|<p>|\\n@\\w+ |$|<[^>]+>)",
+                        "<p>$1</p>$3$4") // clean up loose paragraphs
+                // Do second pass as we can miss some <p> that were caught as closers in first pass
+                .replaceAll("<p>([^<]*?)</p>", "%%%%%$1%%%%") // replace closed paragraphs temporarily
+                .replaceAll("<p>((.|\\n)*?)([\\s\\n]*)(%%%%%|<p>|\\n@\\w+ |$|<[^>]+>)",
+                        "<p>$1</p>$3$4") // clean up loose paragraphs
+                // restore completed paragraphs
+                .replaceAll("%%%%%", "<p>") // replace back to paragraphs
+                .replaceAll("%%%%", "</p>"); // replace back to paragraphs
+    }
 
-	/**
-	 * Convert a field type like "long" to the Java object wrapper type "Long", or pass though if not java primitive
-	 *
-	 * @param primitiveFieldType java field type like "int" etc
-	 * @return java object wrapper type like "Integer" or pass though
-	 */
-	public static String javaPrimitiveToObjectType(String primitiveFieldType) {
-		return switch(primitiveFieldType){
-			case "boolean" -> "Boolean";
-			case "int" -> "Integer";
-			case "long" -> "Long";
-			case "float" -> "Float";
-			case "double" -> "Double";
-			default -> primitiveFieldType;
-		};
-	}
+    /**
+     * Convert a field type like "long" to the Java object wrapper type "Long", or pass though if not java primitive
+     *
+     * @param primitiveFieldType java field type like "int" etc
+     *
+     * @return java object wrapper type like "Integer" or pass though
+     */
+    public static String javaPrimitiveToObjectType(String primitiveFieldType) {
+        return switch (primitiveFieldType) {
+            case "boolean" -> "Boolean";
+            case "int" -> "Integer";
+            case "long" -> "Long";
+            case "float" -> "Float";
+            case "double" -> "Double";
+            default -> primitiveFieldType;
+        };
+    }
 
-	/**
-	 * Recursively calculates the hashcode for a message fields.
-	 *
-	 * @param fields The fields of this object.
-	 * @param generatedCodeSoFar The accumulated hash code so far.
-	 * @return The generated code for getting the hashCode value.
-	 */
-	public static String getFieldsHashCode(final List<Field> fields, String generatedCodeSoFar) {
-		for (Field f : fields) {
-			if (f.parent() != null) {
-				final OneOfField oneOfField = f.parent();
-				generatedCodeSoFar += getFieldsHashCode(oneOfField.fields(), generatedCodeSoFar);
-			} else if (f.optionalValueType()) {
-				generatedCodeSoFar = getPrimitiveWrapperHashCodeGeneration(generatedCodeSoFar, f);
-			} else if (f.repeated()) {
-				generatedCodeSoFar = getRepeatedHashCodeGeneration(generatedCodeSoFar, f);
-			} else {
+    /**
+     * Recursively calculates the hashcode for a message fields.
+     *
+     * @param fields The fields of this object.
+     * @param generatedCodeSoFar The accumulated hash code so far.
+     *
+     * @return The generated code for getting the hashCode value.
+     */
+    public static String getFieldsHashCode(final List<Field> fields, String generatedCodeSoFar) {
+        for (Field f : fields) {
+            if (f.parent() != null) {
+                final OneOfField oneOfField = f.parent();
+                generatedCodeSoFar += getFieldsHashCode(oneOfField.fields(), generatedCodeSoFar);
+            } else if (f.optionalValueType()) {
+                generatedCodeSoFar = getPrimitiveWrapperHashCodeGeneration(generatedCodeSoFar, f);
+            } else if (f.repeated()) {
+                generatedCodeSoFar = getRepeatedHashCodeGeneration(generatedCodeSoFar, f);
+            } else {
                 if (f.type() == Field.FieldType.FIXED32 ||
                         f.type() == Field.FieldType.INT32 ||
                         f.type() == Field.FieldType.SFIXED32 ||
@@ -216,10 +231,10 @@ public final class Common {
                         f.type() == Field.FieldType.UINT32) {
                     generatedCodeSoFar += (
                             """
-                             if ($fieldName != DEFAULT.$fieldName) {
-                                 result = 31 * result + Integer.hashCode($fieldName);
-                             }
-                             """).replace("$fieldName", f.nameCamelFirstLower());
+                            if ($fieldName != DEFAULT.$fieldName) {
+                                result = 31 * result + Integer.hashCode($fieldName);
+                            }
+                            """).replace("$fieldName", f.nameCamelFirstLower());
                 } else if (f.type() == Field.FieldType.FIXED64 ||
                         f.type() == Field.FieldType.INT64 ||
                         f.type() == Field.FieldType.SFIXED64 ||
@@ -227,10 +242,10 @@ public final class Common {
                         f.type() == Field.FieldType.UINT64) {
                     generatedCodeSoFar += (
                             """
-                             if ($fieldName != DEFAULT.$fieldName) {
-                                 result = 31 * result + Long.hashCode($fieldName);
-                             }
-                             """).replace("$fieldName", f.nameCamelFirstLower());
+                            if ($fieldName != DEFAULT.$fieldName) {
+                                result = 31 * result + Long.hashCode($fieldName);
+                            }
+                            """).replace("$fieldName", f.nameCamelFirstLower());
                 } else if (f.type() == Field.FieldType.BOOL) {
                     generatedCodeSoFar += (
                             """
@@ -247,7 +262,7 @@ public final class Common {
                             """).replace("$fieldName", f.nameCamelFirstLower());
                 } else if (f.type() == Field.FieldType.DOUBLE) {
                     generatedCodeSoFar += (
-							"""
+                            """
                             if ($fieldName != DEFAULT.$fieldName) {
                                result = 31 * result + Double.hashCode($fieldName);
                             }
@@ -255,162 +270,168 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.BYTES) {
                     generatedCodeSoFar += (
                             """
-                             if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-                                result = 31 * result + $fieldName.hashCode();
-                             }
-                             """).replace("$fieldName", f.nameCamelFirstLower());
+                            if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                               result = 31 * result + $fieldName.hashCode();
+                            }
+                            """).replace("$fieldName", f.nameCamelFirstLower());
                 } else if (f.type() == Field.FieldType.ENUM) {
                     generatedCodeSoFar += (
                             """
-                             if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-                                result = 31 * result + Integer.hashCode($fieldName.protoOrdinal());
-                             }
-                             """).replace("$fieldName", f.nameCamelFirstLower());
-				} else if (f.type() == Field.FieldType.MAP) {
-					generatedCodeSoFar += getMapHashCodeGeneration(generatedCodeSoFar, f);
-				} else if (f.type() == Field.FieldType.STRING ||
-						f.parent() == null) { // process sub message
-					generatedCodeSoFar += (
-							"""
-                             if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-                                result = 31 * result + $fieldName.hashCode();
-                             }
-                             """).replace("$fieldName", f.nameCamelFirstLower());
+                            if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                               result = 31 * result + Integer.hashCode($fieldName.protoOrdinal());
+                            }
+                            """).replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.MAP) {
+                    generatedCodeSoFar += getMapHashCodeGeneration(generatedCodeSoFar, f);
+                } else if (f.type() == Field.FieldType.STRING ||
+                        f.parent() == null) { // process sub message
+                    generatedCodeSoFar += (
+                            """
+                            if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                               result = 31 * result + $fieldName.hashCode();
+                            }
+                            """).replace("$fieldName", f.nameCamelFirstLower());
                 } else {
                     throw new RuntimeException("Unexpected field type for getting HashCode - " + f.type().toString());
                 }
             }
-		}
-		return generatedCodeSoFar.indent(DEFAULT_INDENT * 2);
-	}
+        }
+        return generatedCodeSoFar.indent(DEFAULT_INDENT * 2);
+    }
 
-	/**
-	 * Get the hashcode codegen for a optional field.
-	 * @param generatedCodeSoFar The string that the codegen is generated into.
-	 * @param f The field for which to generate the hash code.
-	 * @return Updated codegen string.
-	 */
-	@NonNull
-	private static String getPrimitiveWrapperHashCodeGeneration(String generatedCodeSoFar, Field f) {
-		switch (f.messageType()) {
-			case "StringValue" -> generatedCodeSoFar += (
-     			"""
-				if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-				    result = 31 * result + $fieldName.hashCode();
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-			case "BoolValue" -> generatedCodeSoFar += (
-				"""
-				if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-				    result = 31 * result + Boolean.hashCode($fieldName);
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-			case "Int32Value", "UInt32Value" -> generatedCodeSoFar += (
-     			"""
-				if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-				    result = 31 * result + Integer.hashCode($fieldName);
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-			case "Int64Value", "UInt64Value" -> generatedCodeSoFar += (
-     			"""
-				if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-				    result = 31 * result + Long.hashCode($fieldName);
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-			case "FloatValue" -> generatedCodeSoFar += (
-     			"""
-				if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-				    result = 31 * result + Float.hashCode($fieldName);
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-			case "DoubleValue" -> generatedCodeSoFar += (
-     			"""
-				if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-				    result = 31 * result + Double.hashCode($fieldName);
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-			case "BytesValue" -> generatedCodeSoFar += (
-     			"""
-				if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-				    result = 31 * result + ($fieldName == null ? 0 : $fieldName.hashCode());
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-			default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
-		}
-		return generatedCodeSoFar;
-	}
+    /**
+     * Get the hashcode codegen for a optional field.
+     *
+     * @param generatedCodeSoFar The string that the codegen is generated into.
+     * @param f The field for which to generate the hash code.
+     *
+     * @return Updated codegen string.
+     */
+    @NonNull
+    private static String getPrimitiveWrapperHashCodeGeneration(String generatedCodeSoFar, Field f) {
+        switch (f.messageType()) {
+            case "StringValue" -> generatedCodeSoFar += (
+                    """
+                    if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                        result = 31 * result + $fieldName.hashCode();
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            case "BoolValue" -> generatedCodeSoFar += (
+                    """
+                    if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                        result = 31 * result + Boolean.hashCode($fieldName);
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            case "Int32Value", "UInt32Value" -> generatedCodeSoFar += (
+                    """
+                    if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                        result = 31 * result + Integer.hashCode($fieldName);
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            case "Int64Value", "UInt64Value" -> generatedCodeSoFar += (
+                    """
+                    if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                        result = 31 * result + Long.hashCode($fieldName);
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            case "FloatValue" -> generatedCodeSoFar += (
+                    """
+                    if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                        result = 31 * result + Float.hashCode($fieldName);
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            case "DoubleValue" -> generatedCodeSoFar += (
+                    """
+                    if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                        result = 31 * result + Double.hashCode($fieldName);
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            case "BytesValue" -> generatedCodeSoFar += (
+                    """
+                    if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
+                        result = 31 * result + ($fieldName == null ? 0 : $fieldName.hashCode());
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
+        }
+        return generatedCodeSoFar;
+    }
 
-	/**
-	 * Get the hashcode codegen for a repeated field.
-	 * @param generatedCodeSoFar The string that the codegen is generated into.
-	 * @param f The field for which to generate the hash code.
-	 * @return Updated codegen string.
-	 */
-	@NonNull
-	private static String getRepeatedHashCodeGeneration(String generatedCodeSoFar, Field f) {
-		generatedCodeSoFar += (
-            """
-            java.util.List list$$fieldName = $fieldName;
-            if (list$$fieldName != null) {
-                for (Object o : list$$fieldName) {
-                    if (o != null) {
-                        result = 31 * result + o.hashCode();
+    /**
+     * Get the hashcode codegen for a repeated field.
+     *
+     * @param generatedCodeSoFar The string that the codegen is generated into.
+     * @param f The field for which to generate the hash code.
+     *
+     * @return Updated codegen string.
+     */
+    @NonNull
+    private static String getRepeatedHashCodeGeneration(String generatedCodeSoFar, Field f) {
+        generatedCodeSoFar += (
+                """
+                java.util.List list$$fieldName = $fieldName;
+                if (list$$fieldName != null) {
+                    for (Object o : list$$fieldName) {
+                        if (o != null) {
+                            result = 31 * result + o.hashCode();
+                        } else {
+                            result = 31 * result;
+                        }
+                   }
+                }
+                """).replace("$fieldName", f.nameCamelFirstLower());
+        return generatedCodeSoFar;
+    }
+
+    /**
+     * Get the hashcode codegen for a map field.
+     *
+     * @param generatedCodeSoFar The string that the codegen is generated into.
+     * @param f The field for which to generate the hash code.
+     *
+     * @return Updated codegen string.
+     */
+    @NonNull
+    private static String getMapHashCodeGeneration(String generatedCodeSoFar, final Field f) {
+        generatedCodeSoFar += (
+                """
+                for (Object k : ((PbjMap) $fieldName).getSortedKeys()) {
+                    if (k != null) {
+                        result = 31 * result + k.hashCode();
                     } else {
                         result = 31 * result;
                     }
-               }
+                    Object v = $fieldName.get(k);
+                    if (v != null) {
+                        result = 31 * result + v.hashCode();
+                    } else {
+                        result = 31 * result;
+                    }
+                }
+                """).replace("$fieldName", f.nameCamelFirstLower());
+        return generatedCodeSoFar;
+    }
+
+    /**
+     * Recursively calculates `equals` statement for a message fields.
+     *
+     * @param fields The fields of this object.
+     * @param generatedCodeSoFar The accumulated hash code so far.
+     *
+     * @return The generated code for getting the object equality
+     */
+    public static String getFieldsEqualsStatements(final List<Field> fields, String generatedCodeSoFar) {
+        for (Field f : fields) {
+            if (f.parent() != null) {
+                final OneOfField oneOfField = f.parent();
+                generatedCodeSoFar += getFieldsEqualsStatements(oneOfField.fields(), generatedCodeSoFar);
             }
-            """).replace("$fieldName", f.nameCamelFirstLower());
-		return generatedCodeSoFar;
-	}
 
-	/**
-	 * Get the hashcode codegen for a map field.
-	 * @param generatedCodeSoFar The string that the codegen is generated into.
-	 * @param f The field for which to generate the hash code.
-	 * @return Updated codegen string.
-	 */
-	@NonNull
-	private static String getMapHashCodeGeneration(String generatedCodeSoFar, final Field f) {
-		generatedCodeSoFar += (
-				"""
-				for (Object k : ((PbjMap) $fieldName).getSortedKeys()) {
-					if (k != null) {
-						result = 31 * result + k.hashCode();
-					} else {
-						result = 31 * result;
-					}
-					Object v = $fieldName.get(k);
-					if (v != null) {
-						result = 31 * result + v.hashCode();
-					} else {
-						result = 31 * result;
-					}
-				}
-				""").replace("$fieldName", f.nameCamelFirstLower());
-		return generatedCodeSoFar;
-	}
-
-	/**
-	 * Recursively calculates `equals` statement for a message fields.
-	 *
-	 * @param fields The fields of this object.
-	 * @param generatedCodeSoFar The accumulated hash code so far.
-	 * @return The generated code for getting the object equality
-	 */
-	public static String getFieldsEqualsStatements(final List<Field> fields, String generatedCodeSoFar) {
-		for (Field f : fields) {
-			if (f.parent() != null) {
-				final OneOfField oneOfField = f.parent();
-				generatedCodeSoFar += getFieldsEqualsStatements(oneOfField.fields(), generatedCodeSoFar);
-			}
-
-			if (f.optionalValueType()) {
-				generatedCodeSoFar = getPrimitiveWrapperEqualsGeneration(generatedCodeSoFar, f);
-			}
-			else if (f.repeated()) {
-				generatedCodeSoFar = getRepeatedEqualsGeneration(generatedCodeSoFar, f);
-			} else {
+            if (f.optionalValueType()) {
+                generatedCodeSoFar = getPrimitiveWrapperEqualsGeneration(generatedCodeSoFar, f);
+            } else if (f.repeated()) {
+                generatedCodeSoFar = getRepeatedEqualsGeneration(generatedCodeSoFar, f);
+            } else {
                 f.nameCamelFirstLower();
                 if (f.type() == Field.FieldType.FIXED32 ||
                         f.type() == Field.FieldType.INT32 ||
@@ -418,11 +439,11 @@ public final class Common {
                         f.type() == Field.FieldType.SINT32 ||
                         f.type() == Field.FieldType.UINT32) {
                     generatedCodeSoFar +=
-                             """
-                             if ($fieldName != thatObj.$fieldName) {
-                                 return false;
-                             }
-                             """.replace("$fieldName", f.nameCamelFirstLower());
+                            """
+                            if ($fieldName != thatObj.$fieldName) {
+                                return false;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
                 } else if (f.type() == Field.FieldType.FIXED64 ||
                         f.type() == Field.FieldType.INT64 ||
                         f.type() == Field.FieldType.SFIXED64 ||
@@ -470,268 +491,280 @@ public final class Common {
                             }
                             """).replace("$fieldName", f.nameCamelFirstLower());
                 } else {
-                    throw new IllegalArgumentException("Unexpected field type for getting Equals - " + f.type().toString());
+                    throw new IllegalArgumentException(
+                            "Unexpected field type for getting Equals - " + f.type().toString());
                 }
             }
-		}
-		return generatedCodeSoFar.indent(DEFAULT_INDENT);
-	}
+        }
+        return generatedCodeSoFar.indent(DEFAULT_INDENT);
+    }
 
-	/**
-	 * Get the equals codegen for a optional field.
-	 * @param generatedCodeSoFar The string that the codegen is generated into.
-	 * @param f The field for which to generate the equals code.
-	 * @return Updated codegen string.
-	 */
-	@NonNull
-	private static String getPrimitiveWrapperEqualsGeneration(String generatedCodeSoFar, Field f) {
-		switch (f.messageType()) {
-			case "StringValue", "BoolValue", "Int32Value", "UInt32Value", "Int64Value", "UInt64Value", "FloatValue",
-                 "DoubleValue", "BytesValue" ->
-				generatedCodeSoFar += (
+    /**
+     * Get the equals codegen for a optional field.
+     *
+     * @param generatedCodeSoFar The string that the codegen is generated into.
+     * @param f The field for which to generate the equals code.
+     *
+     * @return Updated codegen string.
+     */
+    @NonNull
+    private static String getPrimitiveWrapperEqualsGeneration(String generatedCodeSoFar, Field f) {
+        switch (f.messageType()) {
+            case "StringValue", "BoolValue", "Int32Value", "UInt32Value", "Int64Value", "UInt64Value", "FloatValue",
+                 "DoubleValue", "BytesValue" -> generatedCodeSoFar += (
+                    """
+                    if (this.$fieldName == null && thatObj.$fieldName != null) {
+                        return false;
+                    }
+                    if (this.$fieldName != null && !$fieldName.equals(thatObj.$fieldName)) {
+                        return false;
+                    }
+                    """).replace("$fieldName", f.nameCamelFirstLower());
+            default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
+        }
+        return generatedCodeSoFar;
+    }
+
+    /**
+     * Get the equals codegen for a repeated field.
+     *
+     * @param generatedCodeSoFar The string that the codegen is generated into.
+     * @param f The field for which to generate the equals code.
+     *
+     * @return Updated codegen string.
+     */
+    @NonNull
+    private static String getRepeatedEqualsGeneration(String generatedCodeSoFar, Field f) {
+        generatedCodeSoFar += (
                 """
                 if (this.$fieldName == null && thatObj.$fieldName != null) {
                     return false;
                 }
+                
                 if (this.$fieldName != null && !$fieldName.equals(thatObj.$fieldName)) {
                     return false;
                 }
                 """).replace("$fieldName", f.nameCamelFirstLower());
-            default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
-		}
-		return generatedCodeSoFar;
-	}
+        return generatedCodeSoFar;
+    }
 
-	/**
-	 * Get the equals codegen for a repeated field.
-	 * @param generatedCodeSoFar The string that the codegen is generated into.
-	 * @param f The field for which to generate the equals code.
-	 * @return Updated codegen string.
-	 */
-	@NonNull
-	private static String getRepeatedEqualsGeneration(String generatedCodeSoFar, Field f) {
-		generatedCodeSoFar += (
-    	"""
-		if (this.$fieldName == null && thatObj.$fieldName != null) {
-		    return false;
-		}
+    /**
+     * Generate the compareTo method content for the provided fields
+     *
+     * @param fields The fields of this object.
+     * @param generatedCodeSoFar the generated code so far (non-empty in case of nested objects)
+     * @param destinationSrcDir a directory where the previously generated code is saved
+     *
+     * @return The generated code for compareTo method body
+     */
+    public static String getFieldsCompareToStatements(final List<Field> fields, String generatedCodeSoFar,
+            File destinationSrcDir) {
+        for (Field f : fields) {
+            if (f.optionalValueType()) {
+                generatedCodeSoFar += getPrimitiveWrapperCompareToGeneration(f);
+            } else if (f.repeated()) {
+                throw new UnsupportedOperationException("Repeated fields are not supported in compareTo method");
+            } else {
+                if (f.type() == Field.FieldType.FIXED32 ||
+                        f.type() == Field.FieldType.INT32 ||
+                        f.type() == Field.FieldType.SFIXED32 ||
+                        f.type() == Field.FieldType.SINT32) {
+                    generatedCodeSoFar +=
+                            """
+                            result = Integer.compare($fieldName, thatObj.$fieldName);
+                            if (result != 0) {
+                                return result;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.UINT32) {
+                    generatedCodeSoFar +=
+                            """
+                            result = Integer.compareUnsigned($fieldName, thatObj.$fieldName);
+                            if (result != 0) {
+                                return result;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
 
-		if (this.$fieldName != null && !$fieldName.equals(thatObj.$fieldName)) {
-		    return false;
-		}
-		""").replace("$fieldName", f.nameCamelFirstLower());
-		return generatedCodeSoFar;
-	}
+                } else if (f.type() == Field.FieldType.FIXED64 ||
+                        f.type() == Field.FieldType.INT64 ||
+                        f.type() == Field.FieldType.SFIXED64 ||
+                        f.type() == Field.FieldType.SINT64) {
+                    generatedCodeSoFar +=
+                            """
+                            result = Long.compare($fieldName, thatObj.$fieldName);
+                            if (result != 0) {
+                                return result;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.UINT64) {
+                    generatedCodeSoFar +=
+                            """
+                            result = Long.compareUnsigned($fieldName, thatObj.$fieldName);
+                            if (result != 0) {
+                                return result;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.BOOL) {
+                    generatedCodeSoFar +=
+                            """
+                            result = Boolean.compare($fieldName, thatObj.$fieldName);
+                            if (result != 0) {
+                                return result;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.FLOAT) {
+                    generatedCodeSoFar +=
+                            """
+                            result = Float.compare($fieldName, thatObj.$fieldName);
+                            if (result != 0) {
+                                return result;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.DOUBLE) {
+                    generatedCodeSoFar +=
+                            """
+                            result = Double.compare($fieldName, thatObj.$fieldName);
+                            if (result != 0) {
+                                 return result;
+                            }
+                            """.replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.STRING ||
+                        f.type() == Field.FieldType.BYTES ||
+                        f.type() == Field.FieldType.ENUM) {
+                    generatedCodeSoFar += generateCompareToForObject(f);
+                } else if (f.type() == Field.FieldType.MESSAGE || f.type() == Field.FieldType.ONE_OF) {
+                    verifyComparable(f, destinationSrcDir);
+                    generatedCodeSoFar += generateCompareToForObject(f);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Unexpected field type for getting CompareTo - " + f.type().toString());
+                }
+            }
+        }
+        return generatedCodeSoFar.indent(DEFAULT_INDENT * 2);
+    }
 
+    @NonNull
+    private static String generateCompareToForObject(Field f) {
+        return """
+               if ($fieldName == null && thatObj.$fieldName != null) {
+                   return -1;
+               }
+               if ($fieldName != null && thatObj.$fieldName == null) {
+                   return 1;
+               }
+               if ($fieldName != null) {
+                   result = $fieldName.compareTo(thatObj.$fieldName);
+               }
+               if (result != 0) {
+                   return result;
+               }
+               """.replace("$fieldName", f.nameCamelFirstLower());
+    }
 
-	/**
-	 * Generate the compareTo method content for the provided fields
-	 *
-	 * @param fields                The fields of this object.
-	 * @param generatedCodeSoFar    the generated code so far (non-empty in case of nested objects)
-	 * @param destinationSrcDir a directory where the previously generated code is saved
-	 * @return The generated code for compareTo method body
-	 */
-	public static String getFieldsCompareToStatements(final List<Field> fields, String generatedCodeSoFar, File destinationSrcDir) {
-		for (Field f : fields) {
-			if (f.optionalValueType()) {
-				generatedCodeSoFar += getPrimitiveWrapperCompareToGeneration(f);
-			} else if (f.repeated()) {
-				throw new UnsupportedOperationException("Repeated fields are not supported in compareTo method");
-			} else {
-				if (f.type() == Field.FieldType.FIXED32 ||
-						f.type() == Field.FieldType.INT32 ||
-						f.type() == Field.FieldType.SFIXED32 ||
-						f.type() == Field.FieldType.SINT32) {
-					generatedCodeSoFar +=
-							"""
-							result = Integer.compare($fieldName, thatObj.$fieldName);
-							if (result != 0) {
-							    return result;
-							}
-							""".replace("$fieldName", f.nameCamelFirstLower());
-				} else if (f.type() == Field.FieldType.UINT32) {
-						generatedCodeSoFar +=
-       						"""
-							result = Integer.compareUnsigned($fieldName, thatObj.$fieldName);
-							if (result != 0) {
-							    return result;
-							}
-							""".replace("$fieldName", f.nameCamelFirstLower());
-
-				} else if (f.type() == Field.FieldType.FIXED64 ||
-						f.type() == Field.FieldType.INT64 ||
-						f.type() == Field.FieldType.SFIXED64 ||
-						f.type() == Field.FieldType.SINT64) {
-					generatedCodeSoFar +=
-							"""
-							result = Long.compare($fieldName, thatObj.$fieldName);
-							if (result != 0) {
-							    return result;
-							}
-							""".replace("$fieldName", f.nameCamelFirstLower());
-				} else if (f.type() == Field.FieldType.UINT64) {
-					generatedCodeSoFar +=
-							"""
-							result = Long.compareUnsigned($fieldName, thatObj.$fieldName);
-							if (result != 0) {
-							    return result;
-							}
-							""".replace("$fieldName", f.nameCamelFirstLower());
-				} else if (f.type() == Field.FieldType.BOOL) {
-					generatedCodeSoFar +=
-							"""
-							result = Boolean.compare($fieldName, thatObj.$fieldName);
-							if (result != 0) {
-							    return result;
-							}
-							""".replace("$fieldName", f.nameCamelFirstLower());
-				} else if (f.type() == Field.FieldType.FLOAT) {
-					generatedCodeSoFar +=
-							"""
-							result = Float.compare($fieldName, thatObj.$fieldName);
-							if (result != 0) {
-							    return result;
-							}
-							""".replace("$fieldName", f.nameCamelFirstLower());
-				} else if (f.type() == Field.FieldType.DOUBLE) {
-					generatedCodeSoFar +=
-							"""
-							result = Double.compare($fieldName, thatObj.$fieldName);
-							if (result != 0) {
-							     return result;
-							}
-							""".replace("$fieldName", f.nameCamelFirstLower());
-				} else if (f.type() == Field.FieldType.STRING ||
-						f.type() == Field.FieldType.BYTES ||
-						f.type() == Field.FieldType.ENUM) {
-					generatedCodeSoFar += generateCompareToForObject(f);
-				} else if (f.type() == Field.FieldType.MESSAGE || f.type() == Field.FieldType.ONE_OF) {
-					verifyComparable(f, destinationSrcDir);
-					generatedCodeSoFar += generateCompareToForObject(f);
-				} else {
-					throw new IllegalArgumentException("Unexpected field type for getting CompareTo - " + f.type().toString());
-				}
-			}
-		}
-		return generatedCodeSoFar.indent(DEFAULT_INDENT * 2);
-	}
-
-	@NonNull
-	private static String generateCompareToForObject(Field f) {
-		return """
-				if ($fieldName == null && thatObj.$fieldName != null) {
-				    return -1;
-				}
-				if ($fieldName != null && thatObj.$fieldName == null) {
-				    return 1;
-				}
-				if ($fieldName != null) {
-				    result = $fieldName.compareTo(thatObj.$fieldName);
-				}
-				if (result != 0) {
-				    return result;
-				}
-				""".replace("$fieldName", f.nameCamelFirstLower());
-	}
-
-	/**
-	 * Verify that the field is comparable.
-	 * @param field The field to verify.
-	 * @param destinationSrcDir The directory where the previously generated code is saved.
-	 */
-	private static void verifyComparable(final Field field, File destinationSrcDir) {
-		if (field instanceof final SingleField singleField) {
-			if (singleField.type() != Field.FieldType.MESSAGE) {
-				// everything else except message and bytes is comparable for sure
-				return;
-			}
-			// let's check if the message implements Comparable
-			final String className = singleField.javaFieldType();
-			final File javaFile = getJavaFile(destinationSrcDir, singleField.messageTypeModelPackage(), className);
-			try (BufferedReader reader = new BufferedReader(new FileReader(javaFile))) {
-				String line;
-				while ((line = reader.readLine()) != null) {
-					if (COMPARABLE_PATTERN.matcher(line).matches()) {
-						return;
-					}
-				}
-				throw new IllegalArgumentException(("Field %s.%s specified in `pbj.comparable` option must implement " +
-						"`Comparable` interface but it doesn't.").formatted(className, field.nameCamelFirstLower()));
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-        } if (field instanceof final OneOfField oneOfField) {
-			oneOfField.fields().forEach(v -> verifyComparable(v, destinationSrcDir));
-		} else {
-			throw new UnsupportedOperationException("Unexpected field type - " + field.getClass());
-		}
-	}
-
-	/**
-	 * Generates the compareTo code for a primitive wrapper field.
-	 * @param f The field for which to generate the compareTo code.
-	 * @return The generated code for compareTo method body
-	 */
-	private static String getPrimitiveWrapperCompareToGeneration(Field f) {
-		final String template =
-				"""
-                    if ($fieldName == null && thatObj.$fieldName != null) {
-                        return -1;
-                    } else if ($fieldName != null && thatObj.$fieldName == null) {
-                        return 1;
-                    } else if ($fieldName != null) {
-                        result = $compareStatement;
+    /**
+     * Verify that the field is comparable.
+     *
+     * @param field The field to verify.
+     * @param destinationSrcDir The directory where the previously generated code is saved.
+     */
+    private static void verifyComparable(final Field field, File destinationSrcDir) {
+        if (field instanceof final SingleField singleField) {
+            if (singleField.type() != Field.FieldType.MESSAGE) {
+                // everything else except message and bytes is comparable for sure
+                return;
+            }
+            // let's check if the message implements Comparable
+            final String className = singleField.javaFieldType();
+            final File javaFile = getJavaFile(destinationSrcDir, singleField.messageTypeModelPackage(), className);
+            try (BufferedReader reader = new BufferedReader(new FileReader(javaFile))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (COMPARABLE_PATTERN.matcher(line).matches()) {
+                        return;
                     }
-                    if (result != 0) {
-                        return result;
-                    }
-                    """;
+                }
+                throw new IllegalArgumentException(("Field %s.%s specified in `pbj.comparable` option must implement " +
+                        "`Comparable` interface but it doesn't.").formatted(className, field.nameCamelFirstLower()));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        if (field instanceof final OneOfField oneOfField) {
+            oneOfField.fields().forEach(v -> verifyComparable(v, destinationSrcDir));
+        } else {
+            throw new UnsupportedOperationException("Unexpected field type - " + field.getClass());
+        }
+    }
 
+    /**
+     * Generates the compareTo code for a primitive wrapper field.
+     *
+     * @param f The field for which to generate the compareTo code.
+     *
+     * @return The generated code for compareTo method body
+     */
+    private static String getPrimitiveWrapperCompareToGeneration(Field f) {
+        final String template =
+                """
+                if ($fieldName == null && thatObj.$fieldName != null) {
+                    return -1;
+                } else if ($fieldName != null && thatObj.$fieldName == null) {
+                    return 1;
+                } else if ($fieldName != null) {
+                    result = $compareStatement;
+                }
+                if (result != 0) {
+                    return result;
+                }
+                """;
 
-		final String compareStatement = switch (f.messageType()) {
-			case "StringValue", "BytesValue" -> "$fieldName.compareTo(thatObj.$fieldName)";
-			case "BoolValue" -> "java.lang.Boolean.compare($fieldName, thatObj.$fieldName)";
-			case "Int32Value" -> "java.lang.Integer.compare($fieldName, thatObj.$fieldName)";
-			case "UInt32Value" -> "java.lang.Integer.compareUnsigned($fieldName, thatObj.$fieldName)";
-			case "Int64Value" -> "java.lang.Long.compare($fieldName, thatObj.$fieldName)";
-			case "UInt64Value" -> "java.lang.Long.compareUnsigned($fieldName, thatObj.$fieldName)";
-			case "FloatValue" -> "java.lang.Float.compare($fieldName, thatObj.$fieldName)";
-			case "DoubleValue" -> "java.lang.Double.compare($fieldName, thatObj.$fieldName)";
+        final String compareStatement = switch (f.messageType()) {
+            case "StringValue", "BytesValue" -> "$fieldName.compareTo(thatObj.$fieldName)";
+            case "BoolValue" -> "java.lang.Boolean.compare($fieldName, thatObj.$fieldName)";
+            case "Int32Value" -> "java.lang.Integer.compare($fieldName, thatObj.$fieldName)";
+            case "UInt32Value" -> "java.lang.Integer.compareUnsigned($fieldName, thatObj.$fieldName)";
+            case "Int64Value" -> "java.lang.Long.compare($fieldName, thatObj.$fieldName)";
+            case "UInt64Value" -> "java.lang.Long.compareUnsigned($fieldName, thatObj.$fieldName)";
+            case "FloatValue" -> "java.lang.Float.compare($fieldName, thatObj.$fieldName)";
+            case "DoubleValue" -> "java.lang.Double.compare($fieldName, thatObj.$fieldName)";
             default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
-		};
+        };
 
-		return template
-				.replace("$compareStatement", compareStatement)
-				.replace("$fieldName", f.nameCamelFirstLower());
-	}
+        return template
+                .replace("$compareStatement", compareStatement)
+                .replace("$fieldName", f.nameCamelFirstLower());
+    }
 
-	/**
-	 * Remove leading dot from a string so ".a.b.c" becomes "a.b.c"
-	 *
-	 * @param text text to remove leading dot from
-	 * @return  text without a leading dot
-	 */
-	public static String removingLeadingDot(String text) {
-		if (!text.isEmpty() & text.charAt(0) == '.') {
-			return text.substring(1);
-		}
-		return text;
-	}
+    /**
+     * Remove leading dot from a string so ".a.b.c" becomes "a.b.c"
+     *
+     * @param text text to remove leading dot from
+     *
+     * @return text without a leading dot
+     */
+    public static String removingLeadingDot(String text) {
+        if (!text.isEmpty() && text.charAt(0) == '.') {
+            return text.substring(1);
+        }
+        return text;
+    }
 
-	/**
-	 * Get the java file for a src directory, package and classname with optional suffix. All parent directories will
-	 * also be created.
-	 *
-	 * @param srcDir The src dir root of all java src
-	 * @param javaPackage the java package with '.' deliminators
-	 * @param className the camel case class name
-	 * @return File object for java file
-	 */
-	public static File getJavaFile(File srcDir, String javaPackage, String className) {
-		File packagePath = new File(srcDir.getPath() + File.separatorChar + javaPackage.replaceAll("\\.","\\" + File.separator));
-		//noinspection ResultOfMethodCallIgnored
-		packagePath.mkdirs();
-		return new File(packagePath,className+".java");
-	}
+    /**
+     * Get the java file for a src directory, package and classname with optional suffix. All parent directories will
+     * also be created.
+     *
+     * @param srcDir The src dir root of all java src
+     * @param javaPackage the java package with '.' deliminators
+     * @param className the camel case class name
+     *
+     * @return File object for java file
+     */
+    public static File getJavaFile(File srcDir, String javaPackage, String className) {
+        File packagePath = new File(
+                srcDir.getPath() + File.separatorChar + javaPackage.replaceAll("\\.", "\\" + File.separator));
+        //noinspection ResultOfMethodCallIgnored
+        packagePath.mkdirs();
+        return new File(packagePath, className + ".java");
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/ContextualLookupHelper.java
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl;
 
-import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.*;
-
 import java.io.File;
 import java.util.List;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.EnumDefContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageDefContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageTypeContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.FieldContext;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.Type_Context;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.OneofFieldContext;
 
 /**
  * Wrapper around LookupHelper adding the context of which protobuf source file the lookup is happening within. This

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl;
 
+import static com.hedera.pbj.compiler.impl.Common.TYPE_FIXED32;
+import static com.hedera.pbj.compiler.impl.Common.TYPE_FIXED64;
+import static com.hedera.pbj.compiler.impl.Common.TYPE_LENGTH_DELIMITED;
+import static com.hedera.pbj.compiler.impl.Common.TYPE_VARINT;
+import static com.hedera.pbj.compiler.impl.Common.snakeToCamel;
+
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.Set;
-
-import static com.hedera.pbj.compiler.impl.Common.*;
 
 /**
  * Interface for SingleFields and OneOfFields
@@ -14,392 +18,392 @@ import static com.hedera.pbj.compiler.impl.Common.*;
 @SuppressWarnings("unused")
 public interface Field {
 
-	/** The default maximum size of a repeated or length-encoded field (Bytes, String, Message, etc.). */
-	public static final long DEFAULT_MAX_SIZE = 2 * 1024 * 1024;
+    /** The default maximum size of a repeated or length-encoded field (Bytes, String, Message, etc.). */
+    public static final long DEFAULT_MAX_SIZE = 2 * 1024 * 1024;
 
-	/**
-	 * Is this field a repeated field. Repeated fields are lists of values rather than a single value.
-	 *
-	 * @return true if this field is a list and false if it is a single value
-	 */
-	boolean repeated();
+    /**
+     * Is this field a repeated field. Repeated fields are lists of values rather than a single value.
+     *
+     * @return true if this field is a list and false if it is a single value
+     */
+    boolean repeated();
 
-	/**
-	 * Returns the field's max size relevant to repeated or length-encoded fields.
-	 * The returned value has no meaning for scalar fields (BOOL, INT, etc.).
-	 */
-	default long maxSize() {
-		return DEFAULT_MAX_SIZE;
-	}
+    /**
+     * Returns the field's max size relevant to repeated or length-encoded fields.
+     * The returned value has no meaning for scalar fields (BOOL, INT, etc.).
+     */
+    default long maxSize() {
+        return DEFAULT_MAX_SIZE;
+    }
 
-	/**
-	 * Get the field number, the number of the field in the parent message
-	 *
-	 * @return this fields number
-	 */
-	int fieldNumber();
+    /**
+     * Get the field number, the number of the field in the parent message
+     *
+     * @return this fields number
+     */
+    int fieldNumber();
 
-	/**
-	 * Get this fields name in original case and format
-	 *
-	 * @return this fields name
-	 */
-	String name();
+    /**
+     * Get this fields name in original case and format
+     *
+     * @return this fields name
+     */
+    String name();
 
-	/**
-	 * Get this fields name converted to camel case with the first letter upper case
-	 *
-	 * @return this fields name converted
-	 */
-	default String nameCamelFirstUpper() {
-		return snakeToCamel(name(),true);
-	}
+    /**
+     * Get this fields name converted to camel case with the first letter upper case
+     *
+     * @return this fields name converted
+     */
+    default String nameCamelFirstUpper() {
+        return snakeToCamel(name(),true);
+    }
 
-	/**
-	 * Get this fields name converted to camel case with the first letter lower case
-	 *
-	 * @return this fields name converted
-	 */
-	@NonNull
-	default String nameCamelFirstLower() {
-		return snakeToCamel(name(),false);
-	}
+    /**
+     * Get this fields name converted to camel case with the first letter lower case
+     *
+     * @return this fields name converted
+     */
+    @NonNull
+    default String nameCamelFirstLower() {
+        return snakeToCamel(name(),false);
+    }
 
-	/**
-	 * Get the field type for this field, the field type is independent of repeated
-	 *
-	 * @return this fields type
-	 */
-	FieldType type();
+    /**
+     * Get the field type for this field, the field type is independent of repeated
+     *
+     * @return this fields type
+     */
+    FieldType type();
 
-	/**
-	 * Get the protobuf field type for this field
-	 *
-	 * @return this fields type in protobuf format
-	 */
-	String protobufFieldType();
+    /**
+     * Get the protobuf field type for this field
+     *
+     * @return this fields type in protobuf format
+     */
+    String protobufFieldType();
 
-	/**
-	 * Get the Java field type for this field
-	 *
-	 * @return this fields type in Java format
-	 */
-	String javaFieldType();
+    /**
+     * Get the Java field type for this field
+     *
+     * @return this fields type in Java format
+     */
+    String javaFieldType();
 
-	/**
-	 * Get the Java field type for this field.
-	 * Unlike {@link #javaFieldType()}, this method returns the base type for repeated and oneOf fields.
-	 *
-	 * @return this fields type in Java format
-	 */
-	String javaFieldTypeBase();
+    /**
+     * Get the Java field type for this field.
+     * Unlike {@link #javaFieldType()}, this method returns the base type for repeated and oneOf fields.
+     *
+     * @return this fields type in Java format
+     */
+    String javaFieldTypeBase();
 
-	/**
-	 * Get the name for this type that is added to write/sizeof etc. methods.
-	 *
-	 * @return Name for type used in method names
-	 */
-	String methodNameType();
+    /**
+     * Get the name for this type that is added to write/sizeof etc. methods.
+     *
+     * @return Name for type used in method names
+     */
+    String methodNameType();
 
-	/**
-	 * Add all the needed imports for this field to the supplied set.
-	 *
-	 * @param imports      set of imports to add to, this contains packages not classes. They are always imported as ".*".
-	 * @param modelImports if imports for this field's generated model classes should be added
-	 * @param codecImports if imports for this field's generated codec classes should be added
-	 * @param testImports  if imports for this field's generated test classes should be added
-	 */
-	void addAllNeededImports(Set<String> imports, boolean modelImports,
-							 boolean codecImports, final boolean testImports);
+    /**
+     * Add all the needed imports for this field to the supplied set.
+     *
+     * @param imports      set of imports to add to, this contains packages not classes. They are always imported as ".*".
+     * @param modelImports if imports for this field's generated model classes should be added
+     * @param codecImports if imports for this field's generated codec classes should be added
+     * @param testImports  if imports for this field's generated test classes should be added
+     */
+    void addAllNeededImports(Set<String> imports, boolean modelImports,
+                             boolean codecImports, final boolean testImports);
 
-	/**
-	 * Get the java code to parse the value for this field from input
-	 *
-	 * @return java source code to parse
-	 */
-	String parseCode();
+    /**
+     * Get the java code to parse the value for this field from input
+     *
+     * @return java source code to parse
+     */
+    String parseCode();
 
-	/**
-	 * Get the java code default value for this field, "null" for object types
-	 *
-	 * @return code for default value
-	 */
-	String javaDefault();
+    /**
+     * Get the java code default value for this field, "null" for object types
+     *
+     * @return code for default value
+     */
+    String javaDefault();
 
-	/**
-	 * Get the field definitions line of code for schema file for this field. One line for single fields and multiple
-	 * for oneofs.
-	 *
-	 * @return field definition lines of code
-	 */
-	String schemaFieldsDef();
+    /**
+     * Get the field definitions line of code for schema file for this field. One line for single fields and multiple
+     * for oneofs.
+     *
+     * @return field definition lines of code
+     */
+    String schemaFieldsDef();
 
-	/**
-	 * Get the schema case statement for getting the field definition by field number
-	 *
-	 * @return java source code for case statement to get field def for field number
-	 */
-	String schemaGetFieldsDefCase();
+    /**
+     * Get the schema case statement for getting the field definition by field number
+     *
+     * @return java source code for case statement to get field def for field number
+     */
+    String schemaGetFieldsDefCase();
 
-	/**
-	 * Get the case statement for setting this method to go in parser set method code
-	 *
-	 * @return java source code for case statement setting this field
-	 */
-	String parserFieldsSetMethodCase();
+    /**
+     * Get the case statement for setting this method to go in parser set method code
+     *
+     * @return java source code for case statement setting this field
+     */
+    String parserFieldsSetMethodCase();
 
-	/**
-	 * Get the java doc comment for this field, cleaned and ready to insert in output
-	 *
-	 * @return java doc comment
-	 */
-	String comment();
+    /**
+     * Get the java doc comment for this field, cleaned and ready to insert in output
+     *
+     * @return java doc comment
+     */
+    String comment();
 
-	/**
-	 * Get if this field is deprecated or not
-	 *
-	 * @return true if field is deprecated, otherwise false
-	 */
-	boolean deprecated();
+    /**
+     * Get if this field is deprecated or not
+     *
+     * @return true if field is deprecated, otherwise false
+     */
+    boolean deprecated();
 
-	/**
-	 * Get the message type for this field if it is of type message otherwise null
-	 *
-	 * @return message type or null if not a message type field
-	 */
-	default String messageType() {
-		return null;
-	}
+    /**
+     * Get the message type for this field if it is of type message otherwise null
+     *
+     * @return message type or null if not a message type field
+     */
+    default String messageType() {
+        return null;
+    }
 
-	/**
-	 * Get if this field is an optional value type, optionals are handled in protobuf by value type objects for
-	 * primitives
-	 *
-	 * @return true if this field is option by use of a protobuf value type, otherwise false
-	 */
-	default boolean optionalValueType() {
-		return false;
-	}
+    /**
+     * Get if this field is an optional value type, optionals are handled in protobuf by value type objects for
+     * primitives
+     *
+     * @return true if this field is option by use of a protobuf value type, otherwise false
+     */
+    default boolean optionalValueType() {
+        return false;
+    }
 
-	/**
-	 * Get the parent field for this field, null if there is no parent like in the case of a single field.
-	 *
-	 * @return this fields parent field for oneof fields
-	 */
-	default OneOfField parent() {
-		return null;
-	}
+    /**
+     * Get the parent field for this field, null if there is no parent like in the case of a single field.
+     *
+     * @return this fields parent field for oneof fields
+     */
+    default com.hedera.pbj.compiler.impl.OneOfField parent() {
+        return null;
+    }
 
-	/**
-	 * Extract the name of the Java model class for a message type,
-	 * or null if the type is not a message.
-	 */
-	static String extractMessageTypeName(final Protobuf3Parser.Type_Context typeContext) {
-		return typeContext.messageType() == null ? null : typeContext.messageType().messageName().getText();
-	}
+    /**
+     * Extract the name of the Java model class for a message type,
+     * or null if the type is not a message.
+     */
+    static String extractMessageTypeName(final Protobuf3Parser.Type_Context typeContext) {
+        return typeContext.messageType() == null ? null : typeContext.messageType().messageName().getText();
+    }
 
-	/**
-	 * Extract the name of the Java package for a given FileType for a message type,
-	 * or null if the type is not a message.
-	 */
-	static String extractMessageTypePackage(
-			final Protobuf3Parser.Type_Context typeContext,
-			final FileType fileType,
-			final ContextualLookupHelper lookupHelper) {
-		return typeContext.messageType() == null || typeContext.messageType().messageName().getText() == null ? null :
-				lookupHelper.getPackageFieldMessageType(fileType, typeContext);
-	}
+    /**
+     * Extract the name of the Java package for a given FileType for a message type,
+     * or null if the type is not a message.
+     */
+    static String extractMessageTypePackage(
+            final Protobuf3Parser.Type_Context typeContext,
+            final com.hedera.pbj.compiler.impl.FileType fileType,
+            final com.hedera.pbj.compiler.impl.ContextualLookupHelper lookupHelper) {
+        return typeContext.messageType() == null || typeContext.messageType().messageName().getText() == null ? null :
+                lookupHelper.getPackageFieldMessageType(fileType, typeContext);
+    }
 
-	/**
-	 * Field type enum for use in field classes
-	 */
-	enum FieldType {
-		/** Protobuf message field type */
-		MESSAGE("Object", "Object", "null", TYPE_LENGTH_DELIMITED),
-		/** Protobuf enum(unsigned varint encoded int of ordinal) field type */
-		ENUM("int", "Integer", "null", TYPE_VARINT),
-		/** Protobuf int32(signed varint encoded int) field type */
-		INT32("int", "Integer", "0", TYPE_VARINT),
-		/** Protobuf uint32(unsigned varint encoded int) field type */
-		UINT32("int", "Integer", "0", TYPE_VARINT),
-		/** Protobuf sint32(signed zigzag varint encoded int) field type */
-		SINT32("int", "Integer", "0", TYPE_VARINT),
-		/** Protobuf int64(signed varint encoded long) field type */
-		INT64("long", "Long", "0", TYPE_VARINT),
-		/** Protobuf uint64(unsigned varint encoded long)  field type */
-		UINT64("long", "Long", "0", TYPE_VARINT),
-		/** Protobuf sint64(signed zigzag varint encoded long) field type */
-		SINT64("long", "Long", "0", TYPE_VARINT),
-		/** Protobuf float field type */
-		FLOAT("float", "Float", "0", TYPE_FIXED32),
-		/** Protobuf fixed int32(fixed encoding int) field type */
-		FIXED32("int", "Integer", "0", TYPE_FIXED32),
-		/** Protobuf sfixed int32(signed fixed encoding int) field type */
-		SFIXED32("int", "Integer", "0", TYPE_FIXED32),
-		/** Protobuf double field type */
-		DOUBLE("double", "Double", "0", TYPE_FIXED64),
-		/** Protobuf sfixed64(fixed encoding long) field type */
-		FIXED64("long", "Long", "0", TYPE_FIXED64),
-		/** Protobuf sfixed64(signed fixed encoding long) field type */
-		SFIXED64("long", "Long", "0", TYPE_FIXED64),
-		/** Protobuf string field type */
-		STRING("String", "String", "\"\"", TYPE_LENGTH_DELIMITED),
-		/** Protobuf bool(boolean) field type */
-		BOOL("boolean", "Boolean", "false", TYPE_VARINT),
-		/** Protobuf bytes field type */
-		BYTES("Bytes", "Bytes", "Bytes.EMPTY", TYPE_LENGTH_DELIMITED),
-		/** Protobuf oneof field type, this is not a true field type in protobuf. Needed here for a few edge cases */
-		ONE_OF("OneOf", "OneOf", "null", 0 ),// BAD TYPE
-		// On the wire, a map is a repeated Message {key, value}, sorted in the natural order of keys for determinism.
-		MAP("Map", "Map", "Collections.EMPTY_MAP", TYPE_LENGTH_DELIMITED );
+    /**
+     * Field type enum for use in field classes
+     */
+    enum FieldType {
+        /** Protobuf message field type */
+        MESSAGE("Object", "Object", "null", TYPE_LENGTH_DELIMITED),
+        /** Protobuf enum(unsigned varint encoded int of ordinal) field type */
+        ENUM("int", "Integer", "null", TYPE_VARINT),
+        /** Protobuf int32(signed varint encoded int) field type */
+        INT32("int", "Integer", "0", TYPE_VARINT),
+        /** Protobuf uint32(unsigned varint encoded int) field type */
+        UINT32("int", "Integer", "0", TYPE_VARINT),
+        /** Protobuf sint32(signed zigzag varint encoded int) field type */
+        SINT32("int", "Integer", "0", TYPE_VARINT),
+        /** Protobuf int64(signed varint encoded long) field type */
+        INT64("long", "Long", "0", TYPE_VARINT),
+        /** Protobuf uint64(unsigned varint encoded long)  field type */
+        UINT64("long", "Long", "0", TYPE_VARINT),
+        /** Protobuf sint64(signed zigzag varint encoded long) field type */
+        SINT64("long", "Long", "0", TYPE_VARINT),
+        /** Protobuf float field type */
+        FLOAT("float", "Float", "0", TYPE_FIXED32),
+        /** Protobuf fixed int32(fixed encoding int) field type */
+        FIXED32("int", "Integer", "0", TYPE_FIXED32),
+        /** Protobuf sfixed int32(signed fixed encoding int) field type */
+        SFIXED32("int", "Integer", "0", TYPE_FIXED32),
+        /** Protobuf double field type */
+        DOUBLE("double", "Double", "0", TYPE_FIXED64),
+        /** Protobuf sfixed64(fixed encoding long) field type */
+        FIXED64("long", "Long", "0", TYPE_FIXED64),
+        /** Protobuf sfixed64(signed fixed encoding long) field type */
+        SFIXED64("long", "Long", "0", TYPE_FIXED64),
+        /** Protobuf string field type */
+        STRING("String", "String", "\"\"", TYPE_LENGTH_DELIMITED),
+        /** Protobuf bool(boolean) field type */
+        BOOL("boolean", "Boolean", "false", TYPE_VARINT),
+        /** Protobuf bytes field type */
+        BYTES("Bytes", "Bytes", "Bytes.EMPTY", TYPE_LENGTH_DELIMITED),
+        /** Protobuf oneof field type, this is not a true field type in protobuf. Needed here for a few edge cases */
+        ONE_OF("OneOf", "OneOf", "null", 0 ),// BAD TYPE
+        // On the wire, a map is a repeated Message {key, value}, sorted in the natural order of keys for determinism.
+        MAP("Map", "Map", "Collections.EMPTY_MAP", TYPE_LENGTH_DELIMITED );
 
-		/** The type of field type in Java code */
-		public final String javaType;
-		/** The type of boxed field type in Java code */
-		public final String boxedType;
-		/** The field type default value in Java code */
-		public final String javaDefault;
-		/** The protobuf wire type for field type */
-		public final int wireType;
+        /** The type of field type in Java code */
+        public final String javaType;
+        /** The type of boxed field type in Java code */
+        public final String boxedType;
+        /** The field type default value in Java code */
+        public final String javaDefault;
+        /** The protobuf wire type for field type */
+        public final int wireType;
 
-		/**
-		 * Construct a new FieldType enum
-		 *
-		 * @param javaType The type of field type in Java code
-		 * @param boxedType The boxed type of the field type, e.g. Integer for an int field.
-		 * @param javaDefault The field type default value in Java code
-		 * @param wireType The protobuf wire type for field type
-		 */
-		FieldType(String javaType, final String boxedType, final String javaDefault, int wireType) {
-			this.javaType = javaType;
-			this.boxedType = boxedType;
-			this.javaDefault = javaDefault;
-			this.wireType = wireType;
-		}
+        /**
+         * Construct a new FieldType enum
+         *
+         * @param javaType The type of field type in Java code
+         * @param boxedType The boxed type of the field type, e.g. Integer for an int field.
+         * @param javaDefault The field type default value in Java code
+         * @param wireType The protobuf wire type for field type
+         */
+        FieldType(String javaType, final String boxedType, final String javaDefault, int wireType) {
+            this.javaType = javaType;
+            this.boxedType = boxedType;
+            this.javaDefault = javaDefault;
+            this.wireType = wireType;
+        }
 
-		/**
-		 * Get the field type string = the enum name
-		 *
-		 * @return Field type string
-		 */
-		String fieldType() {
-			return name();
-		}
+        /**
+         * Get the field type string = the enum name
+         *
+         * @return Field type string
+         */
+        String fieldType() {
+            return name();
+        }
 
-		/**
-		 * Get the protobuf wire type for field type
-		 *
-		 * @return protobuf wire type for field type
-		 */
-		public int wireType() {
-			return wireType;
-		}
+        /**
+         * Get the protobuf wire type for field type
+         *
+         * @return protobuf wire type for field type
+         */
+        public int wireType() {
+            return wireType;
+        }
 
-		/**
-		 * Get the type of field type in Java code
-		 *
-		 * @param repeated if the field is repeated or not, java types are different for repeated field
-		 * @return The type of field type in Java code
-		 */
-		@SuppressWarnings("DuplicatedCode")
-		public String javaType(boolean repeated) {
-			if (repeated) {
-				return switch (javaType) {
-					case "int" -> "List<Integer>";
-					case "long" -> "List<Long>";
-					case "float" -> "List<Float>";
-					case "double" -> "List<Double>";
-					case "boolean" -> "List<Boolean>";
-					default -> "List<" + javaType + ">";
-				};
-			} else {
-				return javaType;
-			}
-		}
+        /**
+         * Get the type of field type in Java code
+         *
+         * @param repeated if the field is repeated or not, java types are different for repeated field
+         * @return The type of field type in Java code
+         */
+        @SuppressWarnings("DuplicatedCode")
+        public String javaType(boolean repeated) {
+            if (repeated) {
+                return switch (javaType) {
+                    case "int" -> "List<Integer>";
+                    case "long" -> "List<Long>";
+                    case "float" -> "List<Float>";
+                    case "double" -> "List<Double>";
+                    case "boolean" -> "List<Boolean>";
+                    default -> "List<" + javaType + ">";
+                };
+            } else {
+                return javaType;
+            }
+        }
 
-		/**
-		 * Get the field type for a given parser context
-		 *
-		 * @param typeContext The parser context to get field type for
-		 * @param lookupHelper Lookup helper with global context
-		 * @return The field type enum for parser context
-		 */
-		static FieldType of(Protobuf3Parser.Type_Context typeContext,  final ContextualLookupHelper lookupHelper) {
-			if (typeContext.enumType() != null) {
-				return FieldType.ENUM;
-			} else if (typeContext.messageType() != null) {
-				if (lookupHelper.isEnum(typeContext.messageType())) return FieldType.ENUM;
-				return FieldType.MESSAGE;
-			} else if (typeContext.INT32() != null) {
-				return FieldType.INT32;
-			} else if (typeContext.UINT32() != null) {
-				return FieldType.UINT32;
-			} else if (typeContext.SINT32() != null) {
-				return FieldType.SINT32;
-			} else if (typeContext.INT64() != null) {
-				return FieldType.INT64;
-			} else if (typeContext.UINT64() != null) {
-				return FieldType.UINT64;
-			} else if (typeContext.SINT64() != null) {
-				return FieldType.SINT64;
-			} else if (typeContext.FLOAT() != null) {
-				return FieldType.FLOAT;
-			} else if (typeContext.FIXED32() != null) {
-				return FieldType.FIXED32;
-			} else if (typeContext.SFIXED32() != null) {
-				return FieldType.SFIXED32;
-			} else if (typeContext.DOUBLE() != null) {
-				return FieldType.DOUBLE;
-			} else if (typeContext.FIXED64() != null) {
-				return FieldType.FIXED64;
-			} else if (typeContext.SFIXED64() != null) {
-				return FieldType.SFIXED64;
-			} else if (typeContext.STRING() != null) {
-				return FieldType.STRING;
-			} else if (typeContext.BOOL() != null) {
-				return FieldType.BOOL;
-			} else if (typeContext.BYTES() != null) {
-				return FieldType.BYTES;
-			} else {
-				throw new IllegalArgumentException("Unknown field type: "+typeContext);
-			}
-		}
+        /**
+         * Get the field type for a given parser context
+         *
+         * @param typeContext The parser context to get field type for
+         * @param lookupHelper Lookup helper with global context
+         * @return The field type enum for parser context
+         */
+        static FieldType of(Protobuf3Parser.Type_Context typeContext,  final com.hedera.pbj.compiler.impl.ContextualLookupHelper lookupHelper) {
+            if (typeContext.enumType() != null) {
+                return FieldType.ENUM;
+            } else if (typeContext.messageType() != null) {
+                if (lookupHelper.isEnum(typeContext.messageType())) return FieldType.ENUM;
+                return FieldType.MESSAGE;
+            } else if (typeContext.INT32() != null) {
+                return FieldType.INT32;
+            } else if (typeContext.UINT32() != null) {
+                return FieldType.UINT32;
+            } else if (typeContext.SINT32() != null) {
+                return FieldType.SINT32;
+            } else if (typeContext.INT64() != null) {
+                return FieldType.INT64;
+            } else if (typeContext.UINT64() != null) {
+                return FieldType.UINT64;
+            } else if (typeContext.SINT64() != null) {
+                return FieldType.SINT64;
+            } else if (typeContext.FLOAT() != null) {
+                return FieldType.FLOAT;
+            } else if (typeContext.FIXED32() != null) {
+                return FieldType.FIXED32;
+            } else if (typeContext.SFIXED32() != null) {
+                return FieldType.SFIXED32;
+            } else if (typeContext.DOUBLE() != null) {
+                return FieldType.DOUBLE;
+            } else if (typeContext.FIXED64() != null) {
+                return FieldType.FIXED64;
+            } else if (typeContext.SFIXED64() != null) {
+                return FieldType.SFIXED64;
+            } else if (typeContext.STRING() != null) {
+                return FieldType.STRING;
+            } else if (typeContext.BOOL() != null) {
+                return FieldType.BOOL;
+            } else if (typeContext.BYTES() != null) {
+                return FieldType.BYTES;
+            } else {
+                throw new IllegalArgumentException("Unknown field type: "+typeContext);
+            }
+        }
 
-		/**
-		 * Get the field type for a given map key type parser context
-		 *
-		 * @param typeContext The parser context to get field type for
-		 * @param lookupHelper Lookup helper with global context
-		 * @return The field type enum for parser context
-		 */
-		static FieldType of(Protobuf3Parser.KeyTypeContext typeContext,  final ContextualLookupHelper lookupHelper) {
-			if (typeContext.INT32() != null) {
-				return FieldType.INT32;
-			} else if (typeContext.UINT32() != null) {
-				return FieldType.UINT32;
-			} else if (typeContext.SINT32() != null) {
-				return FieldType.SINT32;
-			} else if (typeContext.INT64() != null) {
-				return FieldType.INT64;
-			} else if (typeContext.UINT64() != null) {
-				return FieldType.UINT64;
-			} else if (typeContext.SINT64() != null) {
-				return FieldType.SINT64;
-			} else if (typeContext.FIXED32() != null) {
-				return FieldType.FIXED32;
-			} else if (typeContext.SFIXED32() != null) {
-				return FieldType.SFIXED32;
-			} else if (typeContext.FIXED64() != null) {
-				return FieldType.FIXED64;
-			} else if (typeContext.SFIXED64() != null) {
-				return FieldType.SFIXED64;
-			} else if (typeContext.STRING() != null) {
-				return FieldType.STRING;
-			} else if (typeContext.BOOL() != null) {
-				return FieldType.BOOL;
-			} else {
-				throw new IllegalArgumentException("Unknown map key type: " + typeContext);
-			}
-		}
-	}
+        /**
+         * Get the field type for a given map key type parser context
+         *
+         * @param typeContext The parser context to get field type for
+         * @param lookupHelper Lookup helper with global context
+         * @return The field type enum for parser context
+         */
+        static FieldType of(Protobuf3Parser.KeyTypeContext typeContext,  final com.hedera.pbj.compiler.impl.ContextualLookupHelper lookupHelper) {
+            if (typeContext.INT32() != null) {
+                return FieldType.INT32;
+            } else if (typeContext.UINT32() != null) {
+                return FieldType.UINT32;
+            } else if (typeContext.SINT32() != null) {
+                return FieldType.SINT32;
+            } else if (typeContext.INT64() != null) {
+                return FieldType.INT64;
+            } else if (typeContext.UINT64() != null) {
+                return FieldType.UINT64;
+            } else if (typeContext.SINT64() != null) {
+                return FieldType.SINT64;
+            } else if (typeContext.FIXED32() != null) {
+                return FieldType.FIXED32;
+            } else if (typeContext.SFIXED32() != null) {
+                return FieldType.SFIXED32;
+            } else if (typeContext.FIXED64() != null) {
+                return FieldType.FIXED64;
+            } else if (typeContext.SFIXED64() != null) {
+                return FieldType.SFIXED64;
+            } else if (typeContext.STRING() != null) {
+                return FieldType.STRING;
+            } else if (typeContext.BOOL() != null) {
+                return FieldType.BOOL;
+            } else {
+                throw new IllegalArgumentException("Unknown map key type: " + typeContext);
+            }
+        }
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
@@ -3,6 +3,8 @@ package com.hedera.pbj.compiler.impl;
 
 import java.util.Set;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
+
+import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 import static com.hedera.pbj.compiler.impl.SingleField.getDeprecatedOption;
 
 /**
@@ -18,9 +20,9 @@ import static com.hedera.pbj.compiler.impl.SingleField.getDeprecatedOption;
  * the map deterministically which is useful for serializing, computing the hash code, etc.
  */
 public record MapField(
-        /** A synthetic "key" field in a map entry. */
+        /* A synthetic "key" field in a map entry. */
         Field keyField,
-        /** A synthetic "value" field in a map entry. */
+        /* A synthetic "value" field in a map entry. */
         Field valueField,
         // The rest of the fields below simply implement the Field interface:
         boolean repeated,
@@ -46,27 +48,26 @@ public record MapField(
                         false,
                         FieldType.of(mapContext.keyType(), lookupHelper),
                         1,
-                        "___" + mapContext.mapName().getText() + "__key",
+                        "___%s__key".formatted(mapContext.mapName().getText()),
                         null,
                         null,
                         null,
                         null,
-                        "An internal, private map entry key for " + mapContext.mapName().getText(),
+                        "An internal, private map entry key for %s".formatted(mapContext.mapName().getText()),
                         false,
                         null),
                 new SingleField(
                         false,
                         FieldType.of(mapContext.type_(), lookupHelper),
                         2,
-                        "___" + mapContext.mapName().getText() + "__value",
+                        "___%s__value".formatted(mapContext.mapName().getText()),
                         Field.extractMessageTypeName(mapContext.type_()),
                         Field.extractMessageTypePackage(mapContext.type_(), FileType.MODEL, lookupHelper),
                         Field.extractMessageTypePackage(mapContext.type_(), FileType.CODEC, lookupHelper),
                         Field.extractMessageTypePackage(mapContext.type_(), FileType.TEST, lookupHelper),
-                        "An internal, private map entry value for " + mapContext.mapName().getText(),
+                        "An internal, private map entry value for %s".formatted(mapContext.mapName().getText()),
                         false,
                         null),
-
                 false, // maps cannot be repeated
                 Integer.parseInt(mapContext.fieldNumber().getText()),
                 mapContext.mapName().getText(),
@@ -86,9 +87,9 @@ public record MapField(
      * Composes the Java generic type of the map field, e.g. "&lt;Integer, String&gt;" for a Map&lt;Integer, String&gt;.
      */
     public String javaGenericType() {
-        return "<" + keyField.type().boxedType + ", " +
-                (valueField().type() == FieldType.MESSAGE ? ((SingleField)valueField()).messageType() : valueField().type().boxedType)
-                + ">";
+        final String fieldTypeName = valueField().type() == FieldType.MESSAGE ? ((SingleField)valueField()).messageType()
+                : valueField().type().boxedType;
+        return "<%s, %s>".formatted(keyField.type().boxedType, fieldTypeName);
     }
 
     /**
@@ -100,15 +101,18 @@ public record MapField(
     }
 
     private void composeFieldDef(StringBuilder sb, Field field) {
-        sb.append("""
-                    /**
-                     * $doc
-                     */
-                """
-                .replace("$doc", field.comment().replaceAll("\n","\n     * "))
-        );
-        sb.append("    public static final FieldDefinition %s = new FieldDefinition(\"%s\", FieldType.%s, %s, false, false, %d);\n"
-                .formatted(Common.camelToUpperSnake(field.name()), field.name(), field.type().fieldType(), field.repeated(), field.fieldNumber()));
+        // spotless:off
+        sb.append(
+            """
+            /**
+             * $doc
+             */
+            """.replace("$doc", field.comment().replaceAll("\n","\n* ")).indent(DEFAULT_INDENT));
+        sb.append(("    public static final FieldDefinition %s = new FieldDefinition(\"%s\"," +
+                   " FieldType.%s, %s, false, false, %d);%n")
+            .formatted(Common.camelToUpperSnake(field.name()), field.name(), field.type().fieldType(),
+                    field.repeated(), field.fieldNumber()));
+        // spotless:on
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
@@ -12,191 +12,185 @@ import java.util.stream.Collectors;
  * An implementation of Field for OneOf fields
  */
 public record OneOfField(
-		String parentMessageName,
-		String name,
-		String comment,
-		List<Field> fields,
-		boolean repeated,
-		boolean deprecated,
-		boolean comparable
+        String parentMessageName,
+        String name,
+        String comment,
+        List<Field> fields,
+        boolean repeated,
+        boolean deprecated,
+        boolean comparable
 ) implements Field {
-	/**
-	 * Create a OneOf field from parser context
-	 *
-	 * @param oneOfContext the parsed one of field
-	 * @param parentMessageName the name of the parent message
-	 * @param lookupHelper helper for accessing global context
-	 */
-	public OneOfField(final Protobuf3Parser.OneofContext oneOfContext, final String parentMessageName, final ContextualLookupHelper lookupHelper) {
-		this(parentMessageName,
-			oneOfContext.oneofName().getText(),
-			Common.buildCleanFieldJavaDoc(
-					oneOfContext.oneofField().stream().map(field -> Integer.parseInt(field.fieldNumber().getText())).toList(),
-					oneOfContext.docComment()),
-			new ArrayList<>(oneOfContext.oneofField().size()),
-			false,
-			getDeprecatedOption(oneOfContext.optionStatement()),
-			isComparable(oneOfContext, lookupHelper)
-		);
-		for (var field: oneOfContext.oneofField()) {
-			fields.add(new SingleField(field, this, lookupHelper));
-		}
-	}
+    /**
+     * Create a OneOf field from parser context
+     *
+     * @param oneOfContext the parsed one of field
+     * @param parentMessageName the name of the parent message
+     * @param lookupHelper helper for accessing global context
+     */
+    public OneOfField(final Protobuf3Parser.OneofContext oneOfContext, final String parentMessageName, final ContextualLookupHelper lookupHelper) {
+        this(parentMessageName,
+            oneOfContext.oneofName().getText(),
+            Common.buildCleanFieldJavaDoc(
+                    oneOfContext.oneofField().stream().map(field -> Integer.parseInt(field.fieldNumber().getText())).toList(),
+                    oneOfContext.docComment()),
+            new ArrayList<>(oneOfContext.oneofField().size()),
+            false,
+            getDeprecatedOption(oneOfContext.optionStatement()),
+            isComparable(oneOfContext, lookupHelper)
+        );
+        for (var field: oneOfContext.oneofField()) {
+            fields.add(new SingleField(field, this, lookupHelper));
+        }
+    }
 
-	private static boolean isComparable(Protobuf3Parser.OneofContext oneOfContext, ContextualLookupHelper lookupHelper) {
-		final boolean comparable;
-		final List<String> comparableFields = lookupHelper.getComparableFields(((Protobuf3Parser.MessageDefContext)
-				oneOfContext.getParent().getParent().getParent()));
-		comparable = comparableFields.contains(oneOfContext.oneofName().getText());
-		return comparable;
-	}
+    private static boolean isComparable(Protobuf3Parser.OneofContext oneOfContext, ContextualLookupHelper lookupHelper) {
+        final boolean comparable;
+        final List<String> comparableFields = lookupHelper.getComparableFields(((Protobuf3Parser.MessageDefContext)
+                oneOfContext.getParent().getParent().getParent()));
+        comparable = comparableFields.contains(oneOfContext.oneofName().getText());
+        return comparable;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public FieldType type() {
-		return FieldType.ONE_OF;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FieldType type() {
+        return FieldType.ONE_OF;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int fieldNumber() {
-		return fields.get(0).fieldNumber();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int fieldNumber() {
+        return fields.get(0).fieldNumber();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String protobufFieldType() {
-		return "oneof";
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String protobufFieldType() {
+        return "oneof";
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String javaFieldType() {
-		return "%s<%s>".formatted(className(), getEnumClassRef());
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String javaFieldType() {
+        return "%s<%s>".formatted(className(), getEnumClassRef());
+    }
 
-	public String className() {
-		return comparable ? "ComparableOneOf" : "OneOf";
-	}
+    public String className() {
+        return comparable ? "ComparableOneOf" : "OneOf";
+    }
 
-	@Override
-	public String javaFieldTypeBase() {
-		return getEnumClassRef();
-	}
+    @Override
+    public String javaFieldTypeBase() {
+        return getEnumClassRef();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String methodNameType() {
-		throw new UnsupportedOperationException("mapToWriteMethod can not handle "+type());
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String methodNameType() {
+        throw new UnsupportedOperationException("mapToWriteMethod can not handle "+type());
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void addAllNeededImports(final Set<String> imports, boolean modelImports,
-									boolean codecImports, final boolean testImports) {
-		imports.add("com.hedera.pbj.runtime");
-		for (var field:fields) {
-			field.addAllNeededImports(imports, modelImports, codecImports, testImports);
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addAllNeededImports(final Set<String> imports, boolean modelImports,
+                                    boolean codecImports, final boolean testImports) {
+        imports.add("com.hedera.pbj.runtime");
+        for (var field:fields) {
+            field.addAllNeededImports(imports, modelImports, codecImports, testImports);
+        }
+    }
 
-	/**
-	 * N/A for OneOfField
-	 */
-	@Override
-	public String parseCode() {
-		return null;
-	}
+    /**
+     * N/A for OneOfField
+     */
+    @Override
+    public String parseCode() {
+        return null;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String javaDefault() {
-		return Common.camelToUpperSnake(name)+"_UNSET";
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String javaDefault() {
+        return Common.camelToUpperSnake(name)+"_UNSET";
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String schemaFieldsDef() {
-		return fields.stream().map(Field::schemaFieldsDef).collect(Collectors.joining("\n"));
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String schemaFieldsDef() {
+        return fields.stream().map(Field::schemaFieldsDef).collect(Collectors.joining("\n"));
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String schemaGetFieldsDefCase() {
-		return fields.stream().map(Field::schemaGetFieldsDefCase).collect(Collectors.joining("\n            "));
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String schemaGetFieldsDefCase() {
+        return fields.stream().map(Field::schemaGetFieldsDefCase).collect(Collectors.joining("\n            "));
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String parserFieldsSetMethodCase() {
-		return fields.stream().map(Field::parserFieldsSetMethodCase).collect(Collectors.joining("\n"));
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String parserFieldsSetMethodCase() {
+        return fields.stream().map(Field::parserFieldsSetMethodCase).collect(Collectors.joining("\n"));
+    }
 
-	/**
-	 * Get reference to enum class in Java code
-	 *
-	 * @return enum class reference
-	 */
-	public String getEnumClassRef() {
-		return parentMessageName+"."+ nameCamelFirstUpper()+"OneOfType";
-	}
+    /**
+     * Get reference to enum class in Java code
+     *
+     * @return enum class reference
+     */
+    public String getEnumClassRef() {
+        return "%s.%sOneOfType".formatted(parentMessageName, nameCamelFirstUpper());
+    }
 
-	/**
-	 * Helpful debug toString
-	 *
-	 * @return debug toString
-	 */
-	@Override
-	public String toString() {
-		return "OneOfField{" +
-				"parentMessageName='" + parentMessageName + '\'' +
-				", name='" + name + '\'' +
-				", comment='" + comment + '\'' +
-				", fields.size=" + fields.size() +
-				", repeated=" + repeated +
-				", deprecated=" + deprecated +
-				'}';
-	}
+    /**
+     * Helpful debug toString
+     *
+     * @return debug toString
+     */
+    @Override
+    public String toString() {
+        return "OneOfField{parentMessageName='%s', name='%s', comment='%s', fields.size=%d, repeated=%s, deprecated=%s}"
+                .formatted(parentMessageName, name, comment, fields.size(), repeated, deprecated);
+    }
 
-	// ====== Static Utility Methods ============================
+    // ====== Static Utility Methods ============================
 
-	/**
-	 * Extract if a field is deprecated or not from the protobuf options on the field
-	 *
-	 * @param optionContext protobuf options from parser
-	 * @return true if field has deprecated option, otherwise false
-	 */
-	private static boolean getDeprecatedOption(List<Protobuf3Parser.OptionStatementContext> optionContext) {
-		boolean deprecated = false;
-		if (optionContext != null) {
-			for (var option : optionContext) {
-				if ("deprecated".equals(option.optionName().getText())) {
-					deprecated = true;
-				} else {
-					System.err.println("Unhandled Option on oneof: "+option.optionName().getText());
-				}
-			}
-		}
-		return deprecated;
-	}
+    /**
+     * Extract if a field is deprecated or not from the protobuf options on the field
+     *
+     * @param optionContext protobuf options from parser
+     * @return true if field has deprecated option, otherwise false
+     */
+    private static boolean getDeprecatedOption(List<Protobuf3Parser.OptionStatementContext> optionContext) {
+        boolean deprecated = false;
+        if (optionContext != null) {
+            for (var option : optionContext) {
+                if ("deprecated".equals(option.optionName().getText())) {
+                    deprecated = true;
+                } else {
+                    System.err.printf("Unhandled Option on oneof: %s%n", option.optionName().getText());
+                }
+            }
+        }
+        return deprecated;
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl;
 
+import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
+
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
@@ -17,317 +19,328 @@ import java.util.Set;
  */
 @SuppressWarnings("DuplicatedCode")
 public record SingleField(boolean repeated, FieldType type, int fieldNumber, String name, String messageType,
-						  String messageTypeModelPackage,
-						  String messageTypeCodecPackage, String messageTypeTestPackage,
-						  String comment, boolean deprecated, OneOfField parent) implements Field {
+                          String messageTypeModelPackage,
+                          String messageTypeCodecPackage, String messageTypeTestPackage,
+                          String comment, boolean deprecated, OneOfField parent) implements Field {
 
+    /**
+     * Construct a SingleField from a parsed field context
+     *
+     * @param fieldContext the field context to extra field data from
+     * @param lookupHelper lookup helper for finding packages and other global context data
+     */
+    public SingleField(Protobuf3Parser.FieldContext fieldContext, final ContextualLookupHelper lookupHelper) {
+        this(fieldContext.REPEATED() != null,
+                FieldType.of(fieldContext.type_(), lookupHelper),
+                Integer.parseInt(fieldContext.fieldNumber().getText()),
+                fieldContext.fieldName().getText(),
+                Field.extractMessageTypeName(fieldContext.type_()),
+                Field.extractMessageTypePackage(fieldContext.type_(), FileType.MODEL, lookupHelper),
+                Field.extractMessageTypePackage(fieldContext.type_(), FileType.CODEC, lookupHelper),
+                Field.extractMessageTypePackage(fieldContext.type_(), FileType.TEST, lookupHelper),
+                Common.buildCleanFieldJavaDoc(Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
+                getDeprecatedOption(fieldContext.fieldOptions()),
+                null
+        );
+    }
 
-	/**
-	 * Construct a SingleField from a parsed field context
-	 *
-	 * @param fieldContext the field context to extra field data from
-	 * @param lookupHelper lookup helper for finding packages and other global context data
-	 */
-	public SingleField(Protobuf3Parser.FieldContext fieldContext, final ContextualLookupHelper lookupHelper) {
-		this(fieldContext.REPEATED() != null,
-				FieldType.of(fieldContext.type_(), lookupHelper),
-				Integer.parseInt(fieldContext.fieldNumber().getText()),
-				fieldContext.fieldName().getText(),
-				Field.extractMessageTypeName(fieldContext.type_()),
-				Field.extractMessageTypePackage(fieldContext.type_(), FileType.MODEL, lookupHelper),
-				Field.extractMessageTypePackage(fieldContext.type_(), FileType.CODEC, lookupHelper),
-				Field.extractMessageTypePackage(fieldContext.type_(), FileType.TEST, lookupHelper),
-				Common.buildCleanFieldJavaDoc(Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
-				getDeprecatedOption(fieldContext.fieldOptions()),
-				null
-		);
-	}
+    /**
+     * Construct a SingleField from a parsed oneof subfield context
+     *
+     * @param fieldContext the field context to extra field data from
+     * @param lookupHelper lookup helper for finding packages and other global context data
+     */
+    public SingleField(Protobuf3Parser.OneofFieldContext fieldContext, final OneOfField parent,  final ContextualLookupHelper lookupHelper) {
+        this(false,
+                FieldType.of(fieldContext.type_(), lookupHelper),
+                Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.fieldName().getText(),
+                (fieldContext.type_().messageType() == null) ? null :
+                        fieldContext.type_().messageType().messageName().getText(),
+                (fieldContext.type_().messageType() == null) ? null :
+                        lookupHelper.getPackageOneofFieldMessageType(FileType.MODEL, fieldContext),
+                (fieldContext.type_().messageType() == null) ? null :
+                        lookupHelper.getPackageOneofFieldMessageType(FileType.CODEC, fieldContext), (fieldContext.type_().messageType() == null) ? null :
+                        lookupHelper.getPackageOneofFieldMessageType(FileType.TEST, fieldContext),
+                Common.buildCleanFieldJavaDoc(Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
+                getDeprecatedOption(fieldContext.fieldOptions()),
+                parent
+        );
+    }
 
-	/**
-	 * Construct a SingleField from a parsed oneof subfield context
-	 *
-	 * @param fieldContext the field context to extra field data from
-	 * @param lookupHelper lookup helper for finding packages and other global context data
-	 */
-	public SingleField(Protobuf3Parser.OneofFieldContext fieldContext, final OneOfField parent,  final ContextualLookupHelper lookupHelper) {
-		this(false,
-				FieldType.of(fieldContext.type_(), lookupHelper),
-				Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.fieldName().getText(),
-				(fieldContext.type_().messageType() == null) ? null :
-						fieldContext.type_().messageType().messageName().getText(),
-				(fieldContext.type_().messageType() == null) ? null :
-						lookupHelper.getPackageOneofFieldMessageType(FileType.MODEL, fieldContext),
-				(fieldContext.type_().messageType() == null) ? null :
-						lookupHelper.getPackageOneofFieldMessageType(FileType.CODEC, fieldContext), (fieldContext.type_().messageType() == null) ? null :
-						lookupHelper.getPackageOneofFieldMessageType(FileType.TEST, fieldContext),
-				Common.buildCleanFieldJavaDoc(Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
-				getDeprecatedOption(fieldContext.fieldOptions()),
-				parent
-		);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean optionalValueType() { // Move logic for checking built in types to common
+        return type == SingleField.FieldType.MESSAGE && (
+                messageType.equals("StringValue") ||
+                messageType.equals("Int32Value") ||
+                messageType.equals("UInt32Value") ||
+                messageType.equals("Int64Value") ||
+                messageType.equals("UInt64Value") ||
+                messageType.equals("FloatValue") ||
+                messageType.equals("DoubleValue") ||
+                messageType.equals("BoolValue") ||
+                messageType.equals("BytesValue")
+        );
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public boolean optionalValueType() { // Move logic for checking built in types to common
-		return type == SingleField.FieldType.MESSAGE && (
-				messageType.equals("StringValue") ||
-				messageType.equals("Int32Value") ||
-				messageType.equals("UInt32Value") ||
-				messageType.equals("Int64Value") ||
-				messageType.equals("UInt64Value") ||
-				messageType.equals("FloatValue") ||
-				messageType.equals("DoubleValue") ||
-				messageType.equals("BoolValue") ||
-				messageType.equals("BytesValue")
-		);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String protobufFieldType() {
+        return type == SingleField.FieldType.MESSAGE ? messageType : type.javaType;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String protobufFieldType() {
-		return type == SingleField.FieldType.MESSAGE ? messageType : type.javaType;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String javaFieldType() {
+        return javaFieldType(true);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String javaFieldType() {
-		return javaFieldType(true);
-	}
+    @Override
+    public String javaFieldTypeBase() {
+        return javaFieldType(false);
+    }
 
-	@Override
-	public String javaFieldTypeBase() {
-		return javaFieldType(false);
-	}
+    @NonNull
+    private String javaFieldType(boolean considerRepeated) {
+        String fieldType = switch(type) {
+            case MESSAGE -> messageType;
+            case ENUM -> Common.snakeToCamel(messageType, true);
+            default -> type.javaType;
+        };
+        fieldType = switch (fieldType) {
+            case "StringValue" -> "String";
+            case "Int32Value", "UInt32Value" -> "Integer";
+            case "Int64Value", "UInt64Value" -> "Long";
+            case "FloatValue" -> "Float";
+            case "DoubleValue" -> "Double";
+            case "BoolValue" -> "Boolean";
+            case "BytesValue" -> "Bytes";
+            default -> fieldType;
+        };
+        if (considerRepeated && repeated) {
+            fieldType = switch (fieldType) {
+                case "int" -> "List<Integer>";
+                case "long" -> "List<Long>";
+                case "float" -> "List<Float>";
+                case "double" -> "List<Double>";
+                case "boolean" -> "List<Boolean>";
+                default -> "List<%s>".formatted(fieldType);
+            };
+        }
+        return fieldType;
+    }
 
-	@NonNull
-	private String javaFieldType(boolean considerRepeated) {
-		String fieldType = switch(type) {
-			case MESSAGE -> messageType;
-			case ENUM -> Common.snakeToCamel(messageType, true);
-			default -> type.javaType;
-		};
-		fieldType = switch (fieldType) {
-			case "StringValue" -> "String";
-			case "Int32Value", "UInt32Value" -> "Integer";
-			case "Int64Value", "UInt64Value" -> "Long";
-			case "FloatValue" -> "Float";
-			case "DoubleValue" -> "Double";
-			case "BoolValue" -> "Boolean";
-			case "BytesValue" -> "Bytes";
-			default -> fieldType;
-		};
-		if (considerRepeated && repeated) {
-			fieldType = switch (fieldType) {
-				case "int" -> "List<Integer>";
-				case "long" -> "List<Long>";
-				case "float" -> "List<Float>";
-				case "double" -> "List<Double>";
-				case "boolean" -> "List<Boolean>";
-				default -> "List<" + fieldType + ">";
-			};
-		}
-		return fieldType;
-	}
+    public String javaFieldTypeForTest() {
+        return switch(type) {
+            case MESSAGE -> messageType;
+            case ENUM -> Common.snakeToCamel(messageType, true);
+            default -> type.javaType;
+        };
+    }
 
-	public String javaFieldTypeForTest() {
-		return switch(type) {
-			case MESSAGE -> messageType;
-			case ENUM -> Common.snakeToCamel(messageType, true);
-			default -> type.javaType;
-		};
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String methodNameType() {
+        return switch(type()) {
+            case BOOL -> "Boolean";
+            case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> "Integer";
+            case INT64, SINT64, UINT64, FIXED64, SFIXED64 -> "Long";
+            case FLOAT -> "Float";
+            case DOUBLE -> "Double";
+            case MESSAGE -> "Message";
+            case STRING -> "String";
+            case ENUM -> "Enum";
+            case BYTES -> "Bytes";
+            default -> throw new UnsupportedOperationException("mapToWriteMethod can not handle %s".formatted(type()));
+        };
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String methodNameType() {
-		return switch(type()) {
-			case BOOL -> "Boolean";
-			case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> "Integer";
-			case INT64, SINT64, UINT64, FIXED64, SFIXED64 -> "Long";
-			case FLOAT -> "Float";
-			case DOUBLE -> "Double";
-			case MESSAGE -> "Message";
-			case STRING -> "String";
-			case ENUM -> "Enum";
-			case BYTES -> "Bytes";
-			default -> throw new UnsupportedOperationException("mapToWriteMethod can not handle "+type());
-		};
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addAllNeededImports(Set<String> imports, boolean modelImports, boolean codecImports, final boolean testImports) {
+        if (repeated || optionalValueType()) imports.add("java.util");
+        if (type == FieldType.BYTES) imports.add("com.hedera.pbj.runtime.io.buffer");
+        if (messageTypeModelPackage != null && modelImports) imports.add(messageTypeModelPackage);
+        if (messageTypeCodecPackage != null && codecImports) imports.add(messageTypeCodecPackage);
+        if (messageTypeTestPackage != null && testImports) imports.add(messageTypeTestPackage);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void addAllNeededImports(Set<String> imports, boolean modelImports, boolean codecImports, final boolean testImports) {
-		if (repeated || optionalValueType()) imports.add("java.util");
-		if (type == FieldType.BYTES) imports.add("com.hedera.pbj.runtime.io.buffer");
-		if (messageTypeModelPackage != null && modelImports) imports.add(messageTypeModelPackage);
-		if (messageTypeCodecPackage != null && codecImports) imports.add(messageTypeCodecPackage);
-		if (messageTypeTestPackage != null && testImports) imports.add(messageTypeTestPackage);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String parseCode() {
+        if (type == FieldType.MESSAGE) {
+            return "%s.PROTOBUF.parse(input, strictMode, maxDepth - 1)".formatted(messageType);
+        } else {
+            return "input";
+        }
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String parseCode() {
-		if (type == FieldType.MESSAGE) {
-			return "%s.PROTOBUF.parse(input, strictMode, maxDepth - 1)"
-					.formatted(messageType, messageType);
-		} else {
-			return "input";
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String javaDefault() {
+        if (optionalValueType()) {
+            return "null";
+        } else if (repeated) {
+            return "Collections.emptyList()";
+        } else if (type == FieldType.ENUM) {
+            return messageType+".fromProtobufOrdinal(0)";
+        } else {
+            return type.javaDefault;
+        }
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String javaDefault() {
-		if (optionalValueType()) {
-			return "null";
-		} else if (repeated) {
-			return "Collections.emptyList()";
-		} else if (type == FieldType.ENUM) {
-			return messageType+".fromProtobufOrdinal(0)";
-		} else {
-			return type.javaDefault;
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String schemaFieldsDef() {
+        // spotless:off
+        final String javaDocComment =
+            """
+            /**
+             * %s
+             */
+            """.formatted(comment().replaceAll("\n","\n * ")).indent(DEFAULT_INDENT);
+        // spotless:on
+        boolean isPartOfOneOf = parent != null;
+        if (optionalValueType()) {
+            final String optionalBaseFieldType = switch (messageType) {
+                case "StringValue" -> "STRING";
+                case "Int32Value" -> "INT32";
+                case "UInt32Value" -> "UINT32";
+                case "Int64Value" -> "INT64";
+                case "UInt64Value" -> "UINT64";
+                case "FloatValue" -> "FLOAT";
+                case "DoubleValue" -> "DOUBLE";
+                case "BoolValue" -> "BOOL";
+                case "BytesValue" -> "BYTES";
+                default -> throw new UnsupportedOperationException(
+                        "Unsupported optional field type found: %s in %s".formatted(type.javaType, this));
+            };
+            // spotless:off
+            return ("%s    public static final FieldDefinition %s =" +
+                    " new FieldDefinition(\"%s\", FieldType.%s, %s, %s, %s, %d);%n")
+                    .formatted(javaDocComment, Common.camelToUpperSnake(name), name, optionalBaseFieldType,
+                            repeated, "true", isPartOfOneOf, fieldNumber);
+            // spotless:on
+        } else {
+            // spotless:off
+            return ("%s    public static final FieldDefinition %s =" +
+                    " new FieldDefinition(\"%s\", FieldType.%s, %s, %s, %s, %d);%n")
+                    .formatted(javaDocComment, Common.camelToUpperSnake(name), name, type.fieldType(),
+                            repeated, "false", isPartOfOneOf, fieldNumber);
+            // spotless:on
+        }
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String schemaFieldsDef() {
-		final String javaDocComment =
-				"""
-                    /**
-                     * $doc
-                     */
-                """
-				.replace("$doc", comment().replaceAll("\n","\n     * "));
-		boolean isPartOfOneOf = parent != null;
-		if (optionalValueType()) {
-			final String optionalBaseFieldType = switch (messageType) {
-				case "StringValue" -> "STRING";
-				case "Int32Value" -> "INT32";
-				case "UInt32Value" -> "UINT32";
-				case "Int64Value" -> "INT64";
-				case "UInt64Value" -> "UINT64";
-				case "FloatValue" -> "FLOAT";
-				case "DoubleValue" -> "DOUBLE";
-				case "BoolValue" -> "BOOL";
-				case "BytesValue" -> "BYTES";
-				default -> throw new UnsupportedOperationException("Unsupported optional field type found: "+type.javaType+" in "+this);
-			};
-			return javaDocComment + "    public static final FieldDefinition %s = new FieldDefinition(\"%s\", FieldType.%s, %s, true, %s, %d);\n"
-					.formatted(Common.camelToUpperSnake(name), name, optionalBaseFieldType, repeated, isPartOfOneOf, fieldNumber);
-		} else {
-			return javaDocComment + "    public static final FieldDefinition %s = new FieldDefinition(\"%s\", FieldType.%s, %s, false, %s, %d);\n"
-					.formatted(Common.camelToUpperSnake(name), name, type.fieldType(), repeated, isPartOfOneOf, fieldNumber);
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    public String schemaGetFieldsDefCase() {
+        return "case %d -> %s;".formatted(fieldNumber, Common.camelToUpperSnake(name));
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public String schemaGetFieldsDefCase() {
-		return "case %d -> %s;".formatted(fieldNumber, Common.camelToUpperSnake(name));
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String parserFieldsSetMethodCase() {
+        final String fieldNameToSet = parent != null ? parent.name() : name;
+        if (optionalValueType()) {
+            if (parent != null) { // one of
+                return "case %d -> this.%s = new %s<>(%s.%sOneOfType.%s, input);"
+                        .formatted(fieldNumber, fieldNameToSet, parent.className(), parent.parentMessageName(),
+                                Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name));
+            } else {
+                return "case %d -> this.%s = input;".formatted(fieldNumber, fieldNameToSet);
+            }
+        } else if (type == FieldType.MESSAGE) {
+            final String valueToSet = parent != null ?
+                    "new %s<>(%s.%3$sOneOfType.%3$s, %%modelClass.PROTOBUF.parse(input))"
+                            .formatted(parent.className(), parent.parentMessageName(), Common.snakeToCamel(parent.name(), true))
+                            : parseCode();
+            if (repeated) {
+                // spotless:off
+                return
+                    """
+                    case %d -> {
+                                        if (this.%s.equals(Collections.emptyList())) {
+                                            this.%s = new ArrayList<>();
+                                        }
+                                        this.%s.add(%s);
+                                    }
+                    """
+                   .formatted(fieldNumber, fieldNameToSet, fieldNameToSet, fieldNameToSet, valueToSet);
+                // spotless:on
+            } else {
+                return "case %d -> this.%s = %s;".formatted(fieldNumber, fieldNameToSet,valueToSet);
+            }
+        } else if (type == FieldType.ENUM) {
+            if (repeated) {
+                return "case %d -> this.%s = input.stream().map(%s::fromProtobufOrdinal).toList();".formatted(fieldNumber, fieldNameToSet,
+                        Common.snakeToCamel(messageType, true));
+            } else {
+                return "case %d -> this.%s = %s.fromProtobufOrdinal(input);".formatted(fieldNumber, fieldNameToSet,
+                        Common.snakeToCamel(messageType, true));
+            }
+        } else if (repeated && (type == FieldType.STRING || type == FieldType.BYTES)) {
+            final String valueToSet = parent != null ?
+                    "new %s<>(%s.%sOneOfType.%s,input)".formatted(parent.className(), parent.parentMessageName(),
+                            Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
+                    "input";
+            // spotless:off
+            return
+                    """
+                    case %d -> {
+                                        if (this.%s.equals(Collections.emptyList())) {
+                                            this.%s = new ArrayList<>();
+                                        }
+                                        this.%s.add(%s);
+                                    }
+                    """
+                    .formatted(fieldNumber, fieldNameToSet, fieldNameToSet, fieldNameToSet, valueToSet);
+            // spotless:on
+        } else {
+            final String valueToSet = parent != null ?
+                    "new %s<>(%s.%sOneOfType.%s,input)".formatted(parent.className(), parent.parentMessageName(),
+                            Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
+                    "input";
+            return "case %d -> this.%s = %s;".formatted(fieldNumber, fieldNameToSet,valueToSet);
+        }
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String parserFieldsSetMethodCase() {
-		final String fieldNameToSet = parent != null ? parent.name() : name;
-		if (optionalValueType()) {
-			if (parent != null) { // one of
-				return "case %d -> this.%s = new %s<>(%s.%sOneOfType.%s, input);"
-						.formatted(fieldNumber, fieldNameToSet, parent.className(), parent.parentMessageName(),
-								Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name));
-			} else {
-				return "case %d -> this.%s = input;".formatted(fieldNumber, fieldNameToSet);
-			}
-		} else if (type == FieldType.MESSAGE) {
-			final String valueToSet = parent != null ?
-					"new $className<>($parentMessageName.$parentNameOneOfType.$parentName, %modelClass.PROTOBUF.parse(input))"
-							.replace("$className", parent.className())
-							.replace("$parentMessageName", parent.parentMessageName())
-							.replace("$parentName", Common.snakeToCamel(parent.name(), true))
-							.replace("$parseCode", parseCode())
-							: parseCode();
-			if (repeated) {
-				return """
-					case %d -> {
-									if (this.%s.equals(Collections.emptyList())) {
-										this.%s = new ArrayList<>();
-									}
-									this.%s.add(%s);
-								}"""
-						.formatted(fieldNumber, fieldNameToSet, fieldNameToSet, fieldNameToSet, valueToSet);
+    // ====== Static Utility Methods ============================
 
-			} else {
-				return "case %d -> this.%s = %s;".formatted(fieldNumber, fieldNameToSet,valueToSet);
-			}
-		} else if (type == FieldType.ENUM) {
-			if (repeated) {
-				return "case %d -> this.%s = input.stream().map(%s::fromProtobufOrdinal).toList();".formatted(fieldNumber, fieldNameToSet,
-						Common.snakeToCamel(messageType, true));
-			} else {
-				return "case %d -> this.%s = %s.fromProtobufOrdinal(input);".formatted(fieldNumber, fieldNameToSet,
-						Common.snakeToCamel(messageType, true));
-			}
-		} else if (repeated && (type == FieldType.STRING || type == FieldType.BYTES)) {
-			final String valueToSet = parent != null ?
-					"new %s<>(%s.%sOneOfType.%s,input)".formatted(parent.className(), parent.parentMessageName(),
-							Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
-					"input";
-			return """
-				case %d -> {
-								if (this.%s.equals(Collections.emptyList())) {
-									this.%s = new ArrayList<>();
-								}
-								this.%s.add(%s);
-							}"""
-					.formatted(fieldNumber, fieldNameToSet, fieldNameToSet, fieldNameToSet, valueToSet);
-
-		} else {
-			final String valueToSet = parent != null ?
-					"new %s<>(%s.%sOneOfType.%s,input)".formatted(parent.className(), parent.parentMessageName(),
-							Common.snakeToCamel(parent.name(), true), Common.camelToUpperSnake(name)) :
-					"input";
-			return "case %d -> this.%s = %s;".formatted(fieldNumber, fieldNameToSet,valueToSet);
-		}
-	}
-
-	// ====== Static Utility Methods ============================
-
-	/**
-	 * Extract if a field is deprecated or not from the protobuf options on the field
-	 *
-	 * @param optionContext protobuf options from parser
-	 * @return true if field has deprecated option, otherwise false
-	 */
-	static boolean getDeprecatedOption(Protobuf3Parser.FieldOptionsContext optionContext) {
-		if (optionContext != null) {
-			for (var option : optionContext.fieldOption()) {
-				if ("deprecated".equals(option.optionName().getText())) {
-					return true;
-				} else {
-					System.err.println("Unhandled Option: " + optionContext.getText());
-				}
-			}
-		}
-		return false;
-	}
+    /**
+     * Extract if a field is deprecated or not from the protobuf options on the field
+     *
+     * @param optionContext protobuf options from parser
+     * @return true if field has deprecated option, otherwise false
+     */
+    static boolean getDeprecatedOption(Protobuf3Parser.FieldOptionsContext optionContext) {
+        if (optionContext != null) {
+            for (var option : optionContext.fieldOption()) {
+                if ("deprecated".equals(option.optionName().getText())) {
+                    return true;
+                } else {
+                    System.err.printf("Unhandled Option: %s%n", optionContext.getText());
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
@@ -23,204 +23,209 @@ import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 @SuppressWarnings({"EscapedSpace"})
 public final class EnumGenerator {
 
-	/** Record for an enum value temporary storage */
-	record EnumValue(String name, boolean deprecated, String javaDoc) {}
+    /** Record for an enum value temporary storage */
+    record EnumValue(String name, boolean deprecated, String javaDoc) {}
 
-	/**
-	 * Generate a Java enum from protobuf enum
-	 *
-	 * @param enumDef the parsed enum def
-	 * @param destinationSrcDir The destination source directory to generate into
-	 * @param lookupHelper Lookup helper for package information
-	 * @throws IOException if there was a problem writing generated code
-	 */
-	public static void generateEnumFile(Protobuf3Parser.EnumDefContext enumDef, File destinationSrcDir,
-								 final ContextualLookupHelper lookupHelper) throws IOException {
-		final String enumName = enumDef.enumName().getText();
-		final String modelPackage = lookupHelper.getPackageForEnum(FileType.MODEL, enumDef);
-		final String javaDocComment = (enumDef.docComment()== null) ? "" :
-				cleanDocStr(enumDef.docComment().getText().replaceAll("\n \\*\s*\n","\n * <br>\n"));
-		String deprecated = "";
-		final Map<Integer, EnumValue> enumValues = new HashMap<>();
-		int maxIndex = 0;
-		for (var item: enumDef.enumBody().enumElement()) {
-			if (item.enumField() != null && item.enumField().ident() != null) {
-				final var enumValueName = item.enumField().ident().getText();
-				final var enumNumber = Integer.parseInt(item.enumField().intLit().getText());
-				final String enumValueJavaDoc = cleanDocStr(
-						(item.enumField().docComment() == null || item.enumField().docComment().getText().isBlank()) ?
-								enumValueName :
-						item.enumField().docComment().getText()
-								.replaceAll("[\t ]*/\\*\\*([\n\t ]+\\*\s+)?","") // remove doc start indenting
-								.replaceAll("/\\*\\*","") //  remove doc start
-								.replaceAll("[\n\t ]+\\*/","") //  remove doc end
-								.replaceAll("\n[\t\s]+\\*\\*?","\n") // remove doc indenting
-								.replaceAll("/n\s*/n","/n") //  remove empty lines
-				);
-				maxIndex = Math.max(maxIndex, enumNumber);
-				// extract if the enum is marks as deprecated
-				boolean deprecatedEnumValue = false;
-				if(item.enumField().enumValueOptions() != null && item.enumField().enumValueOptions().enumValueOption() != null) {
-					for(var option:item.enumField().enumValueOptions().enumValueOption()) {
-						if ("deprecated".equals(option.optionName().getText())) {
-							deprecatedEnumValue = true;
-						} else {
-							System.err.println("Unhandled Option: "+option.getText());
-						}
-					}
-				}
-				enumValues.put(enumNumber, new EnumValue(enumValueName, deprecatedEnumValue,enumValueJavaDoc));
-			} else if (item.optionStatement() != null){
-				if ("deprecated".equals(item.optionStatement().optionName().getText())) {
-					deprecated = "@Deprecated ";
-				} else {
-					System.err.println("Unhandled Option: "+item.optionStatement().getText());
-				}
-			} else {
-				System.err.println("EnumGenerator Warning - Unknown element: "+item+" -- "+item.getText());
-			}
-		}
-		try (FileWriter javaWriter = new FileWriter(getJavaFile(destinationSrcDir, modelPackage, enumName))) {
-			javaWriter.write(
-					"package "+modelPackage+";\n\n"+
-							createEnum(javaDocComment, deprecated, enumName,
-									maxIndex, enumValues, false)
-			);
-		}
-	}
+    /**
+     * Generate a Java enum from protobuf enum
+     *
+     * @param enumDef the parsed enum def
+     * @param destinationSrcDir The destination source directory to generate into
+     * @param lookupHelper Lookup helper for package information
+     * @throws IOException if there was a problem writing generated code
+     */
+    public static void generateEnumFile(Protobuf3Parser.EnumDefContext enumDef, File destinationSrcDir,
+                                 final ContextualLookupHelper lookupHelper) throws IOException {
+        final String enumName = enumDef.enumName().getText();
+        final String modelPackage = lookupHelper.getPackageForEnum(FileType.MODEL, enumDef);
+        final String javaDocComment = (enumDef.docComment()== null) ? "" :
+                cleanDocStr(enumDef.docComment().getText().replaceAll("\n \\*\s*\n","\n * <br>\n"));
+        String deprecated = "";
+        final Map<Integer, EnumValue> enumValues = new HashMap<>();
+        int maxIndex = 0;
+        for (var item: enumDef.enumBody().enumElement()) {
+            if (item.enumField() != null && item.enumField().ident() != null) {
+                final var enumValueName = item.enumField().ident().getText();
+                final var enumNumber = Integer.parseInt(item.enumField().intLit().getText());
+                final String enumValueJavaDoc = cleanDocStr(
+                        (item.enumField().docComment() == null || item.enumField().docComment().getText().isBlank()) ?
+                                enumValueName :
+                        item.enumField().docComment().getText()
+                                .replaceAll("[\t ]*/\\*\\*([\n\t ]+\\*\s+)?","") // remove doc start indenting
+                                .replaceAll("/\\*\\*","") //  remove doc start
+                                .replaceAll("[\n\t ]+\\*/","") //  remove doc end
+                                .replaceAll("\n[\t\s]+\\*\\*?","\n") // remove doc indenting
+                                .replaceAll("/n\s*/n","/n") //  remove empty lines
+                );
+                maxIndex = Math.max(maxIndex, enumNumber);
+                // extract if the enum is marks as deprecated
+                boolean deprecatedEnumValue = false;
+                if(item.enumField().enumValueOptions() != null && item.enumField().enumValueOptions().enumValueOption() != null) {
+                    for(var option:item.enumField().enumValueOptions().enumValueOption()) {
+                        if ("deprecated".equals(option.optionName().getText())) {
+                            deprecatedEnumValue = true;
+                        } else {
+                            System.err.printf("Unhandled Option: %s%n", option.getText());
+                        }
+                    }
+                }
+                enumValues.put(enumNumber, new EnumValue(enumValueName, deprecatedEnumValue,enumValueJavaDoc));
+            } else if (item.optionStatement() != null){
+                if ("deprecated".equals(item.optionStatement().optionName().getText())) {
+                    deprecated = "@Deprecated ";
+                } else {
+                    System.err.printf("Unhandled Option: %s%n", item.optionStatement().getText());
+                }
+            } else {
+                System.err.printf("EnumGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
+            }
+        }
+        try (FileWriter javaWriter = new FileWriter(getJavaFile(destinationSrcDir, modelPackage, enumName))) {
+            javaWriter.write(
+                    "package %s;\n\n%s".formatted(modelPackage, createEnum(javaDocComment, deprecated, enumName,
+                            maxIndex, enumValues, false))
+            );
+        }
+    }
 
-	/**
-	 * Generate code for a enum
-	 *
-	 * @param javaDocComment either enum javadoc comment or empty string
-	 * @param deprecated either @deprecated string or empty string
-	 * @param enumName the name for enum
-	 * @param maxIndex the max ordinal for enum
-	 * @param enumValues map of ordinal to enum value
-	 * @param addUnknown when true we add an enum value for one of
-	 * @return string code for enum
-	 */
-	static String createEnum(String javaDocComment, String deprecated, String enumName,
-							 int maxIndex, Map<Integer, EnumValue> enumValues, boolean addUnknown) {
-		final List<String> enumValuesCode = new ArrayList<>(maxIndex);
-		if (addUnknown) {
-			enumValuesCode.add(
-      				"""
-					/**
-					 * Enum value for a unset OneOf, to avoid null OneOfs
-					 */
-					UNSET(-1, "UNSET")""");
-		}
-		for (int i = 0; i <= maxIndex; i++) {
-			final EnumValue enumValue = enumValues.get(i);
-			if (enumValue != null) {
-				final String cleanedEnumComment = enumValue.javaDoc.contains("\n") ?
-				   """
-					/**
-					 * $enumJavadoc
-					 */
-					"""
-					.replace("$enumJavadoc",
-							enumValue.javaDoc.replaceAll("\n\s*","\n * ")) :
-				   """
-					/** $enumJavadoc */
-					"""
-					.replace("$enumJavadoc", enumValue.javaDoc);
-				final String deprecatedText = enumValue.deprecated ? "@Deprecated\n" : "";
-				enumValuesCode.add(
-						cleanedEnumComment
-								+ deprecatedText+ camelToUpperSnake(enumValue.name) +
-								"("+i+", \""+enumValue.name+"\")");
-			}
-		}
-		return """
-				$javaDocComment
-				$deprecated$public enum $enumName
-				        implements com.hedera.pbj.runtime.EnumWithProtoMetadata {
-				$enumValues;
-				
-				    /** The field ordinal in protobuf for this type */
-				    private final int protoOrdinal;
-				
-				    /** The original field name in protobuf for this type */
-				    private final String protoName;
-				
-				    /**
-				     * OneOf Type Enum Constructor
-				     *
-				     * @param protoOrdinal The oneof field ordinal in protobuf for this type
-				     * @param protoName The original field name in protobuf for this type
-				     */
-				    $enumName(final int protoOrdinal, String protoName) {
-				        this.protoOrdinal = protoOrdinal;
-				        this.protoName = protoName;
-				    }
-				
-				    /**
-				     * Get the oneof field ordinal in protobuf for this type
-				     *
-				     * @return The oneof field ordinal in protobuf for this type
-				     */
-				    public int protoOrdinal() {
-				        return protoOrdinal;
-				    }
-				
-				    /**
-				     * Get the original field name in protobuf for this type
-				     *
-				     * @return The original field name in protobuf for this type
-				     */
-				    public String protoName() {
-				        return protoName;
-				    }
-				
-				    /**
-				     * Get enum from protobuf ordinal
-				     *
-				     * @param ordinal the protobuf ordinal number
-				     * @return enum for matching ordinal
-				     * @throws IllegalArgumentException if ordinal doesn't exist
-				     */
-				    public static $enumName fromProtobufOrdinal(int ordinal) {
-				        return switch(ordinal) {
-				$caseStatements
-				            default -> throw new IllegalArgumentException("Unknown protobuf ordinal "+ordinal);
-				        };
-				    }
-				
-				    /**
-				     * Get enum from string name, supports the enum or protobuf format name
-				     *
-				     * @param name the enum or protobuf format name
-				     * @return enum for matching name
-				     */
-				    public static $enumName fromString(String name) {
-				        return switch(name) {
-				$fromStringCaseStatements
-				            default -> throw new IllegalArgumentException("Unknown token kyc status "+name);
-				        };
-				    }
-				}
-				"""
-				.replace("$javaDocComment", javaDocComment)
-				.replace("$deprecated$", deprecated)
-				.replace("$enumName", enumName)
-				.replace("$enumValues", String.join(",\n\n", enumValuesCode).indent(DEFAULT_INDENT))
-				.replace("$caseStatements", enumValues.entrySet()
-						.stream()
-						.map((entry) -> "case %s -> %s;".formatted(entry.getKey(), camelToUpperSnake(entry.getValue().name))
-								.indent(DEFAULT_INDENT * 3))
-						.collect(Collectors.joining("\n")))
-				.replace("$fromStringCaseStatements", enumValues.values().stream().map(enumValue -> {
-					if (camelToUpperSnake(enumValue.name).equals(enumValue.name)) {
-						return "case \"%s\" -> %s;"
-								.formatted(enumValue.name, camelToUpperSnake(enumValue.name))
-								.indent(DEFAULT_INDENT * 3);
-					} else {
-						return "case \"%s\", \"%s\" -> %s;"
-								.formatted(enumValue.name, camelToUpperSnake(enumValue.name), camelToUpperSnake(enumValue.name))
-								.indent(DEFAULT_INDENT * 3);
-					}
-				}).collect(Collectors.joining("\n")));
-	}
+    /**
+     * Generate code for a enum
+     *
+     * @param javaDocComment either enum javadoc comment or empty string
+     * @param deprecated either @deprecated string or empty string
+     * @param enumName the name for enum
+     * @param maxIndex the max ordinal for enum
+     * @param enumValues map of ordinal to enum value
+     * @param addUnknown when true we add an enum value for one of
+     * @return string code for enum
+     */
+    static String createEnum(String javaDocComment, String deprecated, String enumName,
+                             int maxIndex, Map<Integer, EnumValue> enumValues, boolean addUnknown) {
+        final List<String> enumValuesCode = new ArrayList<>(maxIndex);
+        if (addUnknown) {
+            // spotless:off
+            enumValuesCode.add(
+                    """
+                    /**
+                     * Enum value for a unset OneOf, to avoid null OneOfs
+                     */
+                    UNSET(-1, "UNSET")""");
+            // spotless:on
+        }
+        for (int i = 0; i <= maxIndex; i++) {
+            final EnumValue enumValue = enumValues.get(i);
+            if (enumValue != null) {
+                // spotless:off
+                final String cleanedEnumComment = enumValue.javaDoc.contains("\n") ?
+                    """
+                    /**
+                     * $enumJavadoc
+                     */
+                    """
+                    .replace("$enumJavadoc",
+                            enumValue.javaDoc.replaceAll("\n\s*","\n * ")) :
+                    """
+                    /** $enumJavadoc */
+                    """
+                    .replace("$enumJavadoc", enumValue.javaDoc);
+                final String deprecatedText = enumValue.deprecated ? "@Deprecated\n" : "";
+                enumValuesCode.add("%s%s%s(%d, \"%s\")"
+                        .formatted(cleanedEnumComment, deprecatedText, camelToUpperSnake(enumValue.name), i,
+                                enumValue.name));
+                // spotless:on
+            }
+        }
+        // spotless:off
+        return """
+                $javaDocComment
+                $deprecated$public enum $enumName
+                        implements com.hedera.pbj.runtime.EnumWithProtoMetadata {
+                $enumValues;
+                
+                    /** The field ordinal in protobuf for this type */
+                    private final int protoOrdinal;
+                
+                    /** The original field name in protobuf for this type */
+                    private final String protoName;
+                
+                    /**
+                     * OneOf Type Enum Constructor
+                     *
+                     * @param protoOrdinal The oneof field ordinal in protobuf for this type
+                     * @param protoName The original field name in protobuf for this type
+                     */
+                    $enumName(final int protoOrdinal, String protoName) {
+                        this.protoOrdinal = protoOrdinal;
+                        this.protoName = protoName;
+                    }
+                
+                    /**
+                     * Get the oneof field ordinal in protobuf for this type
+                     *
+                     * @return The oneof field ordinal in protobuf for this type
+                     */
+                    public int protoOrdinal() {
+                        return protoOrdinal;
+                    }
+                
+                    /**
+                     * Get the original field name in protobuf for this type
+                     *
+                     * @return The original field name in protobuf for this type
+                     */
+                    public String protoName() {
+                        return protoName;
+                    }
+                
+                    /**
+                     * Get enum from protobuf ordinal
+                     *
+                     * @param ordinal the protobuf ordinal number
+                     * @return enum for matching ordinal
+                     * @throws IllegalArgumentException if ordinal doesn't exist
+                     */
+                    public static $enumName fromProtobufOrdinal(int ordinal) {
+                        return switch(ordinal) {
+                            $caseStatements
+                            default -> throw new IllegalArgumentException("Unknown protobuf ordinal "+ordinal);
+                        };
+                    }
+                
+                    /**
+                     * Get enum from string name, supports the enum or protobuf format name
+                     *
+                     * @param name the enum or protobuf format name
+                     * @return enum for matching name
+                     */
+                    public static $enumName fromString(String name) {
+                        return switch(name) {
+                            $fromStringCaseStatements
+                            default -> throw new IllegalArgumentException("Unknown token kyc status "+name);
+                        };
+                    }
+                }
+                """
+                .replace("$javaDocComment", javaDocComment)
+                .replace("$deprecated$", deprecated)
+                .replace("$enumName", enumName)
+                .replace("$enumValues", String.join(",\n\n", enumValuesCode).indent(DEFAULT_INDENT))
+                .replace("$caseStatements", enumValues.entrySet()
+                        .stream()
+                        .map((entry) -> "case %s -> %s;"
+                                .formatted(entry.getKey(), camelToUpperSnake(entry.getValue().name))
+                                .indent(DEFAULT_INDENT * 3))
+                        .collect(Collectors.joining("\n")))
+                .replace("$fromStringCaseStatements", enumValues.values().stream().map(enumValue -> {
+                    if (camelToUpperSnake(enumValue.name).equals(enumValue.name)) {
+                        return "case \"%s\" -> %s;"
+                                .formatted(enumValue.name, camelToUpperSnake(enumValue.name))
+                                .indent(DEFAULT_INDENT * 3);
+                    } else {
+                        return "case \"%s\", \"%s\" -> %s;"
+                                .formatted(enumValue.name, camelToUpperSnake(enumValue.name),
+                                        camelToUpperSnake(enumValue.name)).indent(DEFAULT_INDENT * 3);
+                    }
+                }).collect(Collectors.joining("\n")));
+        // spotless:on
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -43,819 +43,884 @@ public final class ModelGenerator implements Generator {
 
     private static final String NON_NULL_ANNOTATION = "@NonNull";
 
-	private static final String HASH_CODE_MANIPULATION =
-		"""
-		// Shifts: 30, 27, 16, 20, 5, 18, 10, 24, 30
-		hashCode += hashCode << 30;
-		hashCode ^= hashCode >>> 27;
-		hashCode += hashCode << 16;
-		hashCode ^= hashCode >>> 20;
-		hashCode += hashCode << 5;
-		hashCode ^= hashCode >>> 18;
-		hashCode += hashCode << 10;
-		hashCode ^= hashCode >>> 24;
-		hashCode += hashCode << 30;
-		""".indent(DEFAULT_INDENT);
+    private static final String HASH_CODE_MANIPULATION =
+            """
+            // Shifts: 30, 27, 16, 20, 5, 18, 10, 24, 30
+            hashCode += hashCode << 30;
+            hashCode ^= hashCode >>> 27;
+            hashCode += hashCode << 16;
+            hashCode ^= hashCode >>> 20;
+            hashCode += hashCode << 5;
+            hashCode ^= hashCode >>> 18;
+            hashCode += hashCode << 10;
+            hashCode ^= hashCode >>> 24;
+            hashCode += hashCode << 30;
+            """.indent(DEFAULT_INDENT);
 
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>Generates a new model object, as a Java Record type.
-	 */
-	public void generate(final MessageDefContext msgDef,
-                         final File destinationSrcDir,
-                         final File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
+    /**
+     * Generating method that assembles all the previously generated pieces together
+     *
+     * @param modelPackage the model package to use for the code generation
+     * @param imports the imports to use for the code generation
+     * @param javaDocComment the java doc comment to use for the code generation
+     * @param deprecated the deprecated annotation to add
+     * @param javaRecordName the name of the class
+     * @param fields the fields to use for the code generation
+     * @param bodyContent the body content to use for the code generation
+     *
+     * @return the generated code
+     */
+    @NonNull
+    private static String generateClass(final String modelPackage,
+            final Set<String> imports,
+            final String javaDocComment,
+            final String deprecated,
+            final String javaRecordName,
+            final List<Field> fields,
+            final String bodyContent,
+            final boolean isComparable) {
+        final String implementsComparable;
+        if (isComparable) {
+            imports.add("java.lang.Comparable");
+            implementsComparable = "implements Comparable<$javaRecordName> ";
+        } else {
+            implementsComparable = "";
+        }
+        // spotless:off
+        return """
+               package $package;
+               $imports
+               import com.hedera.pbj.runtime.Codec;
+               import java.util.function.Consumer;
+               import edu.umd.cs.findbugs.annotations.Nullable;
+               import edu.umd.cs.findbugs.annotations.NonNull;
+               import static java.util.Objects.requireNonNull;
+               
+               $javaDocComment$deprecated
+               public record $javaRecordName(
+               $fields) $implementsComparable{
+               $bodyContent}
+               """
+                .replace("$package", modelPackage)
+                .replace("$imports", imports.isEmpty() ? ""
+                        : imports.stream().collect(Collectors.joining(".*;\nimport ", "\nimport ", ".*;\n")))
+                .replace("$javaDocComment", javaDocComment)
+                .replace("$deprecated", deprecated)
+                .replace("$implementsComparable", implementsComparable)
+                .replace("$javaRecordName", javaRecordName)
+                .replace("$fields", fields.stream().map(field -> "%s%s %s"
+                        .formatted(getFieldAnnotations(field), field.javaFieldType(), field.nameCamelFirstLower()))
+                        .collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT))
+                .replace("$bodyContent", bodyContent);
+        // spotless:on
+    }
 
+    /**
+     * Returns a set of annotations for a given field.
+     *
+     * @param field a field
+     *
+     * @return an empty string, or a string with Java annotations ending with a space
+     */
+    private static String getFieldAnnotations(final Field field) {
+        if (field.repeated()) {
+            return NON_NULL_ANNOTATION + " ";
+        }
+        return switch (field.type()) {
+            case MESSAGE -> "@Nullable ";
+            case BYTES, STRING -> NON_NULL_ANNOTATION + " ";
+            default -> "";
+        };
+    }
 
-		// The javaRecordName will be something like "AccountID".
-		final var javaRecordName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
-		// The modelPackage is the Java package to put the model class into.
-		final String modelPackage = lookupHelper.getPackageForMessage(FileType.MODEL, msgDef);
-		// The File to write the sources that we generate into
-		final File javaFile = getJavaFile(destinationSrcDir, modelPackage, javaRecordName);
-		// The Javadoc "@Deprecated" tag, which is set if the protobuf schema says the field is deprecated
-		String deprecated = "";
-		// The list of fields, as defined in the protobuf schema
-		final List<Field> fields = new ArrayList<>();
-		// The generated Java code for an enum field if OneOf is used
-		final List<String> oneofEnums = new ArrayList<>();
-		// The generated Java code for getters if OneOf is used
-		final List<String> oneofGetters = new ArrayList<>();
-		// The generated Java code for has methods for normal fields
-		final List<String> hasMethods = new ArrayList<>();
-		// The generated Java import statements. We'll build this up as we go.
-		final Set<String> imports = new TreeSet<>();
-		imports.add("com.hedera.pbj.runtime");
-		imports.add("com.hedera.pbj.runtime.io");
-		imports.add("com.hedera.pbj.runtime.io.buffer");
-		imports.add("com.hedera.pbj.runtime.io.stream");
-		imports.add("edu.umd.cs.findbugs.annotations");
+    /**
+     * Filter the fields to only include those that are comparable
+     *
+     * @param msgDef The message definition
+     * @param lookupHelper The lookup helper
+     * @param fields The fields to filter
+     *
+     * @return the filtered fields
+     */
+    @NonNull
+    private static List<Field> filterComparableFields(final MessageDefContext msgDef,
+            final ContextualLookupHelper lookupHelper,
+            final List<Field> fields) {
+        final Map<String, Field> fieldByName = fields.stream().collect(toMap(Field::name, f -> f));
+        final List<String> comparableFields = lookupHelper.getComparableFields(msgDef);
+        return comparableFields.stream().map(fieldByName::get).collect(Collectors.toList());
+    }
 
-		// Iterate over all the items in the protobuf schema
-		for (final var item : msgDef.messageBody().messageElement()) {
-			if (item.messageDef() != null) { // process sub messages
-				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
-			} else if (item.oneof() != null) { // process one ofs
-				oneofGetters.addAll(generateCodeForOneOf(lookupHelper, item, javaRecordName, imports, oneofEnums, fields));
-			} else if (item.mapField() != null) { // process map fields
-				final MapField field = new MapField(item.mapField(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, false, false);
-			} else if (item.field() != null && item.field().fieldName() != null) {
-				generateCodeForField(lookupHelper, item, fields, imports, hasMethods);
-			} else if (item.optionStatement() != null){
-				if ("deprecated".equals(item.optionStatement().optionName().getText())) {
-					deprecated = "@Deprecated ";
-				} else {
-					System.err.println("Unhandled Option: "+item.optionStatement().getText());
-				}
-			} else if (item.reserved() == null){ // ignore reserved and warn about anything else
-				System.err.println("ModelGenerator Warning - Unknown element: "+item+" -- "+item.getText());
-			}
-		}
+    /**
+     * Generates the compareTo method
+     *
+     * @param fields the fields to use for the code generation
+     * @param javaRecordName the name of the class
+     * @param destinationSrcDir the destination source directory
+     *
+     * @return the generated code
+     */
+    @NonNull
+    private static String generateCompareTo(final List<Field> fields, final String javaRecordName,
+            final File destinationSrcDir) {
+        // spotless:off
+        String bodyContent =
+                """
+                /**
+                 * Implementation of Comparable interface
+                 */
+                @Override
+                public int compareTo($javaRecordName thatObj) {
+                    if (thatObj == null) {
+                        return 1;
+                    }
+                    int result = 0;
+                """.replace("$javaRecordName", javaRecordName).indent(DEFAULT_INDENT);
+        bodyContent += Common.getFieldsCompareToStatements(fields, "", destinationSrcDir);
+        bodyContent +=
+                """
+                    return result;
+                }
+                """.indent(DEFAULT_INDENT);
+        // spotless:on
+        return bodyContent;
+    }
 
-		// process field java doc and insert into record java doc
+    /**
+     * Generates the equals method
+     *
+     * @param fields the fields to use for the code generation
+     * @param javaRecordName the name of the class
+     *
+     * @return the generated code
+     */
+    @NonNull
+    private static String generateEquals(final List<Field> fields, final String javaRecordName) {
+        String equalsStatements = "";
+        // Generate a call to private method that iterates through fields
+        // and calculates the hashcode.
+        equalsStatements = Common.getFieldsEqualsStatements(fields, equalsStatements);
+        // spotless:off
+        String bodyContent =
+                """
+                /**
+                * Override the default equals method for
+                */
+                @Override
+                public boolean equals(Object that) {
+                    if (that == null || this.getClass() != that.getClass()) {
+                        return false;
+                    }
+                    $javaRecordName thatObj = ($javaRecordName)that;
+                """.replace("$javaRecordName", javaRecordName).indent(DEFAULT_INDENT);
+        bodyContent += equalsStatements.indent(DEFAULT_INDENT);
+        bodyContent +=
+                """
+                    return true;
+                }""".indent(DEFAULT_INDENT);
+        // spotless:on
+        return bodyContent;
+    }
 
-		// The javadoc comment to use for the model class, which comes **directly** from the protobuf schema,
-		// but is cleaned up and formatted for use in JavaDoc.
-		final String docComment = (msgDef.docComment() == null || msgDef.docComment().getText().isBlank())
-				? javaRecordName :
-				cleanJavaDocComment(msgDef.docComment().getText());
-		String javaDocComment = "/**\n * " + docComment.replaceAll("\n", "\n * ");
-		if (fields.isEmpty()) {
-			javaDocComment +=  "\n */";
-		} else {
-			javaDocComment += "\n *";
-			for (final var field : fields) {
-				javaDocComment += "\n * @param "+field.nameCamelFirstLower()+" "+
-							field.comment()
-								.replaceAll("\n", "\n *         "+" ".repeat(field.nameCamelFirstLower().length()));
-			}
-			javaDocComment += "\n */";
-		}
+    /**
+     * Generates the hashCode method
+     *
+     * @param fields the fields to use for the code generation
+     *
+     * @return the generated code
+     */
+    @NonNull
+    private static String generateHashCode(final List<Field> fields) {
+        // Generate a call to private method that iterates through fields and calculates the hashcode
+        final String statements = getFieldsHashCode(fields, "");
+        // spotless:off
+        String bodyContent =
+                """
+                /**
+                 * Override the default hashCode method for
+                 * all other objects to make hashCode
+                 */
+                @Override
+                public int hashCode() {
+                    int result = 1;
+                """.indent(DEFAULT_INDENT);
+        bodyContent += statements;
+        bodyContent +=
+                """
+                    long hashCode = result;
+                $hashCodeManipulation
+                    return (int)hashCode;
+                }
+                """.replace("$hashCodeManipulation", HASH_CODE_MANIPULATION).indent(DEFAULT_INDENT);
+        // spotless:on
+        return bodyContent;
+    }
 
-		// === Build Body Content
-		String bodyContent = "";
+    /**
+     * Generates a pre-populated constructor for a class.
+     *
+     * @param fields the fields to use for the code generation
+     *
+     * @return the generated code
+     */
+    private static String generateConstructor(
+            final String constructorName,
+            final List<Field> fields,
+            final boolean shouldThrowOnOneOfNull,
+            final MessageDefContext msgDef,
+            final ContextualLookupHelper lookupHelper) {
+        if (fields.isEmpty()) {
+            return "";
+        }
+        // spotless:off
+        return """
+                   /**
+                    * Create a pre-populated $constructorName.
+                    * $constructorParamDocs
+                    */
+                   public $constructorName($constructorParams) {
+               $constructorCode    }
+               """
+                .replace("$constructorParamDocs", fields.stream().map(field ->
+                        "\n     * @param %s %s".formatted(field.nameCamelFirstLower(),
+                        field.comment().replaceAll("\n", "\n     *         %s"
+                                .formatted(" ".repeat(field.nameCamelFirstLower().length()))))
+                ).collect(Collectors.joining(", ")))
+                .replace("$constructorName", constructorName)
+                .replace("$constructorParams", fields.stream().map(field ->
+                        "%s %s".formatted(field.javaFieldType(), field.nameCamelFirstLower())
+                ).collect(Collectors.joining(", ")))
+                .replace("$constructorCode", fields.stream().map(field -> {
+                    StringBuilder sb = new StringBuilder();
+                    if (shouldThrowOnOneOfNull && field instanceof OneOfField) {
+                        sb.append(generateConstructorCodeForField(field)).append('\n');
+                    }
+                    switch (field.type()) {
+                        case BYTES, STRING: {
+                            sb.append("this.$name = $name != null ? $name : $default;"
+                                    .replace("$name", field.nameCamelFirstLower())
+                                    .replace("$default", getDefaultValue(field, msgDef, lookupHelper))
+                            );
+                            break;
+                        }
+                        case MAP: {
+                            sb.append("this.$name = PbjMap.of($name);"
+                                    .replace("$name", field.nameCamelFirstLower())
+                            );
+                            break;
+                        }
+                        default:
+                            if (field.repeated()) {
+                                sb.append(
+                                        "this.$name = $name == null ? Collections.emptyList() : $name;"
+                                                .replace("$name", field.nameCamelFirstLower()));
+                            } else {
+                                sb.append("this.$name = $name;".replace("$name", field.nameCamelFirstLower()));
+                            }
+                            break;
+                    }
+                    return sb.toString();
+                }).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT * 2));
+        // spotless:on
+    }
 
-		// static codec and default instance
-		bodyContent += generateCodecFields(msgDef, lookupHelper, javaRecordName);
-		bodyContent += "\n";
+    /**
+     * Generates the constructor code for the class
+     *
+     * @param f the field to use for the code generation
+     *
+     * @return the generated code
+     */
+    private static String generateConstructorCodeForField(final Field f) {
+        // spotless:off
+        final StringBuilder sb = new StringBuilder(
+                """
+                if ($fieldName == null) {
+                    throw new NullPointerException("Parameter '$fieldName' must be supplied and can not be null");
+                }""".replace("$fieldName", f.nameCamelFirstLower()));
+        if (f instanceof final OneOfField oof) {
+            for (final Field subField : oof.fields()) {
+                if (subField.optionalValueType()) {
+                    sb.append("""
+                              
+                              // handle special case where protobuf does not have destination between a OneOf with optional
+                              // value of empty vs an unset OneOf.
+                              if ($fieldName.kind() == $fieldUpperNameOneOfType.$subFieldNameUpper && $fieldName.value() == null) {
+                                  $fieldName = new $className<>($fieldUpperNameOneOfType.UNSET, null);
+                              }"""
+                            .replace("$className", oof.className())
+                            .replace("$fieldName", f.nameCamelFirstLower())
+                            .replace("$fieldUpperName", f.nameCamelFirstUpper())
+                            .replace("$subFieldNameUpper", camelToUpperSnake(subField.name()))
+                    );
+                }
+            }
+        }
+        // spotless:on
+        return sb.toString().indent(DEFAULT_INDENT);
+    }
 
-		// constructor
-		bodyContent += generateConstructor(javaRecordName, fields, true, msgDef, lookupHelper);
-		bodyContent += "\n";
+    /**
+     * Generates codec fields for the calss
+     *
+     * @param msgDef the message definition
+     * @param lookupHelper the lookup helper
+     * @param javaRecordName the name of the class
+     *
+     * @return the generated code
+     */
+    @NonNull
+    private static String generateCodecFields(final MessageDefContext msgDef, final ContextualLookupHelper lookupHelper,
+            final String javaRecordName) {
+        // spotless:off
+        return """
+               /** Protobuf codec for reading and writing in protobuf format */
+               public static final Codec<$modelClass> PROTOBUF = new $qualifiedCodecClass();
+               /** JSON codec for reading and writing in JSON format */
+               public static final JsonCodec<$modelClass> JSON = new $qualifiedJsonCodecClass();
+               
+               /** Default instance with all fields set to default values */
+               public static final $modelClass DEFAULT = newBuilder().build();
+               """
+                .replace("$modelClass", javaRecordName)
+                .replace("$qualifiedCodecClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef))
+                .replace("$qualifiedJsonCodecClass",
+                        lookupHelper.getFullyQualifiedMessageClassname(FileType.JSON_CODEC, msgDef))
+                .indent(DEFAULT_INDENT);
+        // spotless:on
+    }
 
-		bodyContent += generateHashCode(fields);
-		bodyContent += "\n";
+    /**
+     * Generates accessor fields for the class
+     *
+     * @param item message element context provided by the parser
+     * @param fields the fields to use for the code generation
+     * @param imports the imports to use for the code generation
+     * @param hasMethods the has methods to use for the code generation
+     */
+    private static void generateCodeForField(final ContextualLookupHelper lookupHelper,
+            final Protobuf3Parser.MessageElementContext item,
+            final List<Field> fields,
+            final Set<String> imports,
+            final List<String> hasMethods) {
+        final SingleField field = new SingleField(item.field(), lookupHelper);
+        fields.add(field);
+        field.addAllNeededImports(imports, true, false, false);
+        // Note that repeated fields default to empty list, so technically they always have a non-null value,
+        // and therefore the additional convenience methods, especially when they throw an NPE, don't make sense.
+        // spotless:off
+        if (field.type() == FieldType.MESSAGE && !field.repeated()) {
+            hasMethods.add(
+                    """
+                    /**
+                     * Convenience method to check if the $fieldName has a value
+                     *
+                     * @return true of the $fieldName has a value
+                     */
+                    public boolean has$fieldNameUpperFirst() {
+                     return $fieldName != null;
+                    }
 
-		bodyContent += generateEquals(fields, javaRecordName);
+                    /**
+                     * Gets the value for $fieldName if it has a value, or else returns the default
+                     * value for the type.
+                     *
+                     * @param defaultValue the default value to return if $fieldName is null
+                     * @return the value for $fieldName if it has a value, or else returns the default value
+                     */
+                    public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
+                     return has$fieldNameUpperFirst() ? $fieldName : defaultValue;
+                    }
 
-		final List<Field> comparableFields = filterComparableFields(msgDef, lookupHelper, fields);
-		final boolean hasComparableFields = !comparableFields.isEmpty();
-		if (hasComparableFields) {
-			bodyContent += generateCompareTo(comparableFields, javaRecordName, destinationSrcDir);
-		}
+                    /**
+                     * Gets the value for $fieldName if it has a value, or else throws an NPE.
+                     * value for the type.
+                     *
+                     * @return the value for $fieldName if it has a value
+                     * @throws NullPointerException if $fieldName is null
+                     */
+                    public @NonNull $javaFieldType $fieldNameOrThrow() {
+                     return requireNonNull($fieldName, "Field $fieldName is null");
+                    }
 
-		// Has methods
-		bodyContent += String.join("\n", hasMethods);
-		bodyContent += "\n";
+                    /**
+                     * Executes the supplied {@link Consumer} if, and only if, the $fieldName has a value
+                     *
+                     * @param ifPresent the {@link Consumer} to execute
+                     */
+                    public void if$fieldNameUpperFirst(@NonNull final Consumer<$javaFieldType> ifPresent) {
+                     if (has$fieldNameUpperFirst()) {
+                         ifPresent.accept($fieldName);
+                     }
+                    }
+                    """
+                    .replace("$fieldNameUpperFirst", field.nameCamelFirstUpper())
+                    .replace("$javaFieldType", field.javaFieldType())
+                    .replace("$fieldName", field.nameCamelFirstLower())
+                    .indent(DEFAULT_INDENT));
+        }
+        // spotless:on
+    }
 
-		// oneof getters
-		bodyContent += String.join("\n    ", oneofGetters);
-		bodyContent += "\n";
+    /**
+     * Generates the code related to the oneof field
+     *
+     * @param lookupHelper the lookup helper
+     * @param item message element context provided by the parser
+     * @param javaRecordName the name of the class
+     * @param imports the imports to use for the code generation
+     * @param oneofEnums the oneof enums to use for the code generation
+     * @param fields the fields to use for the code generation
+     *
+     * @return the generated code
+     */
+    private static List<String> generateCodeForOneOf(final ContextualLookupHelper lookupHelper,
+            final Protobuf3Parser.MessageElementContext item,
+            final String javaRecordName,
+            final Set<String> imports,
+            final List<String> oneofEnums,
+            final List<Field> fields) {
+        final List<String> oneofGetters = new ArrayList<>();
+        final var oneOfField = new OneOfField(item.oneof(), javaRecordName, lookupHelper);
+        final var enumName = oneOfField.nameCamelFirstUpper() + "OneOfType";
+        final int maxIndex = oneOfField.fields().getLast().fieldNumber();
+        final Map<Integer, EnumValue> enumValues = new HashMap<>();
+        // spotless:off
+        for (final var field : oneOfField.fields()) {
+            final String javaFieldType = javaPrimitiveToObjectType(field.javaFieldType());
+            final String enumComment = cleanDocStr(field.comment())
+                    .replaceAll("[\t\s]*/\\*\\*", "") // remove doc start indenting
+                    .replaceAll("\n[\t\s]+\\*", "\n") // remove doc indenting
+                    .replaceAll("/\\*\\*", "") //  remove doc start
+                    .replaceAll("\\*\\*/", ""); //  remove doc end
+            enumValues.put(field.fieldNumber(), new EnumValue(field.name(), field.deprecated(), enumComment));
+            // generate getters for one ofs
+            oneofGetters.add(
+                    """
+                    /**
+                     * Direct typed getter for one of field $fieldName.
+                     *
+                     * @return one of value or null if one of is not set or a different one of value
+                     */
+                    public @Nullable $javaFieldType $fieldName() {
+                       return $oneOfField.kind() == $enumName.$enumValue ? ($javaFieldType)$oneOfField.value() : null;
+                    }
 
-		// builder copy & new builder methods
-		bodyContent = genrateBuilderFactoryMethods(bodyContent, fields);
-		bodyContent += "\n";
+                    /**
+                     * Convenience method to check if the $oneOfField has a one-of with type $enumValue
+                     *
+                     * @return true of the one of kind is $enumValue
+                     */
+                    public boolean has$fieldNameUpperFirst() {
+                       return $oneOfField.kind() == $enumName.$enumValue;
+                    }
 
-		// generate builder
-		bodyContent += generateBuilder(msgDef, fields, lookupHelper);
-		if (!oneofEnums.isEmpty()) bodyContent += "\n";
+                    /**
+                     * Gets the value for $fieldName if it has a value, or else returns the default
+                     * value for the type.
+                     *
+                     * @param defaultValue the default value to return if $fieldName is null
+                     * @return the value for $fieldName if it has a value, or else returns the default value
+                     */
+                    public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
+                       return has$fieldNameUpperFirst() ? $fieldName() : defaultValue;
+                    }
 
-		// oneof enums
-		bodyContent += String.join("\n    ", oneofEnums);
+                    /**
+                     * Gets the value for $fieldName if it was set, or throws a NullPointerException if it was not set.
+                     *
+                     * @return the value for $fieldName if it has a value
+                     * @throws NullPointerException if $fieldName is null
+                     */
+                    public @NonNull $javaFieldType $fieldNameOrThrow() {
+                       return requireNonNull($fieldName(), "Field $fieldName is null");
+                    }
+                    """
+                    .replace("$fieldNameUpperFirst", field.nameCamelFirstUpper())
+                    .replace("$fieldName", field.nameCamelFirstLower())
+                    .replace("$javaFieldType", javaFieldType)
+                    .replace("$oneOfField", oneOfField.nameCamelFirstLower())
+                    .replace("$enumName", enumName)
+                    .replace("$enumValue", camelToUpperSnake(field.name()))
+                    .indent(DEFAULT_INDENT)
+            );
+            if (field.type() == FieldType.MESSAGE) {
+                field.addAllNeededImports(imports, true, false, false);
+            }
+        }
+        // spotless:on
+        final String enumComment =
+                """
+                /**
+                 * Enum for the type of "%s" oneof value
+                 */""".formatted(oneOfField.name());
+        final String enumString = createEnum(enumComment, "", enumName, maxIndex, enumValues, true)
+                .indent(DEFAULT_INDENT * 2);
+        oneofEnums.add(enumString);
+        fields.add(oneOfField);
+        imports.add("com.hedera.pbj.runtime");
+        return oneofGetters;
+    }
 
-		// === Build file
-		try (final FileWriter javaWriter = new FileWriter(javaFile)) {
-			javaWriter.write(
-					generateClass(modelPackage, imports, javaDocComment, deprecated, javaRecordName, fields, bodyContent, hasComparableFields)
-			);
-		}
-	}
+    @NonNull
+    private static String genrateBuilderFactoryMethods(String bodyContent, final List<Field> fields) {
+        // spotless:off
+        bodyContent +=
+                """
+                /**
+                 * Return a builder for building a copy of this model object. It will be pre-populated with all the data from this
+                 * model object.
+                 *
+                 * @return a pre-populated builder
+                 */
+                public Builder copyBuilder() {
+                    return new Builder(%s);
+                }
+                
+                /**
+                 * Return a new builder for building a model object. This is just a shortcut for <code>new Model.Builder()</code>.
+                 *
+                 * @return a new builder
+                 */
+                public static Builder newBuilder() {
+                    return new Builder();
+                }
+                """
+                .formatted(fields.stream().map(Field::nameCamelFirstLower).collect(Collectors.joining(", ")))
+                .indent(DEFAULT_INDENT);
+        // spotless:on
+        return bodyContent;
+    }
 
-	/**
-	 * Generating method that assembles all the previously generated pieces together
-	 * @param modelPackage the model package to use for the code generation
-	 * @param imports the imports to use for the code generation
-	 * @param javaDocComment the java doc comment to use for the code generation
-	 * @param deprecated the deprecated annotation to add
-	 * @param javaRecordName the name of the class
-	 * @param fields the fields to use for the code generation
-	 * @param bodyContent the body content to use for the code generation
-	 * @return the generated code
-	 */
-	@NonNull
-	private static String generateClass(final String modelPackage,
-										final Set<String> imports,
-										final String javaDocComment,
-										final String deprecated,
-										final String javaRecordName,
-										final List<Field> fields,
-										final String bodyContent,
-										final boolean isComparable) {
-		final String implementsComparable;
-		if (isComparable) {
-			imports.add("java.lang.Comparable");
-			implementsComparable = "implements Comparable<$javaRecordName> ";
-		} else {
-			implementsComparable = "";
-		}
+    private static void generateBuilderMethods(
+            final List<String> builderMethods,
+            final MessageDefContext msgDef,
+            final Field field,
+            final ContextualLookupHelper lookupHelper) {
+        final String prefix, postfix, fieldToSet;
+        final String fieldAnnotations = getFieldAnnotations(field);
+        final OneOfField parentOneOfField = field.parent();
+        final String fieldName = field.nameCamelFirstLower();
+        if (parentOneOfField != null) {
+            final String oneOfEnumValue = "%s.%s"
+                    .formatted(parentOneOfField.getEnumClassRef(), camelToUpperSnake(field.name()));
+            prefix = "%s%s,".formatted(" new %s<>(".formatted(parentOneOfField.className()), oneOfEnumValue);
+            postfix = ")";
+            fieldToSet = parentOneOfField.nameCamelFirstLower();
+        } else if (fieldAnnotations.contains(NON_NULL_ANNOTATION)) {
+            prefix = "";
+            postfix = " != null ? %s : %s".formatted(fieldName, getDefaultValue(field, msgDef, lookupHelper));
+            fieldToSet = fieldName;
+        } else {
+            prefix = "";
+            postfix = "";
+            fieldToSet = fieldName;
+        }
+        // spotless:off
+        builderMethods.add(
+                """
+                /**
+                 * $fieldDoc
+                 *
+                 * @param $fieldName value to set
+                 * @return builder to continue building with
+                 */
+                public Builder $fieldName($fieldAnnotations$fieldType $fieldName) {
+                    this.$fieldToSet = $prefix$fieldName$postfix;
+                    return this;
+                }"""
+                .replace("$fieldDoc", field.comment()
+                        .replaceAll("\n", "\n * "))
+                .replace("$fieldName", fieldName)
+                .replace("$fieldToSet", fieldToSet)
+                .replace("$prefix", prefix)
+                .replace("$postfix", postfix)
+                .replace("$fieldAnnotations", fieldAnnotations)
+                .replace("$fieldType", field.javaFieldType())
+                .indent(DEFAULT_INDENT)
+        );
+        // add nice method for simple message fields so can just set using un-built builder
+        if (field.type() == Field.FieldType.MESSAGE && !field.optionalValueType() && !field.repeated()) {
+            builderMethods.add(
+                    """
+                    /**
+                     * $fieldDoc
+                     *
+                     * @param builder A pre-populated builder
+                     * @return builder to continue building with
+                     */
+                    public Builder $fieldName($messageClass.Builder builder) {
+                        this.$fieldToSet =$prefix builder.build() $postfix;
+                        return this;
+                    }"""
+                    .replace("$messageClass", field.messageType())
+                    .replace("$fieldDoc", field.comment()
+                            .replaceAll("\n", "\n * "))
+                    .replace("$fieldName", fieldName)
+                    .replace("$fieldToSet", fieldToSet)
+                    .replace("$prefix", prefix)
+                    .replace("$postfix", postfix)
+                    .replace("$fieldType", field.javaFieldType())
+                    .indent(DEFAULT_INDENT)
+            );
+            // spotless:on
+        }
 
-		return """
-				package $package;
-				$imports
-				import com.hedera.pbj.runtime.Codec;
-				import java.util.function.Consumer;
-				import edu.umd.cs.findbugs.annotations.Nullable;
-				import edu.umd.cs.findbugs.annotations.NonNull;
-				import static java.util.Objects.requireNonNull;
-				
-				$javaDocComment$deprecated
-				public record $javaRecordName(
-				$fields) $implementsComparable{
-				$bodyContent}
-				"""
-				.replace("$package", modelPackage)
-				.replace("$imports", imports.isEmpty() ? "" : imports.stream().collect(Collectors.joining(".*;\nimport ", "\nimport ", ".*;\n")))
-				.replace("$javaDocComment", javaDocComment)
-				.replace("$deprecated", deprecated)
-				.replace("$implementsComparable", implementsComparable)
-				.replace("$javaRecordName", javaRecordName)
-				.replace("$fields", fields.stream().map(field ->
-						getFieldAnnotations(field)
-								+ field.javaFieldType() + " " + field.nameCamelFirstLower()
-				).collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT))
-				.replace("$bodyContent", bodyContent);
-	}
+        // add nice method for message fields with list types for varargs
+        if (field.repeated()) {
+            // Need to re-define the prefix and postfix for repeated fields because they don't use `values` directly
+            // but wrap it in List.of(values) instead, so the simple definitions above don't work here.
+            final String repeatedPrefix;
+            final String repeatedPostfix;
+            // spotless:off
+            if (parentOneOfField != null) {
+                repeatedPrefix = "%s values == null ? %s : "
+                        .formatted(prefix, getDefaultValue(field, msgDef, lookupHelper));
+                repeatedPostfix = postfix;
+            } else if (fieldAnnotations.contains(NON_NULL_ANNOTATION)) {
+                repeatedPrefix = "values == null ? %s : "
+                        .formatted(getDefaultValue(field, msgDef, lookupHelper));
+                repeatedPostfix = "";
+            } else {
+                repeatedPrefix = prefix;
+                repeatedPostfix = postfix;
+            }
+            builderMethods.add(
+                    """
+                    /**
+                     * $fieldDoc
+                     *
+                     * @param values varargs value to be built into a list
+                     * @return builder to continue building with
+                     */
+                    public Builder $fieldName($baseType ... values) {
+                        this.$fieldToSet = $repeatedPrefix List.of(values) $repeatedPostfix;
+                        return this;
+                    }"""
+                    .replace("$baseType",
+                            field.javaFieldType().substring("List<".length(), field.javaFieldType().length() - 1))
+                    .replace("$fieldDoc", field.comment()
+                            .replaceAll("\n", "\n * "))
+                    .replace("$fieldName", fieldName)
+                    .replace("$fieldToSet", fieldToSet)
+                    .replace("$fieldType", field.javaFieldType())
+                    .replace("$repeatedPrefix", repeatedPrefix)
+                    .replace("$repeatedPostfix", repeatedPostfix)
+                    .indent(DEFAULT_INDENT)
+            );
+            // spotless:on
+        }
+    }
 
-	/**
-	 * Returns a set of annotations for a given field.
-	 * @param field a field
-	 * @return an empty string, or a string with Java annotations ending with a space
-	 */
-	private static String getFieldAnnotations(final Field field) {
-		if (field.repeated()) return NON_NULL_ANNOTATION + " ";
+    /**
+     * Generates the builder for the class
+     *
+     * @param msgDef the message definition
+     * @param fields the fields to use for the code generation
+     * @param lookupHelper the lookup helper
+     *
+     * @return the generated code
+     */
+    private static String generateBuilder(final MessageDefContext msgDef, final List<Field> fields,
+            final ContextualLookupHelper lookupHelper) {
+        final String javaRecordName = msgDef.messageName().getText();
+        final List<String> builderMethods = new ArrayList<>();
+        for (final Field field : fields) {
+            if (field.type() == Field.FieldType.ONE_OF) {
+                final OneOfField oneOfField = (OneOfField)field;
+                for (final Field subField : oneOfField.fields()) {
+                    generateBuilderMethods(builderMethods, msgDef, subField, lookupHelper);
+                }
+            } else {
+                generateBuilderMethods(builderMethods, msgDef, field, lookupHelper);
+            }
+        }
+        // spotless:off
+        return """
+               /**
+                * Builder class for easy creation, ideal for clean code where performance is not critical. In critical performance
+                * paths use the constructor directly.
+                */
+               public static final class Builder {
+                   $fields;
+               
+                   /**
+                    * Create an empty builder
+                    */
+                   public Builder() {}
+               
+               $prePopulatedBuilder
+                   /**
+                    * Build a new model record with data set on builder
+                    *
+                    * @return new model record with data set
+                    */
+                   public $javaRecordName build() {
+                       return new $javaRecordName($recordParams);
+                   }
+               
+               $builderMethods}"""
+                .replace("$fields", fields.stream().map(field -> "%sprivate %s %s = %s"
+                        .formatted(getFieldAnnotations(field), field.javaFieldType(), field.nameCamelFirstLower(),
+                                getDefaultValue(field, msgDef, lookupHelper)))
+                .collect(Collectors.joining(";\n    ")))
+                .replace("$prePopulatedBuilder", generateConstructor("Builder", fields, false, msgDef, lookupHelper))
+                .replace("$javaRecordName", javaRecordName)
+                .replace("$recordParams",
+                        fields.stream().map(Field::nameCamelFirstLower).collect(Collectors.joining(", ")))
+                .replace("$builderMethods", String.join("\n", builderMethods))
+                .indent(DEFAULT_INDENT);
+        // spotless:on
+    }
 
-		return switch (field.type()) {
-			case MESSAGE -> "@Nullable ";
-			case BYTES, STRING -> NON_NULL_ANNOTATION + " ";
-			default -> "";
-		};
-	}
+    /**
+     * Gets the default value for the field
+     *
+     * @param field the field to use for the code generation
+     * @param msgDef the message definition
+     * @param lookupHelper the lookup helper
+     *
+     * @return the generated code
+     */
+    private static String getDefaultValue(final Field field, final MessageDefContext msgDef,
+            final ContextualLookupHelper lookupHelper) {
+        if (field.type() == Field.FieldType.ONE_OF) {
+            return lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef) + "." + field.javaDefault();
+        } else {
+            return field.javaDefault();
+        }
+    }
 
-	/**
-	 * Filter the fields to only include those that are comparable
-	 * @param msgDef The message definition
-	 * @param lookupHelper The lookup helper
-	 * @param fields The fields to filter
-	 * @return the filtered fields
-	 */
-	@NonNull
-	private static List<Field> filterComparableFields(final MessageDefContext msgDef,
-													final ContextualLookupHelper lookupHelper,
-													final List<Field> fields) {
-		final Map<String, Field> fieldByName = fields.stream().collect(toMap(Field::name, f -> f));
-		final List<String> comparableFields = lookupHelper.getComparableFields(msgDef);
-		return comparableFields.stream().map(fieldByName::get).collect(Collectors.toList());
-	}
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Generates a new model object, as a Java Record type.
+     */
+    public void generate(final MessageDefContext msgDef,
+            final File destinationSrcDir,
+            final File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
 
-	/**
-	 * Generates the compareTo method
-	 *
-	 * @param fields                the fields to use for the code generation
-	 * @param javaRecordName        the name of the class
-	 * @param destinationSrcDir     the destination source directory
-	 * @return the generated code
-	 */
-	@NonNull
-	private static String generateCompareTo(final List<Field> fields, final String javaRecordName, final File destinationSrcDir) {
-		String bodyContent =
-			"""
-			/**
-			 * Implementation of Comparable interface
-			 */
-			@Override
-			public int compareTo($javaRecordName thatObj) {
-				if (thatObj == null) {
-					return 1;
-				}
-				int result = 0;
-			""".replace("$javaRecordName", javaRecordName).indent(DEFAULT_INDENT);
+        // The javaRecordName will be something like "AccountID".
+        final var javaRecordName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
+        // The modelPackage is the Java package to put the model class into.
+        final String modelPackage = lookupHelper.getPackageForMessage(FileType.MODEL, msgDef);
+        // The File to write the sources that we generate into
+        final File javaFile = getJavaFile(destinationSrcDir, modelPackage, javaRecordName);
+        // The Javadoc "@Deprecated" tag, which is set if the protobuf schema says the field is deprecated
+        String deprecated = "";
+        // The list of fields, as defined in the protobuf schema
+        final List<Field> fields = new ArrayList<>();
+        // The generated Java code for an enum field if OneOf is used
+        final List<String> oneofEnums = new ArrayList<>();
+        // The generated Java code for getters if OneOf is used
+        final List<String> oneofGetters = new ArrayList<>();
+        // The generated Java code for has methods for normal fields
+        final List<String> hasMethods = new ArrayList<>();
+        // The generated Java import statements. We'll build this up as we go.
+        final Set<String> imports = new TreeSet<>();
+        imports.add("com.hedera.pbj.runtime");
+        imports.add("com.hedera.pbj.runtime.io");
+        imports.add("com.hedera.pbj.runtime.io.buffer");
+        imports.add("com.hedera.pbj.runtime.io.stream");
+        imports.add("edu.umd.cs.findbugs.annotations");
 
-		bodyContent += Common.getFieldsCompareToStatements(fields, "", destinationSrcDir);
+        // Iterate over all the items in the protobuf schema
+        for (final var item : msgDef.messageBody().messageElement()) {
+            if (item.messageDef() != null) { // process sub messages
+                generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
+            } else if (item.oneof() != null) { // process one ofs
+                oneofGetters.addAll(
+                        generateCodeForOneOf(lookupHelper, item, javaRecordName, imports, oneofEnums, fields));
+            } else if (item.mapField() != null) { // process map fields
+                final MapField field = new MapField(item.mapField(), lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, false, false);
+            } else if (item.field() != null && item.field().fieldName() != null) {
+                generateCodeForField(lookupHelper, item, fields, imports, hasMethods);
+            } else if (item.optionStatement() != null) {
+                if ("deprecated".equals(item.optionStatement().optionName().getText())) {
+                    deprecated = "@Deprecated ";
+                } else {
+                    System.err.printf("Unhandled Option: %s%n", item.optionStatement().getText());
+                }
+            } else if (item.reserved() == null) { // ignore reserved and warn about anything else
+                System.err.printf("ModelGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
+            }
+        }
 
-		bodyContent +=
-			"""
-				return result;
-			}
-			""".indent(DEFAULT_INDENT);
-		return bodyContent;
-	}
+        // process field java doc and insert into record java doc
 
-	/**
-	 * Generates the equals method
-	 * @param fields the fields to use for the code generation
-	 * @param javaRecordName the name of the class
-	 * @return the generated code
-	 */
-	@NonNull
-	private static String generateEquals(final List<Field> fields, final String javaRecordName) {
-		String equalsStatements = "";
-		// Generate a call to private method that iterates through fields
-		// and calculates the hashcode.
-		equalsStatements = Common.getFieldsEqualsStatements(fields, equalsStatements);
+        // The javadoc comment to use for the model class, which comes **directly** from the protobuf schema,
+        // but is cleaned up and formatted for use in JavaDoc.
+        final String docComment = (msgDef.docComment() == null || msgDef.docComment().getText().isBlank())
+                ? javaRecordName :
+                cleanJavaDocComment(msgDef.docComment().getText());
+        String javaDocComment = "/**\n * " + docComment.replaceAll("\n", "\n * ");
+        if (fields.isEmpty()) {
+            javaDocComment += "\n */";
+        } else {
+            // spotless:off
+            javaDocComment += "\n *";
+            for (final var field : fields) {
+                final int nameLength = field.nameCamelFirstLower().length();
+                final String indentedComment = field.comment()
+                        .replaceAll("\n", "\n *         %s".formatted(" ".repeat(nameLength)));
+                javaDocComment += "\n * @param %s %s".formatted(field.nameCamelFirstLower(), indentedComment);
+            }
+            javaDocComment += "\n */";
+            // spotless:on
+        }
 
-		String bodyContent =
-		"""
-		/**
-		* Override the default equals method for
-		*/
-		@Override
-		public boolean equals(Object that) {
-		    if (that == null || this.getClass() != that.getClass()) {
-		        return false;
-		    }
-		    $javaRecordName thatObj = ($javaRecordName)that;
-		""".replace("$javaRecordName", javaRecordName).indent(DEFAULT_INDENT);
+        // === Build Body Content
+        String bodyContent = "";
 
-		bodyContent += equalsStatements.indent(DEFAULT_INDENT);
-		bodyContent +=
-		"""
-		    return true;
-		}""".indent(DEFAULT_INDENT);
-		return bodyContent;
-	}
+        // static codec and default instance
+        bodyContent += generateCodecFields(msgDef, lookupHelper, javaRecordName);
+        bodyContent += "\n";
 
-	/**
-	 * Generates the hashCode method
-	 * @param fields the fields to use for the code generation
-	 * @return the generated code
-	 */
-	@NonNull
-	private static String generateHashCode(final List<Field> fields) {
-		// Generate a call to private method that iterates through fields and calculates the hashcode
-		final String statements = getFieldsHashCode(fields, "");
+        // constructor
+        bodyContent += generateConstructor(javaRecordName, fields, true, msgDef, lookupHelper);
+        bodyContent += "\n";
 
-		String bodyContent =
-			"""
-			/**
-			 * Override the default hashCode method for
-			 * all other objects to make hashCode
-			 */
-			@Override
-			public int hashCode() {
-				int result = 1;
-			""".indent(DEFAULT_INDENT);
+        bodyContent += generateHashCode(fields);
+        bodyContent += "\n";
 
-		bodyContent += statements;
+        bodyContent += generateEquals(fields, javaRecordName);
 
-		bodyContent +=
-			"""
-				long hashCode = result;
-			$hashCodeManipulation
-				return (int)hashCode;
-			}
-			""".replace("$hashCodeManipulation", HASH_CODE_MANIPULATION)
-				.indent(DEFAULT_INDENT);
-		return bodyContent;
-	}
+        final List<Field> comparableFields = filterComparableFields(msgDef, lookupHelper, fields);
+        final boolean hasComparableFields = !comparableFields.isEmpty();
+        if (hasComparableFields) {
+            bodyContent += generateCompareTo(comparableFields, javaRecordName, destinationSrcDir);
+        }
 
-	/**
-	 * Generates a pre-populated constructor for a class.
-	 * @param fields the fields to use for the code generation
-	 * @return the generated code
-	 */
-	private static String generateConstructor(
-			final String constructorName,
-			final List<Field> fields,
-			final boolean shouldThrowOnOneOfNull,
-			final MessageDefContext msgDef,
-			final ContextualLookupHelper lookupHelper) {
-		if (fields.isEmpty()) {
-			return "";
-		}
-		return """
-			    /**
-			     * Create a pre-populated $constructorName.
-			     * $constructorParamDocs
-			     */
-			    public $constructorName($constructorParams) {
-			$constructorCode    }
-			"""
-				.replace("$constructorParamDocs",fields.stream().map(field ->
-						"\n     * @param "+field.nameCamelFirstLower()+" "+
-								field.comment().replaceAll("\n", "\n     *         "+" ".repeat(field.nameCamelFirstLower().length()))
-				).collect(Collectors.joining(", ")))
-				.replace("$constructorName", constructorName)
-				.replace("$constructorParams",fields.stream().map(field ->
-						field.javaFieldType() + " " + field.nameCamelFirstLower()
-				).collect(Collectors.joining(", ")))
-				.replace("$constructorCode",fields.stream().map(field -> {
-					StringBuilder sb = new StringBuilder();
-					if (shouldThrowOnOneOfNull && field instanceof OneOfField) {
-						sb.append(generateConstructorCodeForField(field)).append('\n');
-					}
-					switch (field.type()) {
-						case BYTES, STRING: {
-							sb.append("this.$name = $name != null ? $name : $default;"
-									.replace("$name", field.nameCamelFirstLower())
-									.replace("$default", getDefaultValue(field, msgDef, lookupHelper))
-							);
-							break;
-						}
-						case MAP: {
-							sb.append("this.$name = PbjMap.of($name);"
-									.replace("$name", field.nameCamelFirstLower())
-							);
-							break;
-						}
-						default:
-							if (field.repeated()) {
-								sb.append("this.$name = $name == null ? Collections.emptyList() : $name;".replace("$name", field.nameCamelFirstLower()));
-							} else {
-								sb.append("this.$name = $name;".replace("$name", field.nameCamelFirstLower()));
-							}
-							break;
-					}
-					return sb.toString();
-				}).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT * 2));
-	}
+        // Has methods
+        bodyContent += String.join("\n", hasMethods);
+        bodyContent += "\n";
 
-	/**
-	 * Generates the constructor code for the class
-	 * @param f the field to use for the code generation
-	 * @return the generated code
-	 */
-	private static String generateConstructorCodeForField(final Field f) {
-		final StringBuilder sb = new StringBuilder("""
-								if ($fieldName == null) {
-								    throw new NullPointerException("Parameter '$fieldName' must be supplied and can not be null");
-								}""".replace("$fieldName", f.nameCamelFirstLower()));
-		if (f instanceof final OneOfField oof) {
-			for (final Field subField: oof.fields()) {
-				if (subField.optionalValueType()) {
-					sb.append("""
-       
-							// handle special case where protobuf does not have destination between a OneOf with optional
-							// value of empty vs an unset OneOf.
-							if ($fieldName.kind() == $fieldUpperNameOneOfType.$subFieldNameUpper && $fieldName.value() == null) {
-								$fieldName = new $className<>($fieldUpperNameOneOfType.UNSET, null);
-							}"""
-							.replace("$className", oof.className())
-							.replace("$fieldName", f.nameCamelFirstLower())
-							.replace("$fieldUpperName", f.nameCamelFirstUpper())
-							.replace("$subFieldNameUpper", camelToUpperSnake(subField.name()))
-					);
-				}
-			}
-		}
-		return sb.toString().indent(DEFAULT_INDENT);
-	}
+        // oneof getters
+        bodyContent += String.join("\n    ", oneofGetters);
+        bodyContent += "\n";
 
-	/**
-	 * Generates codec fields for the calss
-	 * @param msgDef the message definition
-	 * @param lookupHelper the lookup helper
-	 * @param javaRecordName the name of the class
-	 * @return the generated code
-	 */
-	@NonNull
-	private static String generateCodecFields(final MessageDefContext msgDef, final ContextualLookupHelper lookupHelper, final String javaRecordName) {
-		return """
-				/** Protobuf codec for reading and writing in protobuf format */
-				public static final Codec<$modelClass> PROTOBUF = new $qualifiedCodecClass();
-				/** JSON codec for reading and writing in JSON format */
-				public static final JsonCodec<$modelClass> JSON = new $qualifiedJsonCodecClass();
-				
-				/** Default instance with all fields set to default values */
-				public static final $modelClass DEFAULT = newBuilder().build();
-				"""
-				.replace("$modelClass", javaRecordName)
-				.replace("$qualifiedCodecClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef))
-				.replace("$qualifiedJsonCodecClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.JSON_CODEC, msgDef))
-				.indent(DEFAULT_INDENT);
-	}
+        // builder copy & new builder methods
+        bodyContent = genrateBuilderFactoryMethods(bodyContent, fields);
+        bodyContent += "\n";
 
-	/**
-	 * Generates accessor fields for the class
-	 * @param item message element context provided by the parser
-	 * @param fields the fields to use for the code generation
-	 * @param imports the imports to use for the code generation
-	 * @param hasMethods the has methods to use for the code generation
-	 */
-	private static void generateCodeForField(final ContextualLookupHelper lookupHelper,
-                                             final Protobuf3Parser.MessageElementContext item,
-                                             final List<Field> fields,
-                                             final Set<String> imports,
-                                             final List<String> hasMethods) {
-		final SingleField field = new SingleField(item.field(), lookupHelper);
-		fields.add(field);
-		field.addAllNeededImports(imports, true, false, false);
-		// Note that repeated fields default to empty list, so technically they always have a non-null value,
-		// and therefore the additional convenience methods, especially when they throw an NPE, don't make sense.
-		if (field.type() == FieldType.MESSAGE && !field.repeated()) {
-			hasMethods.add("""
-					/**
-					 * Convenience method to check if the $fieldName has a value
-					 *
-					 * @return true of the $fieldName has a value
-					 */
-					public boolean has$fieldNameUpperFirst() {
-						return $fieldName != null;
-					}
-					
-					/**
-					 * Gets the value for $fieldName if it has a value, or else returns the default
-					 * value for the type.
-					 *
-					 * @param defaultValue the default value to return if $fieldName is null
-					 * @return the value for $fieldName if it has a value, or else returns the default value
-					 */
-					public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
-						return has$fieldNameUpperFirst() ? $fieldName : defaultValue;
-					}
-					
-					/**
-					 * Gets the value for $fieldName if it has a value, or else throws an NPE.
-					 * value for the type.
-					 *
-					 * @return the value for $fieldName if it has a value
-					 * @throws NullPointerException if $fieldName is null
-					 */
-					public @NonNull $javaFieldType $fieldNameOrThrow() {
-						return requireNonNull($fieldName, "Field $fieldName is null");
-					}
-					
-					/**
-					 * Executes the supplied {@link Consumer} if, and only if, the $fieldName has a value
-					 *
-					 * @param ifPresent the {@link Consumer} to execute
-					 */
-					public void if$fieldNameUpperFirst(@NonNull final Consumer<$javaFieldType> ifPresent) {
-						if (has$fieldNameUpperFirst()) {
-							ifPresent.accept($fieldName);
-						}
-					}
-					"""
-					.replace("$fieldNameUpperFirst", field.nameCamelFirstUpper())
-					.replace("$javaFieldType", field.javaFieldType())
-					.replace("$fieldName", field.nameCamelFirstLower())
-					.indent(DEFAULT_INDENT)
-			);
-		}
-	}
+        // generate builder
+        bodyContent += generateBuilder(msgDef, fields, lookupHelper);
+        if (!oneofEnums.isEmpty()) {
+            bodyContent += "\n";
+        }
 
-	/**
-	 * Generates the code related to the oneof field
-	 * @param lookupHelper the lookup helper
-	 * @param item message element context provided by the parser
-	 * @param javaRecordName the name of the class
-	 * @param imports the imports to use for the code generation
-	 * @param oneofEnums the oneof enums to use for the code generation
-	 * @param fields the fields to use for the code generation
-	 * @return the generated code
-	 */
-	private static List<String>  generateCodeForOneOf(final ContextualLookupHelper lookupHelper,
-                                                      final Protobuf3Parser.MessageElementContext item,
-                                                      final String javaRecordName,
-                                                      final Set<String> imports,
-                                                      final List<String> oneofEnums,
-                                                      final List<Field> fields) {
-		final List<String> oneofGetters = new ArrayList<>();
-		final var oneOfField = new OneOfField(item.oneof(), javaRecordName, lookupHelper);
-		final var enumName = oneOfField.nameCamelFirstUpper() + "OneOfType";
-		final int maxIndex = oneOfField.fields().getLast().fieldNumber();
-		final Map<Integer, EnumValue> enumValues = new HashMap<>();
-		for (final var field : oneOfField.fields()) {
-			final String javaFieldType = javaPrimitiveToObjectType(field.javaFieldType());
-			final String enumComment = cleanDocStr(field.comment())
-				.replaceAll("[\t\s]*/\\*\\*","") // remove doc start indenting
-				.replaceAll("\n[\t\s]+\\*","\n") // remove doc indenting
-				.replaceAll("/\\*\\*","") //  remove doc start
-				.replaceAll("\\*\\*/",""); //  remove doc end
-			enumValues.put(field.fieldNumber(), new EnumValue(field.name(), field.deprecated(), enumComment));
-			// generate getters for one ofs
-			oneofGetters.add("""
-					/**
-					 * Direct typed getter for one of field $fieldName.
-					 *
-					 * @return one of value or null if one of is not set or a different one of value
-					 */
-					public @Nullable $javaFieldType $fieldName() {
-						return $oneOfField.kind() == $enumName.$enumValue ? ($javaFieldType)$oneOfField.value() : null;
-					}
-					
-					/**
-					 * Convenience method to check if the $oneOfField has a one-of with type $enumValue
-					 *
-					 * @return true of the one of kind is $enumValue
-					 */
-					public boolean has$fieldNameUpperFirst() {
-						return $oneOfField.kind() == $enumName.$enumValue;
-					}
-					
-					/**
-					 * Gets the value for $fieldName if it has a value, or else returns the default
-					 * value for the type.
-					 *
-					 * @param defaultValue the default value to return if $fieldName is null
-					 * @return the value for $fieldName if it has a value, or else returns the default value
-					 */
-					public $javaFieldType $fieldNameOrElse(@NonNull final $javaFieldType defaultValue) {
-						return has$fieldNameUpperFirst() ? $fieldName() : defaultValue;
-					}
-					
-					/**
-					 * Gets the value for $fieldName if it was set, or throws a NullPointerException if it was not set.
-					 *
-					 * @return the value for $fieldName if it has a value
-					 * @throws NullPointerException if $fieldName is null
-					 */
-					public @NonNull $javaFieldType $fieldNameOrThrow() {
-						return requireNonNull($fieldName(), "Field $fieldName is null");
-					}
-					"""
-					.replace("$fieldNameUpperFirst",field.nameCamelFirstUpper())
-					.replace("$fieldName",field.nameCamelFirstLower())
-					.replace("$javaFieldType",javaFieldType)
-					.replace("$oneOfField",oneOfField.nameCamelFirstLower())
-					.replace("$enumName",enumName)
-					.replace("$enumValue",camelToUpperSnake(field.name()))
-					.indent(DEFAULT_INDENT)
-			);
-			if (field.type() == FieldType.MESSAGE) {
-				field.addAllNeededImports(imports, true, false, false);
-			}
-		}
-		final String enumComment = """
-							/**
-							 * Enum for the type of "%s" oneof value
-							 */""".formatted(oneOfField.name());
-		final String enumString = createEnum(enumComment ,"",enumName,maxIndex,enumValues, true)
-				.indent(DEFAULT_INDENT * 2);
-		oneofEnums.add(enumString);
-		fields.add(oneOfField);
-		imports.add("com.hedera.pbj.runtime");
-		return oneofGetters;
-	}
+        // oneof enums
+        bodyContent += String.join("\n    ", oneofEnums);
 
-	@NonNull
-	private static String genrateBuilderFactoryMethods(String bodyContent, final List<Field> fields) {
-		bodyContent +=
-    		"""
-			/**
-			 * Return a builder for building a copy of this model object. It will be pre-populated with all the data from this
-			 * model object.
-			 *
-			 * @return a pre-populated builder
-			 */
-			public Builder copyBuilder() {
-			    return new Builder(%s);
-			}
-			
-			/**
-			 * Return a new builder for building a model object. This is just a shortcut for <code>new Model.Builder()</code>.
-			 *
-			 * @return a new builder
-			 */
-			public static Builder newBuilder() {
-			    return new Builder();
-			}
-			"""
-			.formatted(fields.stream().map(Field::nameCamelFirstLower).collect(Collectors.joining(", ")))
-			.indent(DEFAULT_INDENT);
-		return bodyContent;
-	}
-
-	private static void generateBuilderMethods(
-			final List<String> builderMethods,
-			final MessageDefContext msgDef,
-			final Field field,
-			final ContextualLookupHelper lookupHelper) {
-		final String prefix, postfix, fieldToSet;
-		final String fieldAnnotations = getFieldAnnotations(field);
-		final OneOfField parentOneOfField = field.parent();
-		final String fieldName = field.nameCamelFirstLower();
-		if (parentOneOfField != null) {
-			final String oneOfEnumValue = parentOneOfField.getEnumClassRef() + "." + camelToUpperSnake(field.name());
-			prefix = " new %s<>(".formatted(parentOneOfField.className()) + oneOfEnumValue + ",";
-			postfix = ")";
-			fieldToSet = parentOneOfField.nameCamelFirstLower();
-		} else if (fieldAnnotations.contains(NON_NULL_ANNOTATION)) {
-			prefix = "";
-			postfix = " != null ? " + fieldName + " : " + getDefaultValue(field, msgDef, lookupHelper);
-			fieldToSet = fieldName;
-		} else {
-			prefix = "";
-			postfix = "";
-			fieldToSet = fieldName;
-		}
-		builderMethods.add("""
-						/**
-						 * $fieldDoc
-						 *
-						 * @param $fieldName value to set
-						 * @return builder to continue building with
-						 */
-						public Builder $fieldName($fieldAnnotations$fieldType $fieldName) {
-						    this.$fieldToSet = $prefix$fieldName$postfix;
-						    return this;
-						}"""
-				.replace("$fieldDoc",field.comment()
-						.replaceAll("\n", "\n * "))
-				.replace("$fieldName", fieldName)
-				.replace("$fieldToSet",fieldToSet)
-				.replace("$prefix",prefix)
-				.replace("$postfix",postfix)
-				.replace("$fieldAnnotations", fieldAnnotations)
-				.replace("$fieldType",field.javaFieldType())
-				.indent(DEFAULT_INDENT)
-		);
-		// add nice method for simple message fields so can just set using un-built builder
-		if (field.type() == Field.FieldType.MESSAGE && !field.optionalValueType() && !field.repeated()) {
-			builderMethods.add("""
-						/**
-						 * $fieldDoc
-						 *
-						 * @param builder A pre-populated builder
-						 * @return builder to continue building with
-						 */
-						public Builder $fieldName($messageClass.Builder builder) {
-						    this.$fieldToSet =$prefix builder.build() $postfix;
-						    return this;
-						}"""
-					.replace("$messageClass",field.messageType())
-					.replace("$fieldDoc",field.comment()
-							.replaceAll("\n", "\n * "))
-					.replace("$fieldName", fieldName)
-					.replace("$fieldToSet",fieldToSet)
-					.replace("$prefix",prefix)
-					.replace("$postfix",postfix)
-					.replace("$fieldType",field.javaFieldType())
-					.indent(DEFAULT_INDENT)
-			);
-		}
-
-		// add nice method for message fields with list types for varargs
-		if (field.repeated()) {
-			// Need to re-define the prefix and postfix for repeated fields because they don't use `values` directly
-			// but wrap it in List.of(values) instead, so the simple definitions above don't work here.
-			final String repeatedPrefix;
-			final String repeatedPostfix;
-			if (parentOneOfField != null) {
-				repeatedPrefix = prefix + " values == null ? " + getDefaultValue(field, msgDef, lookupHelper) + " : ";
-				repeatedPostfix = postfix;
-			} else if (fieldAnnotations.contains(NON_NULL_ANNOTATION)) {
-				repeatedPrefix = "values == null ? " + getDefaultValue(field, msgDef, lookupHelper) + " : ";
-				repeatedPostfix = "";
-			} else {
-				repeatedPrefix = prefix;
-				repeatedPostfix = postfix;
-			}
-			builderMethods.add("""
-						/**
-						 * $fieldDoc
-						 *
-						 * @param values varargs value to be built into a list
-						 * @return builder to continue building with
-						 */
-						public Builder $fieldName($baseType ... values) {
-						    this.$fieldToSet = $repeatedPrefix List.of(values) $repeatedPostfix;
-						    return this;
-						}"""
-					.replace("$baseType",field.javaFieldType().substring("List<".length(),field.javaFieldType().length()-1))
-					.replace("$fieldDoc",field.comment()
-							.replaceAll("\n", "\n * "))
-					.replace("$fieldName", fieldName)
-					.replace("$fieldToSet",fieldToSet)
-					.replace("$fieldType",field.javaFieldType())
-					.replace("$repeatedPrefix",repeatedPrefix)
-					.replace("$repeatedPostfix",repeatedPostfix)
-					.indent(DEFAULT_INDENT)
-			);
-		}
-	}
-
-	/**
-	 * Generates the builder for the class
-	 * @param msgDef the message definition
-	 * @param fields the fields to use for the code generation
-	 * @param lookupHelper the lookup helper
-	 * @return the generated code
-	 */
-	private static String generateBuilder(final MessageDefContext msgDef, final List<Field> fields, final ContextualLookupHelper lookupHelper) {
-		final String javaRecordName = msgDef.messageName().getText();
-		final List<String> builderMethods = new ArrayList<>();
-		for (final Field field: fields) {
-			if (field.type() == Field.FieldType.ONE_OF) {
-				final OneOfField oneOfField = (OneOfField) field;
-				for (final Field subField: oneOfField.fields()) {
-					generateBuilderMethods(builderMethods, msgDef, subField, lookupHelper);
-				}
-			} else {
-				generateBuilderMethods(builderMethods, msgDef, field, lookupHelper);
-			}
-		}
-		return """
-			/**
-			 * Builder class for easy creation, ideal for clean code where performance is not critical. In critical performance
-			 * paths use the constructor directly.
-			 */
-			public static final class Builder {
-			    $fields;
-		
-			    /**
-			     * Create an empty builder
-			     */
-			    public Builder() {}
-			
-			$prePopulatedBuilder
-			    /**
-			     * Build a new model record with data set on builder
-			     *
-			     * @return new model record with data set
-			     */
-			    public $javaRecordName build() {
-			        return new $javaRecordName($recordParams);
-			    }
-		
-			$builderMethods}"""
-				.replace("$fields", fields.stream().map(field ->
-						getFieldAnnotations(field)
-								+ "private " + field.javaFieldType()
-								+ " " + field.nameCamelFirstLower()
-								+ " = " + getDefaultValue(field, msgDef, lookupHelper)
-						).collect(Collectors.joining(";\n    ")))
-				.replace("$prePopulatedBuilder", generateConstructor("Builder", fields, false, msgDef, lookupHelper))
-				.replace("$javaRecordName",javaRecordName)
-				.replace("$recordParams",fields.stream().map(Field::nameCamelFirstLower).collect(Collectors.joining(", ")))
-				.replace("$builderMethods", String.join("\n", builderMethods))
-				.indent(DEFAULT_INDENT);
-	}
-
-	/**
-	 * Gets the default value for the field
-	 * @param field the field to use for the code generation
-	 * @param msgDef the message definition
-	 * @param lookupHelper the lookup helper
-	 * @return the generated code
-	 */
-	private static String getDefaultValue(final Field field, final MessageDefContext msgDef, final ContextualLookupHelper lookupHelper) {
-		if (field.type() == Field.FieldType.ONE_OF) {
-			return lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef)+"."+field.javaDefault();
-		} else {
-			return field.javaDefault();
-		}
-	}
+        // === Build file
+        try (final FileWriter javaWriter = new FileWriter(javaFile)) {
+            javaWriter.write(
+                    generateClass(modelPackage, imports, javaDocComment, deprecated, javaRecordName, fields,
+                            bodyContent, hasComparableFields)
+            );
+        }
+    }
 
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl.generators;
 
-import com.hedera.pbj.compiler.impl.*;
+import com.hedera.pbj.compiler.impl.Common;
+import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
+import com.hedera.pbj.compiler.impl.Field;
+import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.MapField;
+import com.hedera.pbj.compiler.impl.OneOfField;
+import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 
 import java.io.File;
@@ -19,119 +25,121 @@ import java.util.stream.Stream;
  */
 public final class SchemaGenerator implements Generator {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public void generate(final Protobuf3Parser.MessageDefContext msgDef, final File destinationSrcDir,
-						 File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
-		final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
-		final String schemaClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.SCHEMA, msgDef);
-		final String schemaPackage = lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef);
-		final File javaFile = Common.getJavaFile(destinationSrcDir, schemaPackage, schemaClassName);
-		final List<Field> fields = new ArrayList<>();
-		final Set<String> imports = new TreeSet<>();
-		for (final var item : msgDef.messageBody().messageElement()) {
-			if (item.messageDef() != null) { // process sub messages
-				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
-			} else if (item.oneof() != null) { // process one ofs
-				final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, false, false);
-			} else if (item.mapField() != null) { // process map flattenedFields
-				final MapField field = new MapField(item.mapField(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, false, false);
-			} else if (item.field() != null && item.field().fieldName() != null) {
-				final var field = new SingleField(item.field(), lookupHelper);
-				fields.add(field);
-			} else if (item.reserved() == null && item.optionStatement() == null) {
-				// we can ignore reserved and option statements for now
-				System.err.println("SchemaGenerator Warning - Unknown element: "+item+" -- "+item.getText());
-			}
-		}
+    /**
+     * {@inheritDoc}
+     */
+    public void generate(final Protobuf3Parser.MessageDefContext msgDef, final File destinationSrcDir,
+                         File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
+        final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
+        final String schemaClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.SCHEMA, msgDef);
+        final String schemaPackage = lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef);
+        final File javaFile = Common.getJavaFile(destinationSrcDir, schemaPackage, schemaClassName);
+        final List<Field> fields = new ArrayList<>();
+        final Set<String> imports = new TreeSet<>();
+        for (final var item : msgDef.messageBody().messageElement()) {
+            if (item.messageDef() != null) { // process sub messages
+                generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
+            } else if (item.oneof() != null) { // process one ofs
+                final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, false, false);
+            } else if (item.mapField() != null) { // process map flattenedFields
+                final MapField field = new MapField(item.mapField(), lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, false, false);
+            } else if (item.field() != null && item.field().fieldName() != null) {
+                final var field = new SingleField(item.field(), lookupHelper);
+                fields.add(field);
+            } else if (item.reserved() == null && item.optionStatement() == null) {
+                // we can ignore reserved and option statements for now
+                System.err.printf("SchemaGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
+            }
+        }
 
-		final List<Field> flattenedFields = fields.stream()
-				.flatMap(field -> field instanceof OneOfField ? ((OneOfField)field).fields().stream() :
-						Stream.of(field))
-				.collect(Collectors.toList());
+        final List<Field> flattenedFields = fields.stream()
+                .flatMap(field -> field instanceof OneOfField ? ((OneOfField)field).fields().stream() :
+                        Stream.of(field))
+                .collect(Collectors.toList());
+        // spotless:off
+        try (FileWriter javaWriter = new FileWriter(javaFile)) {
+            javaWriter.write("""
+                    package $schemaPackage;
+                    
+                    import com.hedera.pbj.runtime.FieldDefinition;
+                    import com.hedera.pbj.runtime.FieldType;
+                    import com.hedera.pbj.runtime.Schema;
+                    $imports
+                    
+                    /**
+                     * Schema for $modelClassName model object. Generate based on protobuf schema.
+                     */
+                    public final class $schemaClassName implements Schema {
+                    
+                        /**
+                         * Private constructor to prevent instantiation.
+                         */
+                         private $schemaClassName() {
+                             // no-op
+                         }
+                    
+                        // -- FIELD DEFINITIONS ---------------------------------------------
+                    
+                    $fields
+                    
+                        // -- OTHER METHODS -------------------------------------------------
+                    
+                        /**
+                         * Check if a field definition belongs to this schema.
+                         *
+                         * @param f field def to check
+                         * @return true if it belongs to this schema
+                         */
+                        public static boolean valid(FieldDefinition f) {
+                            return f != null && getField(f.number()) == f;
+                        }
+                    
+                    $getMethods
+                    }
+                    """
+                    .replace("$schemaPackage", schemaPackage)
+                    .replace("$imports", imports.isEmpty() ? "" : imports.stream()
+                            .filter(input -> !input.equals(schemaPackage))
+                            .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
+                    .replace("$modelClassName", modelClassName)
+                    .replace("$schemaClassName", schemaClassName)
+                    .replace("$fields", fields.stream().map(Field::schemaFieldsDef)
+                            .collect(Collectors.joining("\n\n")))
+                    .replace("$getMethods", generateGetField(flattenedFields))
+            );
+        }
+        // spotless:on
+    }
 
-		try (FileWriter javaWriter = new FileWriter(javaFile)) {
-			javaWriter.write("""
-					package $schemaPackage;
-					
-					import com.hedera.pbj.runtime.FieldDefinition;
-					import com.hedera.pbj.runtime.FieldType;
-					import com.hedera.pbj.runtime.Schema;
-					$imports
-					
-					/**
-					 * Schema for $modelClassName model object. Generate based on protobuf schema.
-					 */
-					public final class $schemaClassName implements Schema {
-					
-						/**
-						 * Private constructor to prevent instantiation.
-						 */
-						 private $schemaClassName() {
-						 	// no-op
-						 }
-					
-					    // -- FIELD DEFINITIONS ---------------------------------------------
-					
-					$fields
-					
-					    // -- OTHER METHODS -------------------------------------------------
-					
-					    /**
-					     * Check if a field definition belongs to this schema.
-					     *
-					     * @param f field def to check
-					     * @return true if it belongs to this schema
-					     */
-					    public static boolean valid(FieldDefinition f) {
-					    	return f != null && getField(f.number()) == f;
-					    }
-					
-					$getMethods
-					}
-					"""
-					.replace("$schemaPackage", schemaPackage)
-					.replace("$imports", imports.isEmpty() ? "" : imports.stream()
-							.filter(input -> !input.equals(schemaPackage))
-							.collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
-					.replace("$modelClassName", modelClassName)
-					.replace("$schemaClassName", schemaClassName)
-					.replace("$fields", fields.stream().map(
-							Field::schemaFieldsDef
-					).collect(Collectors.joining("\n\n")))
-					.replace("$getMethods", generateGetField(flattenedFields))
-			);
-		}
-	}
-
-	/**
-	 * Generate getField method to get a field definition given a field number
-	 *
-	 * @param flattenedFields flattened list of all fields, with oneofs flattened
-	 * @return source code string for getField method
-	 */
-	private static String generateGetField(final List<Field> flattenedFields) {
-		return 	"""		
-					/**
-					 * Get a field definition given a field number
-					 *
-					 * @param fieldNumber the fields number to get def for
-					 * @return field def or null if field number does not exist
-					 */
-					public static FieldDefinition getField(final int fieldNumber) {
-					    return switch(fieldNumber) {
-					        %s
-					        default -> null;
-					    };
-					}
-				""".formatted(flattenedFields.stream()
-											.map(Field::schemaGetFieldsDefCase)
-											.collect(Collectors.joining("\n            ")));
-	}
-
+    /**
+     * Generate getField method to get a field definition given a field number
+     *
+     * @param flattenedFields flattened list of all fields, with oneofs flattened
+     * @return source code string for getField method
+     */
+    private static String generateGetField(final List<Field> flattenedFields) {
+        // spotless:off
+        return
+                """        
+                /**
+                 * Get a field definition given a field number
+                 *
+                 * @param fieldNumber the fields number to get def for
+                 * @return field def or null if field number does not exist
+                 */
+                public static FieldDefinition getField(final int fieldNumber) {
+                    return switch(fieldNumber) {
+                        %s
+                        default -> null;
+                    };
+                }
+                """.formatted(flattenedFields.stream()
+                        .map(Field::schemaGetFieldsDefCase)
+                        .collect(Collectors.joining("\n            ")));
+        // spotless:on
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -3,16 +3,21 @@ package com.hedera.pbj.compiler.impl.generators;
 
 import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 
-import com.hedera.pbj.compiler.impl.*;
+import com.hedera.pbj.compiler.impl.Common;
+import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
+import com.hedera.pbj.compiler.impl.Field;
+import com.hedera.pbj.compiler.impl.FileAndPackageNamesConfig;
+import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.MapField;
+import com.hedera.pbj.compiler.impl.OneOfField;
+import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
-import kotlin.reflect.jvm.internal.impl.protobuf.CodedOutputStream;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -23,382 +28,377 @@ import java.util.stream.Stream;
  */
 public final class TestGenerator implements Generator {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public void generate(Protobuf3Parser.MessageDefContext msgDef, File destinationSrcDir,
-						 File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
-		final var modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
-		final var testClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.TEST, msgDef);
-		final String testPackage = lookupHelper.getPackageForMessage(FileType.TEST, msgDef);
-		final String protoCJavaFullQualifiedClass = lookupHelper.getFullyQualifiedMessageClassname(FileType.PROTOC,msgDef);
-		final File javaFile = Common.getJavaFile(destinationTestSrcDir, testPackage, testClassName);
-		final List<Field> fields = new ArrayList<>();
-		final Set<String> imports = new TreeSet<>();
-		imports.add("com.hedera.pbj.runtime.io.buffer");
-		imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
-		for (final var item: msgDef.messageBody().messageElement()) {
-			if (item.messageDef() != null) { // process sub messages
-				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
-			} else if (item.oneof() != null) { // process one ofs
-				final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, false, true);
-				for(var subField : field.fields()) {
-					subField.addAllNeededImports(imports, true, false, true);
-				}
-			} else if (item.mapField() != null) { // process map fields
-				final MapField field = new MapField(item.mapField(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, false, true);
-			} else if (item.field() != null && item.field().fieldName() != null) {
-				final var field = new SingleField(item.field(), lookupHelper);
-				fields.add(field);
-				if (field.type() == Field.FieldType.MESSAGE || field.type() == Field.FieldType.ENUM) {
-					field.addAllNeededImports(imports, true, false, true);
-				}
-			} else if (item.reserved() == null && item.optionStatement() == null) {
-				System.err.println("TestGenerator Warning - Unknown element: "+item+" -- "+item.getText());
-			}
-		}
-		imports.add("java.util");
-		try (FileWriter javaWriter = new FileWriter(javaFile)) {
-			javaWriter.write("""
-					package %s;
-									
-					import com.google.protobuf.util.JsonFormat;
-					import com.google.protobuf.CodedOutputStream;
-					import com.hedera.pbj.runtime.io.buffer.BufferedData;
-					import com.hedera.pbj.runtime.JsonTools;
-					import org.junit.jupiter.api.Test;
-					import org.junit.jupiter.params.ParameterizedTest;
-					import org.junit.jupiter.params.provider.MethodSource;
-					import com.hedera.pbj.runtime.test.*;
-					import java.util.stream.IntStream;
-					import java.util.stream.Stream;
-					import java.nio.ByteBuffer;
-					import java.nio.CharBuffer;
-					%s
-												
-					import com.google.protobuf.CodedInputStream;
-					import com.google.protobuf.WireFormat;
-					import java.io.IOException;
-					import java.nio.charset.StandardCharsets;
-										
-					import static com.hedera.pbj.runtime.ProtoTestTools.*;
-					import static org.junit.jupiter.api.Assertions.*;
-										
-					/**
-					 * Unit Test for %s model object. Generate based on protobuf schema.
-					 */
-					public final class %s {
-					%s
-					%s
-					}
-					""".formatted(
-							testPackage,
-						imports.isEmpty() ? "" : imports.stream()
-								.filter(input -> !input.equals(testPackage))
-								.collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")),
-						modelClassName,
-						testClassName,
-						generateTestMethod(modelClassName, protoCJavaFullQualifiedClass)
-								.indent(DEFAULT_INDENT),
-						generateModelTestArgumentsMethod(modelClassName, fields)
-								.indent(DEFAULT_INDENT)
-					)
-			);
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    public void generate(Protobuf3Parser.MessageDefContext msgDef, File destinationSrcDir,
+                         File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
+        final var modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
+        final var testClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.TEST, msgDef);
+        final String testPackage = lookupHelper.getPackageForMessage(FileType.TEST, msgDef);
+        final String protoCJavaFullQualifiedClass = lookupHelper.getFullyQualifiedMessageClassname(FileType.PROTOC,msgDef);
+        final File javaFile = Common.getJavaFile(destinationTestSrcDir, testPackage, testClassName);
+        final List<Field> fields = new ArrayList<>();
+        final Set<String> imports = new TreeSet<>();
+        imports.add("com.hedera.pbj.runtime.io.buffer");
+        imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
+        for (final var item: msgDef.messageBody().messageElement()) {
+            if (item.messageDef() != null) { // process sub messages
+                generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
+            } else if (item.oneof() != null) { // process one ofs
+                final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, false, true);
+                for(var subField : field.fields()) {
+                    subField.addAllNeededImports(imports, true, false, true);
+                }
+            } else if (item.mapField() != null) { // process map fields
+                final MapField field = new MapField(item.mapField(), lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, false, true);
+            } else if (item.field() != null && item.field().fieldName() != null) {
+                final var field = new SingleField(item.field(), lookupHelper);
+                fields.add(field);
+                if (field.type() == Field.FieldType.MESSAGE || field.type() == Field.FieldType.ENUM) {
+                    field.addAllNeededImports(imports, true, false, true);
+                }
+            } else if (item.reserved() == null && item.optionStatement() == null) {
+                System.err.printf("TestGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
+            }
+        }
+        imports.add("java.util");
+        // spotless:off
+        try (FileWriter javaWriter = new FileWriter(javaFile)) {
+            javaWriter.write(
+                    """
+                    package %s;
+                    
+                    import com.google.protobuf.util.JsonFormat;
+                    import com.google.protobuf.CodedOutputStream;
+                    import com.hedera.pbj.runtime.io.buffer.BufferedData;
+                    import com.hedera.pbj.runtime.JsonTools;
+                    import org.junit.jupiter.api.Test;
+                    import org.junit.jupiter.params.ParameterizedTest;
+                    import org.junit.jupiter.params.provider.MethodSource;
+                    import com.hedera.pbj.runtime.test.*;
+                    import java.util.stream.IntStream;
+                    import java.util.stream.Stream;
+                    import java.nio.ByteBuffer;
+                    import java.nio.CharBuffer;
+                    %s
+                    
+                    import com.google.protobuf.CodedInputStream;
+                    import com.google.protobuf.WireFormat;
+                    import java.io.IOException;
+                    import java.nio.charset.StandardCharsets;
+                    
+                    import static com.hedera.pbj.runtime.ProtoTestTools.*;
+                    import static org.junit.jupiter.api.Assertions.*;
+                    
+                    /**
+                     * Unit Test for %s model object. Generate based on protobuf schema.
+                     */
+                    public final class %s {
+                    %s
+                    %s
+                    }
+                    """.formatted(testPackage, imports.isEmpty() ? "" : imports.stream()
+                                .filter(input -> !input.equals(testPackage))
+                                .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")),
+                        modelClassName, testClassName,
+                        generateTestMethod(modelClassName, protoCJavaFullQualifiedClass).indent(DEFAULT_INDENT),
+                        generateModelTestArgumentsMethod(modelClassName, fields).indent(DEFAULT_INDENT)
+                    )
+            );
+        }
+        // spotless:on
+    }
 
-	private static String generateModelTestArgumentsMethod(final String modelClassName, final List<Field> fields) {
-		return """	
-				/**
-				 * List of all valid arguments for testing, built as a static list, so we can reuse it.
-				 */
-				public static final List<%s> ARGUMENTS;
-				
-				static {
-				%s
-				    // work out the longest of all the lists of args as that is how many test cases we need
-				    final int maxValues = IntStream.of(
-				%s
-				    ).max().getAsInt();
-				    // create new stream of model objects using lists above as constructor params
-				    ARGUMENTS = (maxValues > 0 ? IntStream.range(0, maxValues) : IntStream.of(0))
-				            .mapToObj(i -> new %s(
-				%s
-				            )).toList();
-				}
-				
-				/**
-				 * Create a stream of all test permutations of the %s class we are testing. This is reused by other tests
-				 * as well that have model objects with fields of this type.
-				 *
-				 * @return stream of model objects for all test cases
-				 */
-				public static Stream<NoToStringWrapper<%s>> createModelTestArguments() {
-					return ARGUMENTS.stream().map(NoToStringWrapper::new);
-				}
-				""".formatted(
-					modelClassName,
-					fields.stream()
-							.filter(field -> !field.javaFieldType().equals(modelClassName))
-							.map(f -> "final var %sList = %s;".formatted(f.nameCamelFirstLower(), generateTestData(modelClassName, f, f.optionalValueType(), f.repeated())))
-							.collect(Collectors.joining("\n")).indent(DEFAULT_INDENT),
-					fields.stream()
-							.filter(field -> !field.javaFieldType().equals(modelClassName))
-							.map(f -> f.nameCamelFirstLower()+"List.size()")
-							.collect(Collectors.collectingAndThen(
-									Collectors.toList(),
-									list -> list.isEmpty() ? Stream.of("0") : list.stream()
-							))
-							.collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 2),
-					modelClassName,
-					fields.stream().map(field ->
-							field.javaFieldType().equals(modelClassName)
-									? field.javaFieldType() + ".newBuilder().build()"
-									: "$nameList.get(Math.min(i, $nameList.size()-1))".replace("$name", field.nameCamelFirstLower())
-					).collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 4),
-					modelClassName,
-					modelClassName
-				);
-	}
+    private static String generateModelTestArgumentsMethod(final String modelClassName, final List<Field> fields) {
+        // spotless:off
+        return
+                """
+                /**
+                 * List of all valid arguments for testing, built as a static list, so we can reuse it.
+                 */
+                public static final List<%s> ARGUMENTS;
+                
+                static {
+                %s
+                    // work out the longest of all the lists of args as that is how many test cases we need
+                    final int maxValues = IntStream.of(
+                %s
+                    ).max().getAsInt();
+                    // create new stream of model objects using lists above as constructor params
+                    ARGUMENTS = (maxValues > 0 ? IntStream.range(0, maxValues) : IntStream.of(0))
+                            .mapToObj(i -> new %s(
+                %s
+                            )).toList();
+                }
+                
+                /**
+                 * Create a stream of all test permutations of the %s class we are testing. This is reused by other tests
+                 * as well that have model objects with fields of this type.
+                 *
+                 * @return stream of model objects for all test cases
+                 */
+                public static Stream<NoToStringWrapper<%s>> createModelTestArguments() {
+                    return ARGUMENTS.stream().map(NoToStringWrapper::new);
+                }
+                """.formatted(modelClassName,fields.stream()
+                            .filter(field -> !field.javaFieldType().equals(modelClassName))
+                            .map(f -> "final var %sList = %s;".formatted(f.nameCamelFirstLower(),
+                                    generateTestData(modelClassName, f, f.optionalValueType(), f.repeated())))
+                            .collect(Collectors.joining("\n")).indent(DEFAULT_INDENT),
+                    fields.stream().filter(field -> !field.javaFieldType().equals(modelClassName))
+                            .map(f -> f.nameCamelFirstLower()+"List.size()")
+                            .collect(Collectors.collectingAndThen(Collectors.toList(),
+                                    list -> list.isEmpty() ? Stream.of("0") : list.stream()))
+                            .collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 2),
+                    modelClassName,
+                    fields.stream().map(field -> field.javaFieldType().equals(modelClassName)
+                            ? field.javaFieldType() + ".newBuilder().build()"
+                            : "$nameList.get(Math.min(i, $nameList.size()-1))"
+                                    .replace("$name", field.nameCamelFirstLower()))
+                            .collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 4),
+                    modelClassName, modelClassName
+                );
+        // spotless:on
+    }
 
-	private static String generateTestData(String modelClassName, Field field, boolean optional, boolean repeated) {
-		if (optional) {
+    private static String generateTestData(String modelClassName, Field field, boolean optional, boolean repeated) {
+        if (optional) {
+            Field.FieldType convertedFieldType = getOptionalConvertedFieldType(field);
+            return "addNull(%s)".formatted(getOptionsForFieldType(convertedFieldType, convertedFieldType.javaType));
+        } else if (repeated) {
+            final String optionsList = generateTestData(modelClassName, field, field.optionalValueType(), false);
+            return "generateListArguments(%s)".formatted(optionsList);
+        } else if (field instanceof final OneOfField oneOf) {
+            // spotless:off
+            final List<String> options = new ArrayList<>();
+            final String classDotField = "%s.%s".formatted(modelClassName, field.nameCamelFirstUpper());
+            for (var subField : oneOf.fields()) {
+                if (subField instanceof SingleField) {
+                    final String enumValueName = Common.camelToUpperSnake(subField.name());
+                    // special cases to break cyclic dependencies
+                    if (!("THRESHOLD_KEY".equals(enumValueName) || "KEY_LIST".equals(enumValueName)
+                            || "THRESHOLD_SIGNATURE".equals(enumValueName) || "SIGNATURE_LIST".equals(enumValueName))) {
+                        final String listStr;
+                        if (subField.optionalValueType()) {
+                            Field.FieldType convertedSubFieldType = getOptionalConvertedFieldType(subField);
+                            listStr = getOptionsForFieldType(convertedSubFieldType, convertedSubFieldType.javaType);
+                        } else {
+                            listStr = getOptionsForFieldType(subField.type(), ((SingleField) subField).javaFieldTypeForTest());
+                        }
+                        options.add("%s%s".formatted(listStr,
+                                """
+                                
+                                .stream()
+                                .map(value -> new %s<>(%sOneOfType.%s, value))
+                                .toList()"""
+                                        .formatted(((OneOfField)field).className(), classDotField, enumValueName)
+                                        .indent(DEFAULT_INDENT)));
+                    }
+                } else {
+                    System.err.printf(
+                            "Did not expect a OneOfField in a OneOfField. In modelClassName=%s field=%s subField=%s%n",
+                            modelClassName, field, subField);
+                }
+            }
+            return """
+                    Stream.of(
+                        List.of(new %s<>(%sOneOfType.UNSET, null)),
+                        %s
+                    ).flatMap(List::stream).toList()"""
+                    .formatted(((OneOfField) field).className(), classDotField,
+                        String.join(",\n", options).indent(DEFAULT_INDENT)).indent(DEFAULT_INDENT * 2);
+            // spotless:on
+        } else if (field instanceof final MapField mapField) {
+            // e.g. INTEGER_TESTS_LIST
+            final String keyOptions = getOptionsForFieldType(mapField.keyField().type(), mapField.keyField().javaFieldType());
+            // e.g. STRING_TESTS_LIST, or, say, CustomMessageTest.ARGUMENTS
+            final String valueOptions = getOptionsForFieldType(mapField.valueField().type(), mapField.valueField().javaFieldType());
 
-			Field.FieldType convertedFieldType = getOptionalConvertedFieldType(field);
-			return """
-					addNull(%s)"""
-					.formatted(getOptionsForFieldType(convertedFieldType, convertedFieldType.javaType));
-		} else if (repeated) {
-			final String optionsList = generateTestData(modelClassName, field, field.optionalValueType(), false);
-			return """
-					generateListArguments(%s)""".formatted(optionsList);
-		} else if (field instanceof final OneOfField oneOf) {
-			final List<String> options = new ArrayList<>();
-			for (var subField : oneOf.fields()) {
-				if (subField instanceof SingleField) {
-					final String enumValueName = Common.camelToUpperSnake(subField.name());
-					// special cases to break cyclic dependencies
-					if (!("THRESHOLD_KEY".equals(enumValueName) || "KEY_LIST".equals(enumValueName)
-							|| "THRESHOLD_SIGNATURE".equals(enumValueName) || "SIGNATURE_LIST".equals(enumValueName))) {
-						final String listStr;
-						if (subField.optionalValueType()) {
-							Field.FieldType convertedSubFieldType = getOptionalConvertedFieldType(subField);
-							listStr = getOptionsForFieldType(convertedSubFieldType, convertedSubFieldType.javaType);
-						} else {
-							listStr = getOptionsForFieldType(subField.type(), ((SingleField) subField).javaFieldTypeForTest());
-						}
-						options.add(listStr + ("\n.stream()\n" +
-								"""
-										.map(value -> new %s<>(%sOneOfType.%s, value))
-										.toList()""".formatted(
-										((OneOfField) field).className(),
-										modelClassName + "." + field.nameCamelFirstUpper(),
-										enumValueName
-								)).indent(DEFAULT_INDENT)
-						);
-					}
-				} else {
-					System.err.println("Did not expect a OneOfField in a OneOfField. In " +
-							"modelClassName=" + modelClassName + " field=" + field + " subField=" + subField);
-				}
-			}
-			return """
-					Stream.of(
-					    List.of(new %s<>(%sOneOfType.UNSET, null)),
-					    %s
-					).flatMap(List::stream).toList()""".formatted(
-					((OneOfField) field).className(),
-					modelClassName + "." + field.nameCamelFirstUpper(),
-					String.join(",\n", options).indent(DEFAULT_INDENT)
-					).indent(DEFAULT_INDENT * 2);
-		} else if (field instanceof final MapField mapField) {
-			// e.g. INTEGER_TESTS_LIST
-			final String keyOptions = getOptionsForFieldType(mapField.keyField().type(), mapField.keyField().javaFieldType());
-			// e.g. STRING_TESTS_LIST, or, say, CustomMessageTest.ARGUMENTS
-			final String valueOptions = getOptionsForFieldType(mapField.valueField().type(), mapField.valueField().javaFieldType());
+            // A cartesian product is nice to use, but it doesn't seem reasonable from the performance perspective.
+            // Instead, we want to test three cases:
+            // 1. Empty map
+            // 2. Map with a single entry
+            // 3. Map with multiple (e.g. two) entries
+            // Note that keys and value options lists may be pretty small. E.g. Boolean would only have 2 elements. So we use mod.
+            // Also note that we assume there's at least one element in each list.
+            // spotless:off
+            return """
+                    List.of(
+                        Map.$javaGenericTypeof(),
+                        Map.$javaGenericTypeof($keyOptions.get(0), $valueOptions.get(0)),
+                        Map.$javaGenericTypeof(
+                            $keyOptions.get(1 % $keyOptions.size()), $valueOptions.get(1 % $valueOptions.size()),
+                            $keyOptions.get(2 % $keyOptions.size()), $valueOptions.get(2 % $valueOptions.size())
+                        )
+                    )"""
+                    .replace("$javaGenericType", mapField.javaGenericType())
+                    .replace("$keyOptions", keyOptions)
+                    .replace("$valueOptions", valueOptions);
+            // spotless:on
+        } else {
+            return getOptionsForFieldType(field.type(), ((SingleField)field).javaFieldTypeForTest());
+        }
+    }
 
-			// A cartesian product is nice to use, but it doesn't seem reasonable from the performance perspective.
-			// Instead, we want to test three cases:
-			// 1. Empty map
-			// 2. Map with a single entry
-			// 3. Map with multiple (e.g. two) entries
-			// Note that keys and value options lists may be pretty small. E.g. Boolean would only have 2 elements. So we use mod.
-			// Also note that we assume there's at least one element in each list.
-			return """
-         			List.of(
-     					Map.$javaGenericTypeof(),
-     					Map.$javaGenericTypeof($keyOptions.get(0), $valueOptions.get(0)),
-     					Map.$javaGenericTypeof(
-     						$keyOptions.get(1 % $keyOptions.size()), $valueOptions.get(1 % $valueOptions.size()),
-     						$keyOptions.get(2 % $keyOptions.size()), $valueOptions.get(2 % $valueOptions.size())
-     					)
-					)"""
-					.replace("$javaGenericType", mapField.javaGenericType())
-					.replace("$keyOptions", keyOptions)
-					.replace("$valueOptions", valueOptions)
-					;
-		} else {
-			return getOptionsForFieldType(field.type(), ((SingleField)field).javaFieldTypeForTest());
-		}
-	}
+    private static Field.FieldType getOptionalConvertedFieldType(final Field field) {
+        return switch (field.messageType()) {
+            case "StringValue" -> Field.FieldType.STRING;
+            case "Int32Value" -> Field.FieldType.INT32;
+            case "UInt32Value" -> Field.FieldType.UINT32;
+            case "Int64Value" -> Field.FieldType.INT64;
+            case "UInt64Value" -> Field.FieldType.UINT64;
+            case "FloatValue" -> Field.FieldType.FLOAT;
+            case "DoubleValue" -> Field.FieldType.DOUBLE;
+            case "BoolValue" -> Field.FieldType.BOOL;
+            case "BytesValue" -> Field.FieldType.BYTES;
+            default -> Field.FieldType.MESSAGE;
+        };
+    }
 
-	private static Field.FieldType getOptionalConvertedFieldType(final Field field) {
-		return switch (field.messageType()) {
-			case "StringValue" -> Field.FieldType.STRING;
-			case "Int32Value" -> Field.FieldType.INT32;
-			case "UInt32Value" -> Field.FieldType.UINT32;
-			case "Int64Value" -> Field.FieldType.INT64;
-			case "UInt64Value" -> Field.FieldType.UINT64;
-			case "FloatValue" -> Field.FieldType.FLOAT;
-			case "DoubleValue" -> Field.FieldType.DOUBLE;
-			case "BoolValue" -> Field.FieldType.BOOL;
-			case "BytesValue" -> Field.FieldType.BYTES;
-			default -> Field.FieldType.MESSAGE;
-		};
-	}
+    private static String getOptionsForFieldType(Field.FieldType fieldType, String javaFieldType) {
+        return switch (fieldType) {
+            case INT32, SINT32, SFIXED32 -> "INTEGER_TESTS_LIST";
+            case UINT32, FIXED32 -> "UNSIGNED_INTEGER_TESTS_LIST";
+            case INT64, SINT64, SFIXED64 -> "LONG_TESTS_LIST";
+            case UINT64, FIXED64 -> "UNSIGNED_LONG_TESTS_LIST";
+            case FLOAT -> "FLOAT_TESTS_LIST";
+            case DOUBLE -> "DOUBLE_TESTS_LIST";
+            case BOOL -> "BOOLEAN_TESTS_LIST";
+            case STRING -> "STRING_TESTS_LIST";
+            case BYTES -> "BYTES_TESTS_LIST";
+            case ENUM -> "Arrays.asList(%s.values())".formatted(javaFieldType);
+            case ONE_OF -> throw new RuntimeException("Should never happen, should have been caught in generateTestData()");
+            case MESSAGE -> "%s%s.ARGUMENTS".formatted(javaFieldType, FileAndPackageNamesConfig.TEST_JAVA_FILE_SUFFIX);
+            case MAP -> throw new RuntimeException("Should never happen, should have been caught in generateTestData()");
+        };
+    }
 
-	private static String getOptionsForFieldType(Field.FieldType fieldType, String javaFieldType) {
-		return switch (fieldType) {
-			case INT32, SINT32, SFIXED32 -> "INTEGER_TESTS_LIST";
-			case UINT32, FIXED32 -> "UNSIGNED_INTEGER_TESTS_LIST";
-			case INT64, SINT64, SFIXED64 -> "LONG_TESTS_LIST";
-			case UINT64, FIXED64 -> "UNSIGNED_LONG_TESTS_LIST";
-			case FLOAT -> "FLOAT_TESTS_LIST";
-			case DOUBLE -> "DOUBLE_TESTS_LIST";
-			case BOOL -> "BOOLEAN_TESTS_LIST";
-			case STRING -> "STRING_TESTS_LIST";
-			case BYTES -> "BYTES_TESTS_LIST";
-			case ENUM -> "Arrays.asList(" + javaFieldType + ".values())";
-			case ONE_OF -> throw new RuntimeException("Should never happen, should have been caught in generateTestData()");
-			case MESSAGE -> javaFieldType + FileAndPackageNamesConfig.TEST_JAVA_FILE_SUFFIX + ".ARGUMENTS";
-			case MAP -> throw new RuntimeException("Should never happen, should have been caught in generateTestData()");
-		};
-	}
+    /**
+     * Generate code for test method. The test method is designed to reuse thread local buffers. This is
+     * very important for performance as without this the tests quickly overwhelm the garbage collector.
+     *
+     * This method also adds a public static final reference to the ProtoC class for this model object.
+     *
+     * @param modelClassName The class name of the model object we are creating a test for
+     * @param protoCJavaFullQualifiedClass The qualified class name of the protoc generated object class
+     * @return Code for test method
+     */
+    private static String generateTestMethod(final String modelClassName, final String protoCJavaFullQualifiedClass) {
+        // spotless:off
+        return """
+                /** A reference to the protoc generated object class. */
+                public static final Class<$protocModelClass> PROTOC_MODEL_CLASS
+                        = $protocModelClass.class;
 
-	/**
-	 * Generate code for test method. The test method is designed to reuse thread local buffers. This is
-	 * very important for performance as without this the tests quickly overwhelm the garbage collector.
-	 *
-	 * This method also adds a public static final reference to the ProtoC class for this model object.
-	 *
-	 * @param modelClassName The class name of the model object we are creating a test for
-	 * @param protoCJavaFullQualifiedClass The qualified class name of the protoc generated object class
-	 * @return Code for test method
-	 */
-	private static String generateTestMethod(final String modelClassName, final String protoCJavaFullQualifiedClass) {
-		return """
-				/** A reference to the protoc generated object class. */
-				public static final Class<$protocModelClass> PROTOC_MODEL_CLASS
-						= $protocModelClass.class;
-
-				@ParameterizedTest
-				@MethodSource("createModelTestArguments")
-				public void test$modelClassNameAgainstProtoC(final NoToStringWrapper<$modelClassName> modelObjWrapper) throws Exception {
-				    final $modelClassName modelObj = modelObjWrapper.getValue();
-				    // get reusable thread buffers
-				    final var dataBuffer = getThreadLocalDataBuffer();
-				    final var dataBuffer2 = getThreadLocalDataBuffer2();
-				    final var byteBuffer = getThreadLocalByteBuffer();
-				    final var charBuffer = getThreadLocalCharBuffer();
-				    final var charBuffer2 = getThreadLocalCharBuffer2();
-				    
-				    // model to bytes with PBJ
-				    $modelClassName.PROTOBUF.write(modelObj, dataBuffer);
-				    // clamp limit to bytes written
-				    dataBuffer.limit(dataBuffer.position());
-				    
-				    // copy bytes to ByteBuffer
-				    dataBuffer.resetPosition();
-				    final int protoBufByteCount = (int)dataBuffer.remaining();
-				    dataBuffer.readBytes(byteBuffer);
-				    byteBuffer.flip();
-				    
-				    // read proto bytes with ProtoC to make sure it is readable and no parse exceptions are thrown
-				    final $protocModelClass protoCModelObj = $protocModelClass.parseFrom(byteBuffer);
-				    
-				    // read proto bytes with PBJ parser
-				    dataBuffer.resetPosition();
-				    final $modelClassName modelObj2 = $modelClassName.PROTOBUF.parse(dataBuffer);
-				    
-				    // check the read back object is equal to written original one
-				    //assertEquals(modelObj.toString(), modelObj2.toString());
-				    assertEquals(modelObj, modelObj2);
-				    
-				    // model to bytes with ProtoC writer
-				    byteBuffer.clear();
-				    final CodedOutputStream codedOutput = CodedOutputStream.newInstance(byteBuffer);
-				    protoCModelObj.writeTo(codedOutput);
-				    codedOutput.flush();
-				    byteBuffer.flip();
-				    // copy to a data buffer
-				    dataBuffer2.writeBytes(byteBuffer);
-				    dataBuffer2.flip();
-				    
-				    // compare written bytes
-				    assertEquals(dataBuffer, dataBuffer2);
-
-				    // parse those bytes again with PBJ
-				    dataBuffer2.resetPosition();
-				    final $modelClassName modelObj3 = $modelClassName.PROTOBUF.parse(dataBuffer2);
-				    assertEquals(modelObj, modelObj3);
-
-				    // check measure methods
-				    dataBuffer2.resetPosition();
-				    assertEquals(protoBufByteCount, $modelClassName.PROTOBUF.measure(dataBuffer2));
-				    assertEquals(protoBufByteCount, $modelClassName.PROTOBUF.measureRecord(modelObj));
-				    		
-				    // check fast equals
-				    dataBuffer2.resetPosition();
-				    assertTrue($modelClassName.PROTOBUF.fastEquals(modelObj, dataBuffer2));
-
-				    // Test toBytes()
-				    Bytes bytes = $modelClassName.PROTOBUF.toBytes(modelObj);
-				    final var dataBuffer3 = getThreadLocalDataBuffer();
-				    bytes.toReadableSequentialData().readBytes(dataBuffer3);
-				    byte[] readBytes = new byte[(int)dataBuffer3.length()];
-				    dataBuffer3.getBytes(0, readBytes);
-				    assertArrayEquals(bytes.toByteArray(), readBytes);
-
-				    // Test JSON Writing
-				    final CharBufferToWritableSequentialData charBufferToWritableSequentialData = new CharBufferToWritableSequentialData(charBuffer);
-				    $modelClassName.JSON.write(modelObj,charBufferToWritableSequentialData);
-				    charBuffer.flip();
-				    JsonFormat.printer().appendTo(protoCModelObj, charBuffer2);
-				    charBuffer2.flip();
-				    assertEquals(charBuffer2, charBuffer);
-				    
-				    // Test JSON Reading
-				    final $modelClassName jsonReadPbj = $modelClassName.JSON.parse(JsonTools.parseJson(charBuffer), false, Integer.MAX_VALUE);
-				    assertEquals(modelObj, jsonReadPbj);
-				}
-				
-				@SuppressWarnings("EqualsWithItself")
-				@Test
-				public void testTestEqualsAndHashCode() throws Exception {
-				    if (ARGUMENTS.size() >= 3) {
-				        final var item1 = ARGUMENTS.get(0);
-				        final var item2 = ARGUMENTS.get(1);
-				        final var item3 = ARGUMENTS.get(2);
-				        assertEquals(item1, item1);
-				        assertEquals(item2, item2);
-				        assertEquals(item3, item3);
-				        assertNotEquals(item1, item2);
-				        assertNotEquals(item2, item3);
-				        final var item1HashCode = item1.hashCode();
-				        final var item2HashCode = item2.hashCode();
-				        final var item3HashCode = item3.hashCode();
-				        assertNotEquals(item1HashCode, item2HashCode);
-				        assertNotEquals(item2HashCode, item3HashCode);
-				    }
-				}
-				"""
-				.replace("$modelClassName",modelClassName)
-				.replace("$protocModelClass",protoCJavaFullQualifiedClass)
-				.replace("$modelClassName",modelClassName)
-		;
-	}
+                @ParameterizedTest
+                @MethodSource("createModelTestArguments")
+                public void test$modelClassNameAgainstProtoC(final NoToStringWrapper<$modelClassName> modelObjWrapper) throws Exception {
+                    final $modelClassName modelObj = modelObjWrapper.getValue();
+                    // get reusable thread buffers
+                    final var dataBuffer = getThreadLocalDataBuffer();
+                    final var dataBuffer2 = getThreadLocalDataBuffer2();
+                    final var byteBuffer = getThreadLocalByteBuffer();
+                    final var charBuffer = getThreadLocalCharBuffer();
+                    final var charBuffer2 = getThreadLocalCharBuffer2();
+                
+                    // model to bytes with PBJ
+                    $modelClassName.PROTOBUF.write(modelObj, dataBuffer);
+                    // clamp limit to bytes written
+                    dataBuffer.limit(dataBuffer.position());
+                
+                    // copy bytes to ByteBuffer
+                    dataBuffer.resetPosition();
+                    final int protoBufByteCount = (int)dataBuffer.remaining();
+                    dataBuffer.readBytes(byteBuffer);
+                    byteBuffer.flip();
+                
+                    // read proto bytes with ProtoC to make sure it is readable and no parse exceptions are thrown
+                    final $protocModelClass protoCModelObj = $protocModelClass.parseFrom(byteBuffer);
+                
+                    // read proto bytes with PBJ parser
+                    dataBuffer.resetPosition();
+                    final $modelClassName modelObj2 = $modelClassName.PROTOBUF.parse(dataBuffer);
+                
+                    // check the read back object is equal to written original one
+                    //assertEquals(modelObj.toString(), modelObj2.toString());
+                    assertEquals(modelObj, modelObj2);
+                
+                    // model to bytes with ProtoC writer
+                    byteBuffer.clear();
+                    final CodedOutputStream codedOutput = CodedOutputStream.newInstance(byteBuffer);
+                    protoCModelObj.writeTo(codedOutput);
+                    codedOutput.flush();
+                    byteBuffer.flip();
+                    // copy to a data buffer
+                    dataBuffer2.writeBytes(byteBuffer);
+                    dataBuffer2.flip();
+                
+                    // compare written bytes
+                    assertEquals(dataBuffer, dataBuffer2);
+                
+                    // parse those bytes again with PBJ
+                    dataBuffer2.resetPosition();
+                    final $modelClassName modelObj3 = $modelClassName.PROTOBUF.parse(dataBuffer2);
+                    assertEquals(modelObj, modelObj3);
+                
+                    // check measure methods
+                    dataBuffer2.resetPosition();
+                    assertEquals(protoBufByteCount, $modelClassName.PROTOBUF.measure(dataBuffer2));
+                    assertEquals(protoBufByteCount, $modelClassName.PROTOBUF.measureRecord(modelObj));
+                
+                    // check fast equals
+                    dataBuffer2.resetPosition();
+                    assertTrue($modelClassName.PROTOBUF.fastEquals(modelObj, dataBuffer2));
+                
+                    // Test toBytes()
+                    Bytes bytes = $modelClassName.PROTOBUF.toBytes(modelObj);
+                    final var dataBuffer3 = getThreadLocalDataBuffer();
+                    bytes.toReadableSequentialData().readBytes(dataBuffer3);
+                    byte[] readBytes = new byte[(int)dataBuffer3.length()];
+                    dataBuffer3.getBytes(0, readBytes);
+                    assertArrayEquals(bytes.toByteArray(), readBytes);
+                
+                    // Test JSON Writing
+                    final CharBufferToWritableSequentialData charBufferToWritableSequentialData = new CharBufferToWritableSequentialData(charBuffer);
+                    $modelClassName.JSON.write(modelObj,charBufferToWritableSequentialData);
+                    charBuffer.flip();
+                    JsonFormat.printer().appendTo(protoCModelObj, charBuffer2);
+                    charBuffer2.flip();
+                    assertEquals(charBuffer2, charBuffer);
+                
+                    // Test JSON Reading
+                    final $modelClassName jsonReadPbj = $modelClassName.JSON.parse(JsonTools.parseJson(charBuffer), false, Integer.MAX_VALUE);
+                    assertEquals(modelObj, jsonReadPbj);
+                }
+                
+                @SuppressWarnings("EqualsWithItself")
+                @Test
+                public void testTestEqualsAndHashCode() throws Exception {
+                    if (ARGUMENTS.size() >= 3) {
+                        final var item1 = ARGUMENTS.get(0);
+                        final var item2 = ARGUMENTS.get(1);
+                        final var item3 = ARGUMENTS.get(2);
+                        assertEquals(item1, item1);
+                        assertEquals(item2, item2);
+                        assertEquals(item3, item3);
+                        assertNotEquals(item1, item2);
+                        assertNotEquals(item2, item3);
+                        final var item1HashCode = item1.hashCode();
+                        final var item2HashCode = item2.hashCode();
+                        final var item3HashCode = item3.hashCode();
+                        assertNotEquals(item1HashCode, item2HashCode);
+                        assertNotEquals(item2HashCode, item3HashCode);
+                    }
+                }
+                """
+                .replace("$modelClassName",modelClassName)
+                .replace("$protocModelClass",protoCJavaFullQualifiedClass)
+                .replace("$modelClassName",modelClassName);
+        // spotless:on
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl.generators.json;
 
-import com.hedera.pbj.compiler.impl.*;
+import com.hedera.pbj.compiler.impl.Common;
+import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
+import com.hedera.pbj.compiler.impl.Field;
+import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.MapField;
+import com.hedera.pbj.compiler.impl.OneOfField;
+import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.generators.Generator;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 
@@ -20,121 +26,123 @@ import java.util.stream.Collectors;
 @SuppressWarnings("DuplicatedCode")
 public final class JsonCodecGenerator implements Generator {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public void generate(Protobuf3Parser.MessageDefContext msgDef, final File destinationSrcDir,
-						 File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
-		final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
-		final String codecClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.JSON_CODEC, msgDef);
-		final String codecPackage = lookupHelper.getPackageForMessage(FileType.JSON_CODEC, msgDef);
-		final File javaFile = Common.getJavaFile(destinationSrcDir, codecPackage, codecClassName);
+    /**
+     * {@inheritDoc}
+     */
+    public void generate(Protobuf3Parser.MessageDefContext msgDef, final File destinationSrcDir,
+                         File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
+        final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
+        final String codecClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.JSON_CODEC, msgDef);
+        final String codecPackage = lookupHelper.getPackageForMessage(FileType.JSON_CODEC, msgDef);
+        final File javaFile = Common.getJavaFile(destinationSrcDir, codecPackage, codecClassName);
 
-		final List<Field> fields = new ArrayList<>();
-		final Set<String> imports = new TreeSet<>();
-		imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
-		imports.add(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef));
+        final List<Field> fields = new ArrayList<>();
+        final Set<String> imports = new TreeSet<>();
+        imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
+        imports.add(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef));
 
-		for(var item: msgDef.messageBody().messageElement()) {
-			if (item.messageDef() != null) { // process sub messages
-				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
-			} else if (item.oneof() != null) { // process one ofs
-				final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, true, false);
-			} else if (item.mapField() != null) { // process map fields
-				final MapField field = new MapField(item.mapField(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, true, false);
-			} else if (item.field() != null && item.field().fieldName() != null) {
-				final var field = new SingleField(item.field(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, true, false);
-			} else if (item.reserved() == null && item.optionStatement() == null) {
-				System.err.println("WriterGenerator Warning - Unknown element: "+item+" -- "+item.getText());
-			}
-		}
-		final String writeMethod = JsonCodecWriteMethodGenerator.generateWriteMethod(modelClassName, fields);
+        for(var item: msgDef.messageBody().messageElement()) {
+            if (item.messageDef() != null) { // process sub messages
+                generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
+            } else if (item.oneof() != null) { // process one ofs
+                final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, true, false);
+            } else if (item.mapField() != null) { // process map fields
+                final MapField field = new MapField(item.mapField(), lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, true, false);
+            } else if (item.field() != null && item.field().fieldName() != null) {
+                final var field = new SingleField(item.field(), lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, true, false);
+            } else if (item.reserved() == null && item.optionStatement() == null) {
+                System.err.printf("WriterGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
+            }
+        }
+        final String writeMethod = JsonCodecWriteMethodGenerator.generateWriteMethod(modelClassName, fields);
 
-		try (FileWriter javaWriter = new FileWriter(javaFile)) {
-			javaWriter.write("""
-					package $package;
-					
-					import com.hedera.pbj.runtime.*;
-					import com.hedera.pbj.runtime.io.*;
-					import com.hedera.pbj.runtime.io.buffer.*;
-					import java.io.IOException;
-					import java.nio.*;
-					import java.nio.charset.*;
-					import java.util.*;
-					import edu.umd.cs.findbugs.annotations.NonNull;
-					import edu.umd.cs.findbugs.annotations.Nullable;
-					
-					import $qualifiedModelClass;
-					$imports
-					import com.hedera.pbj.runtime.jsonparser.*;
-					import static $schemaClass.*;
-					import static com.hedera.pbj.runtime.JsonTools.*;
-					
-					/**
-					 * JSON Codec for $modelClass model object. Generated based on protobuf schema.
-					 */
-					public final class $codecClass implements JsonCodec<$modelClass> {
-					
-						/**
-						 * Empty constructor
-						 */
-						 public $codecClass() {
-						 	// no-op
-						 }
-					
-					    $unsetOneOfConstants
-					    $parseObject
-					    $writeMethod
-					}
-					"""
-					.replace("$package", codecPackage)
-					.replace("$imports", imports.isEmpty() ? "" : imports.stream()
-							.filter(input -> !input.equals(codecPackage))
-							.collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
-					.replace("$schemaClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef))
-					.replace("$modelClass", modelClassName)
-					.replace("$qualifiedModelClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef))
-					.replace("$codecClass", codecClassName)
-					.replace("$unsetOneOfConstants", JsonCodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
-					.replace("$writeMethod", writeMethod)
-					.replace("$parseObject", JsonCodecParseMethodGenerator.generateParseObjectMethod(modelClassName, fields))
-			);
-		}
-	}
+        try (FileWriter javaWriter = new FileWriter(javaFile)) {
+            // spotless:off
+            javaWriter.write("""
+                    package $package;
+                    
+                    import com.hedera.pbj.runtime.*;
+                    import com.hedera.pbj.runtime.io.*;
+                    import com.hedera.pbj.runtime.io.buffer.*;
+                    import java.io.IOException;
+                    import java.nio.*;
+                    import java.nio.charset.*;
+                    import java.util.*;
+                    import edu.umd.cs.findbugs.annotations.NonNull;
+                    import edu.umd.cs.findbugs.annotations.Nullable;
+                    
+                    import $qualifiedModelClass;
+                    $imports
+                    import com.hedera.pbj.runtime.jsonparser.*;
+                    import static $schemaClass.*;
+                    import static com.hedera.pbj.runtime.JsonTools.*;
+                    
+                    /**
+                     * JSON Codec for $modelClass model object. Generated based on protobuf schema.
+                     */
+                    public final class $codecClass implements JsonCodec<$modelClass> {
+                    
+                        /**
+                         * Empty constructor
+                         */
+                         public $codecClass() {
+                             // no-op
+                         }
+                    
+                        $unsetOneOfConstants
+                        $parseObject
+                        $writeMethod
+                    }
+                    """
+                    .replace("$package", codecPackage)
+                    .replace("$imports", imports.isEmpty() ? "" : imports.stream()
+                            .filter(input -> !input.equals(codecPackage))
+                            .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
+                    .replace("$schemaClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef))
+                    .replace("$modelClass", modelClassName)
+                    .replace("$qualifiedModelClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef))
+                    .replace("$codecClass", codecClassName)
+                    .replace("$unsetOneOfConstants", JsonCodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
+                    .replace("$writeMethod", writeMethod)
+                    .replace("$parseObject", JsonCodecParseMethodGenerator.generateParseObjectMethod(modelClassName, fields))
+            );
+        // spotless:on
+        }
+    }
 
-	/**
-	 * Converts a field name to a JSON field name.
-	 *
-	 * @param fieldName the field name
-	 * @return the JSON field name
-	 */
-	static String toJsonFieldName(String fieldName) {
-		// based directly on protoc so output matches
-		final int length = fieldName.length();
-		StringBuilder result = new StringBuilder(length);
-		boolean isNextUpperCase = false;
-		for (int i = 0; i < length; i++) {
-			char ch = fieldName.charAt(i);
-			if (ch == '_') {
-				isNextUpperCase = true;
-			} else if (isNextUpperCase) {
-				// This closely matches the logic for ASCII characters in:
-				// http://google3/google/protobuf/descriptor.cc?l=249-251&rcl=228891689
-				if ('a' <= ch && ch <= 'z') {
-					ch = (char) (ch - 'a' + 'A');
-				}
-				result.append(ch);
-				isNextUpperCase = false;
-			} else {
-				result.append(ch);
-			}
-		}
-		return result.toString();
-	}
+    /**
+     * Converts a field name to a JSON field name.
+     *
+     * @param fieldName the field name
+     * @return the JSON field name
+     */
+    static String toJsonFieldName(String fieldName) {
+        // based directly on protoc so output matches
+        final int length = fieldName.length();
+        StringBuilder result = new StringBuilder(length);
+        boolean isNextUpperCase = false;
+        for (int i = 0; i < length; i++) {
+            char ch = fieldName.charAt(i);
+            if (ch == '_') {
+                isNextUpperCase = true;
+            } else if (isNextUpperCase) {
+                // This closely matches the logic for ASCII characters in:
+                // http://google3/google/protobuf/descriptor.cc?l=249-251&rcl=228891689
+                if ('a' <= ch && ch <= 'z') {
+                    ch = (char) (ch - 'a' + 'A');
+                }
+                result.append(ch);
+                isNextUpperCase = false;
+            } else {
+                result.append(ch);
+            }
+        }
+        return result.toString();
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -1,14 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl.generators.protobuf;
 
-import com.hedera.pbj.compiler.impl.*;
+import com.hedera.pbj.compiler.impl.Common;
+import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
+import com.hedera.pbj.compiler.impl.Field;
+import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.MapField;
+import com.hedera.pbj.compiler.impl.OneOfField;
+import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.generators.Generator;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -17,101 +26,100 @@ import java.util.stream.Collectors;
 @SuppressWarnings("DuplicatedCode")
 public final class CodecGenerator implements Generator {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public void generate(Protobuf3Parser.MessageDefContext msgDef, final File destinationSrcDir,
-						 File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
-		final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
-		final String codecClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.CODEC, msgDef);
-		final String codecPackage = lookupHelper.getPackageForMessage(FileType.CODEC, msgDef);
-		final File javaFile = Common.getJavaFile(destinationSrcDir, codecPackage, codecClassName);
+    /**
+     * {@inheritDoc}
+     */
+    public void generate(Protobuf3Parser.MessageDefContext msgDef, final File destinationSrcDir,
+                         File destinationTestSrcDir, final ContextualLookupHelper lookupHelper) throws IOException {
+        final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
+        final String codecClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.CODEC, msgDef);
+        final String codecPackage = lookupHelper.getPackageForMessage(FileType.CODEC, msgDef);
+        final File javaFile = Common.getJavaFile(destinationSrcDir, codecPackage, codecClassName);
 
-		final List<Field> fields = new ArrayList<>();
-		final Set<String> imports = new TreeSet<>();
-		imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
-		imports.add(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef));
+        final List<Field> fields = new ArrayList<>();
+        final Set<String> imports = new TreeSet<>();
+        imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
+        imports.add(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef));
 
-		for(var item: msgDef.messageBody().messageElement()) {
-			if (item.messageDef() != null) { // process sub messages
-				generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
-			} else if (item.oneof() != null) { // process one ofs
-				final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, true, false);
-			} else if (item.mapField() != null) { // process map fields
-				final MapField field = new MapField(item.mapField(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, true, false);
-			} else if (item.field() != null && item.field().fieldName() != null) {
-				final var field = new SingleField(item.field(), lookupHelper);
-				fields.add(field);
-				field.addAllNeededImports(imports, true, true, false);
-			} else if (item.reserved() == null && item.optionStatement() == null) {
-				System.err.println("WriterGenerator Warning - Unknown element: "+item+" -- "+item.getText());
-			}
-		}
-		final String writeMethod = CodecWriteMethodGenerator.generateWriteMethod(modelClassName, fields);
+        for(var item: msgDef.messageBody().messageElement()) {
+            if (item.messageDef() != null) { // process sub messages
+                generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
+            } else if (item.oneof() != null) { // process one ofs
+                final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, true, false);
+            } else if (item.mapField() != null) { // process map fields
+                final MapField field = new MapField(item.mapField(), lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, true, false);
+            } else if (item.field() != null && item.field().fieldName() != null) {
+                final var field = new SingleField(item.field(), lookupHelper);
+                fields.add(field);
+                field.addAllNeededImports(imports, true, true, false);
+            } else if (item.reserved() == null && item.optionStatement() == null) {
+                System.err.printf("WriterGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
+            }
+        }
+        final String writeMethod = CodecWriteMethodGenerator.generateWriteMethod(modelClassName, fields);
 
-		try (FileWriter javaWriter = new FileWriter(javaFile)) {
-			javaWriter.write("""
-					package $package;
-					
-					import com.hedera.pbj.runtime.*;
-					import com.hedera.pbj.runtime.io.*;
-					import com.hedera.pbj.runtime.io.buffer.*;
-					import com.hedera.pbj.runtime.io.stream.EOFException;
-					import java.io.IOException;
-					import java.nio.*;
-					import java.nio.charset.*;
-					import java.util.*;
-					import edu.umd.cs.findbugs.annotations.NonNull;
-					
-					import $qualifiedModelClass;
-					$imports
-					import static $schemaClass.*;
-					import static com.hedera.pbj.runtime.ProtoWriterTools.*;
-					import static com.hedera.pbj.runtime.ProtoParserTools.*;
-					import static com.hedera.pbj.runtime.ProtoConstants.*;
-				
-					/**
-					 * Protobuf Codec for $modelClass model object. Generated based on protobuf schema.
-					 */
-					public final class $codecClass implements Codec<$modelClass> {
-					
-						/**
-						 * Empty constructor
-						 */
-						 public $codecClass() {
-						 	// no-op
-						 }
-					
-					$unsetOneOfConstants
-					$parseMethod
-					$writeMethod
-					$measureDataMethod
-					$measureRecordMethod
-					$fastEqualsMethod
-					}
-					"""
-					.replace("$package", codecPackage)
-					.replace("$imports", imports.isEmpty() ? "" : imports.stream()
-							.filter(input -> !input.equals(codecPackage))
-							.collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
-					.replace("$schemaClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef))
-					.replace("$modelClass", modelClassName)
-					.replace("$qualifiedModelClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef))
-					.replace("$codecClass", codecClassName)
-					.replace("$unsetOneOfConstants", CodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
-					.replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(modelClassName, fields))
-					.replace("$writeMethod", writeMethod)
-					.replace("$measureDataMethod", CodecMeasureDataMethodGenerator.generateMeasureMethod(modelClassName, fields))
-					.replace("$measureRecordMethod", CodecMeasureRecordMethodGenerator.generateMeasureMethod(modelClassName, fields))
-					.replace("$fastEqualsMethod", CodecFastEqualsMethodGenerator.generateFastEqualsMethod(modelClassName, fields))
-			);
-		}
-	}
-
-
-
+        try (FileWriter javaWriter = new FileWriter(javaFile)) {
+            // spotless:off
+            javaWriter.write("""
+                    package $package;
+                    
+                    import com.hedera.pbj.runtime.*;
+                    import com.hedera.pbj.runtime.io.*;
+                    import com.hedera.pbj.runtime.io.buffer.*;
+                    import com.hedera.pbj.runtime.io.stream.EOFException;
+                    import java.io.IOException;
+                    import java.nio.*;
+                    import java.nio.charset.*;
+                    import java.util.*;
+                    import edu.umd.cs.findbugs.annotations.NonNull;
+                    
+                    import $qualifiedModelClass;
+                    $imports
+                    import static $schemaClass.*;
+                    import static com.hedera.pbj.runtime.ProtoWriterTools.*;
+                    import static com.hedera.pbj.runtime.ProtoParserTools.*;
+                    import static com.hedera.pbj.runtime.ProtoConstants.*;
+                
+                    /**
+                     * Protobuf Codec for $modelClass model object. Generated based on protobuf schema.
+                     */
+                    public final class $codecClass implements Codec<$modelClass> {
+                    
+                        /**
+                         * Empty constructor
+                         */
+                         public $codecClass() {
+                             // no-op
+                         }
+                    
+                    $unsetOneOfConstants
+                    $parseMethod
+                    $writeMethod
+                    $measureDataMethod
+                    $measureRecordMethod
+                    $fastEqualsMethod
+                    }
+                    """
+                    .replace("$package", codecPackage)
+                    .replace("$imports", imports.isEmpty() ? "" : imports.stream()
+                            .filter(input -> !input.equals(codecPackage))
+                            .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
+                    .replace("$schemaClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef))
+                    .replace("$modelClass", modelClassName)
+                    .replace("$qualifiedModelClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef))
+                    .replace("$codecClass", codecClassName)
+                    .replace("$unsetOneOfConstants", CodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
+                    .replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(modelClassName, fields))
+                    .replace("$writeMethod", writeMethod)
+                    .replace("$measureDataMethod", CodecMeasureDataMethodGenerator.generateMeasureMethod(modelClassName, fields))
+                    .replace("$measureRecordMethod", CodecMeasureRecordMethodGenerator.generateMeasureMethod(modelClassName, fields))
+                    .replace("$fastEqualsMethod", CodecFastEqualsMethodGenerator.generateFastEqualsMethod(modelClassName, fields))
+            );
+        // spotless:on
+        }
+    }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
@@ -27,6 +27,7 @@ class CodecMeasureRecordMethodGenerator {
                 fields,
                 field -> "data.%s()".formatted(field.nameCamelFirstLower()),
                 true);
+        // spotless:off
         return """
                 /**
                  * Compute number of bytes that would be written when calling {@code write()} method.
@@ -43,6 +44,7 @@ class CodecMeasureRecordMethodGenerator {
                 .replace("$modelClass", modelClassName)
                 .replace("$fieldSizeOfLines", fieldSizeOfLines)
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 
     static String buildFieldSizeOfLines(
@@ -121,6 +123,7 @@ class CodecMeasureRecordMethodGenerator {
                     mapEntryFields,
                     getValueBuilder,
                     false);
+            // spotless:off
             return prefix + """
                         if (!$map.isEmpty()) {
                             final Pbj$javaFieldType pbjMap = (Pbj$javaFieldType) $map;
@@ -140,8 +143,8 @@ class CodecMeasureRecordMethodGenerator {
                     .replace("$javaFieldType", mapField.javaFieldType())
                     .replace("$K", mapField.keyField().type().boxedType)
                     .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? ((SingleField)mapField.valueField()).messageType() : mapField.valueField().type().boxedType)
-                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
-                    ;
+                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT));
+            // spotless:on
         } else {
             return prefix + switch(field.type()) {
                 case ENUM -> "size += sizeOfEnum(%s, %s);"

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -27,6 +27,7 @@ class CodecParseMethodGenerator {
      * @return code for constants
      */
     static String generateUnsetOneOfConstants(final List<Field> fields) {
+        // spotless:off
         return "\n" + fields.stream()
             .filter(f -> f instanceof OneOfField)
             .map(f -> {
@@ -42,9 +43,11 @@ class CodecParseMethodGenerator {
                         .replace("$unsetFieldName", field.getEnumClassRef());
             })
             .collect(Collectors.joining("\n"));
+        // spotless:on
     }
 
     static String generateParseMethod(final String modelClassName, final List<Field> fields) {
+        // spotless:off
         return """
                 /**
                  * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
@@ -86,10 +89,12 @@ class CodecParseMethodGenerator {
         .replace("$parseLoop", generateParseLoop(generateCaseStatements(fields), ""))
         .replace("$skipMaxSize", String.valueOf(Field.DEFAULT_MAX_SIZE))
         .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 
     // prefix is pre-pended to variable names to support a nested parsing loop.
     static String generateParseLoop(final String caseStatements, @NonNull final String prefix) {
+        // spotless:off
         return """
                         // -- PARSE LOOP ---------------------------------------------
                         // Continue to parse bytes out of the input stream until we get to the end.
@@ -155,6 +160,7 @@ class CodecParseMethodGenerator {
                 .replace("$prefix",prefix)
                 .replace("$skipMaxSize", String.valueOf(Field.DEFAULT_MAX_SIZE))
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 
     /**
@@ -194,27 +200,28 @@ class CodecParseMethodGenerator {
         final int wireType = Common.TYPE_LENGTH_DELIMITED;
         final int fieldNum = field.fieldNumber();
         final int tag = Common.getTag(wireType, fieldNum);
-        sb.append("case " + tag +" /* type=" + wireType + " [" + field.type() + "] packed-repeated " +
-                "field=" + fieldNum + " [" + field.name() + "] */ -> {\n");
+        // spotless:off
+        sb.append("case %d /* type=%d [%s] packed-repeated field=%d [%s] */ -> {%n"
+                .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         sb.append("""
-				// Read the length of packed repeated field data
-				final long length = input.readVarInt(false);
-				if (length > $maxSize) {
-				    throw new ParseException("$fieldName size " + length + " is greater than max " + $maxSize);
-				}
-				if (input.remaining() < length) {
-				    throw new BufferUnderflowException();
-				}
-				final var beforeLimit = input.limit();
-				final long beforePosition = input.position();
-				input.limit(input.position() + length);
-				while (input.hasRemaining()) {
-				    $tempFieldName = addToList($tempFieldName,$readMethod);
-				}
-				input.limit(beforeLimit);
-				if (input.position() != beforePosition + length) {
-				    throw new BufferUnderflowException();
-				}"""
+                // Read the length of packed repeated field data
+                final long length = input.readVarInt(false);
+                if (length > $maxSize) {
+                    throw new ParseException("$fieldName size " + length + " is greater than max " + $maxSize);
+                }
+                if (input.remaining() < length) {
+                    throw new BufferUnderflowException();
+                }
+                final var beforeLimit = input.limit();
+                final long beforePosition = input.position();
+                input.limit(input.position() + length);
+                while (input.hasRemaining()) {
+                    $tempFieldName = addToList($tempFieldName,$readMethod);
+                }
+                input.limit(beforeLimit);
+                if (input.position() != beforePosition + length) {
+                    throw new BufferUnderflowException();
+                }"""
                 .replace("$tempFieldName", "temp_" + field.name())
                 .replace("$readMethod", readMethod(field))
                 .replace("$maxSize", String.valueOf(field.maxSize()))
@@ -222,6 +229,7 @@ class CodecParseMethodGenerator {
                 .indent(DEFAULT_INDENT)
         );
         sb.append("\n}\n");
+        // spotless:on
     }
 
     /**
@@ -234,28 +242,29 @@ class CodecParseMethodGenerator {
         final int wireType = field.optionalValueType() ? Common.TYPE_LENGTH_DELIMITED : field.type().wireType();
         final int fieldNum = field.fieldNumber();
         final int tag = Common.getTag(wireType, fieldNum);
-        sb.append("case " + tag +" /* type=" + wireType + " [" + field.type() + "] " +
-                "field=" + fieldNum + " [" + field.name() + "] */ -> {\n");
+        // spotless:off
+        sb.append("case %d /* type=%d [%s] field=%d [%s] */ -> {%n"
+                .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         if (field.optionalValueType()) {
             sb.append("""
-							// Read the message size, it is not needed
-							final var valueTypeMessageSize = input.readVarInt(false);
-							final $fieldType value;
-							if (valueTypeMessageSize > 0) {
-							    final var beforeLimit = input.limit();
-							    input.limit(input.position() + valueTypeMessageSize);
-							    // read inner tag
-							    final int valueFieldTag = input.readVarInt(false);
-							    // assert tag is as expected
-							    assert (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
-							    assert (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
-							    // read value
-							    value = $readMethod;
-							    input.limit(beforeLimit);
-							} else {
-							    // means optional is default value
-							    value = $defaultValue;
-							}"""
+                            // Read the message size, it is not needed
+                            final var valueTypeMessageSize = input.readVarInt(false);
+                            final $fieldType value;
+                            if (valueTypeMessageSize > 0) {
+                                final var beforeLimit = input.limit();
+                                input.limit(input.position() + valueTypeMessageSize);
+                                // read inner tag
+                                final int valueFieldTag = input.readVarInt(false);
+                                // assert tag is as expected
+                                assert (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
+                                assert (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
+                                // read value
+                                value = $readMethod;
+                                input.limit(beforeLimit);
+                            } else {
+                                // means optional is default value
+                                value = $defaultValue;
+                            }"""
                     .replace("$fieldType", field.javaFieldType())
                     .replace("$readMethod", readMethod(field))
                     .replace("$defaultValue",
@@ -280,121 +289,134 @@ class CodecParseMethodGenerator {
                     .indent(DEFAULT_INDENT)
             );
             sb.append('\n');
+            // spotless:on
         } else if (field.type() == Field.FieldType.MESSAGE) {
+            // spotless:off
             sb.append("""
-						final var messageLength = input.readVarInt(false);
-						final $fieldType value;
-						if (messageLength == 0) {
-							value = $fieldType.DEFAULT;
-						} else {
-							if (messageLength > $maxSize) {
-								throw new ParseException("$fieldName size " + messageLength + " is greater than max " + $maxSize);
-							}
-							final var limitBefore = input.limit();
-							// Make sure that we have enough bytes in the message
-							// to read the subObject.
-							// If the buffer is truncated on the boundary of a subObject,
-							// we will not throw.
-							final var startPos = input.position();
-							try {
-								if ((startPos + messageLength) > limitBefore) {
-									throw new BufferUnderflowException();
-								}
-								input.limit(startPos + messageLength);
-								value = $readMethod;
-								// Make sure we read the full number of bytes. for the types
-								if ((startPos + messageLength) != input.position()) {
-									throw new BufferOverflowException();
-								}
-							} finally {
-								input.limit(limitBefore);
-							}
-						}
-						"""
+                        final var messageLength = input.readVarInt(false);
+                        final $fieldType value;
+                        if (messageLength == 0) {
+                            value = $fieldType.DEFAULT;
+                        } else {
+                            if (messageLength > $maxSize) {
+                                throw new ParseException("$fieldName size " + messageLength + " is greater than max " + $maxSize);
+                            }
+                            final var limitBefore = input.limit();
+                            // Make sure that we have enough bytes in the message
+                            // to read the subObject.
+                            // If the buffer is truncated on the boundary of a subObject,
+                            // we will not throw.
+                            final var startPos = input.position();
+                            try {
+                                if ((startPos + messageLength) > limitBefore) {
+                                    throw new BufferUnderflowException();
+                                }
+                                input.limit(startPos + messageLength);
+                                value = $readMethod;
+                                // Make sure we read the full number of bytes. for the types
+                                if ((startPos + messageLength) != input.position()) {
+                                    throw new BufferOverflowException();
+                                }
+                            } finally {
+                                input.limit(limitBefore);
+                            }
+                        }
+                        """
                     .replace("$readMethod", readMethod(field))
                     .replace("$fieldType", field.javaFieldTypeBase())
                     .replace("$fieldName", field.name())
                     .replace("$maxSize", String.valueOf(field.maxSize()))
                     .indent(DEFAULT_INDENT)
             );
+            // spotless:on
         } else if (field.type() == Field.FieldType.MAP) {
             // This is almost like reading a message above because that's how Protobuf encodes map entries.
             // However(!), we read the key and value fields explicitly to avoid creating temporary entry objects.
             final MapField mapField = (MapField) field;
             final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
+            // spotless:off
             sb.append("""
-						final var __map_messageLength = input.readVarInt(false);
-						
-						$fieldDefs
-						if (__map_messageLength != 0) {
-							if (__map_messageLength > $maxSize) {
-								throw new ParseException("$fieldName size " + __map_messageLength + " is greater than max " + $maxSize);
-							}
-							final var __map_limitBefore = input.limit();
-							// Make sure that we have enough bytes in the message
-							// to read the subObject.
-							// If the buffer is truncated on the boundary of a subObject,
-							// we will not throw.
-							final var __map_startPos = input.position();
-							try {
-								if ((__map_startPos + __map_messageLength) > __map_limitBefore) {
-									throw new BufferUnderflowException();
-								}
-								input.limit(__map_startPos + __map_messageLength);
-								$mapParseLoop
-								// Make sure we read the full number of bytes. for the types
-								if ((__map_startPos + __map_messageLength) != input.position()) {
-									throw new BufferOverflowException();
-								}
-							} finally {
-								input.limit(__map_limitBefore);
-							}
-						}
-						"""
+                        final var __map_messageLength = input.readVarInt(false);
+                        
+                        $fieldDefs
+                        if (__map_messageLength != 0) {
+                            if (__map_messageLength > $maxSize) {
+                                throw new ParseException("$fieldName size " + __map_messageLength + " is greater than max " + $maxSize);
+                            }
+                            final var __map_limitBefore = input.limit();
+                            // Make sure that we have enough bytes in the message
+                            // to read the subObject.
+                            // If the buffer is truncated on the boundary of a subObject,
+                            // we will not throw.
+                            final var __map_startPos = input.position();
+                            try {
+                                if ((__map_startPos + __map_messageLength) > __map_limitBefore) {
+                                    throw new BufferUnderflowException();
+                                }
+                                input.limit(__map_startPos + __map_messageLength);
+                                $mapParseLoop
+                                // Make sure we read the full number of bytes. for the types
+                                if ((__map_startPos + __map_messageLength) != input.position()) {
+                                    throw new BufferOverflowException();
+                                }
+                            } finally {
+                                input.limit(__map_limitBefore);
+                            }
+                        }
+                        """
                     .replace("$fieldName", field.name())
-                    .replace("$fieldDefs",mapEntryFields.stream().map(mapEntryField -> "%s temp_%s = %s;".formatted(mapEntryField.javaFieldType(),
+                    .replace("$fieldDefs",mapEntryFields.stream().map(mapEntryField ->
+                            "%s temp_%s = %s;".formatted(mapEntryField.javaFieldType(),
                             mapEntryField.name(), mapEntryField.javaDefault())).collect(Collectors.joining("\n")))
-                    .replace("$mapParseLoop", generateParseLoop(generateCaseStatements(mapEntryFields), "map_entry_").indent(-DEFAULT_INDENT))
+                    .replace("$mapParseLoop", generateParseLoop(generateCaseStatements(mapEntryFields), "map_entry_")
+                            .indent(-DEFAULT_INDENT))
                     .replace("$maxSize", String.valueOf(field.maxSize()))
             );
+            // spotless:on
         } else {
             sb.append(("final var value = " + readMethod(field) + ";\n").indent(DEFAULT_INDENT));
         }
         // set value to temp var
+        // spotless:off
         sb.append(Common.FIELD_INDENT);
         if (field.parent() != null && field.repeated()) {
             throw new PbjCompilerException("Fields can not be oneof and repeated ["+field+"]");
         } else if (field.parent() != null) {
             final var oneOfField = field.parent();
-            sb.append("temp_" + oneOfField.name() + " =  new %s<>(".formatted(oneOfField.className()) +
-                    oneOfField.getEnumClassRef() + '.' + Common.camelToUpperSnake(field.name()) + ", value);\n");
+            sb.append("temp_%s =  new %s<>(%s.%s, value);%n"
+                    .formatted(oneOfField.name(), oneOfField.className(), oneOfField.getEnumClassRef(),
+                            Common.camelToUpperSnake(field.name())));
         } else if (field.repeated()) {
-            sb.append("if (temp_" + field.name() + ".size() >= " + field.maxSize() + ") {\n");
-            sb.append("		throw new ParseException(\"" + field.name() + " size \" + temp_" + field.name() + ".size() + \" is greater than max \" + " + field.maxSize() + ");\n");
-            sb.append("	}\n");
-            sb.append("	temp_" + field.name() + " = addToList(temp_" + field.name() + ",value);\n");
+            sb.append(
+                """
+                if (temp_%s.size() >= %d) {
+                    throw new ParseException("%1$s size %%d is greater than max %2$d".formatted(temp_%1$s.size()));
+                }
+                temp_%1$s = addToList(temp_%1$s,value);
+                """.formatted(field.name(), field.maxSize()));
         } else if (field.type() == Field.FieldType.MAP) {
             final MapField mapField = (MapField) field;
-
-            sb.append("if (__map_messageLength != 0) {\n");
-            sb.append("		if (temp_" + field.name() + ".size() >= " + field.maxSize() + ") {\n");
-            sb.append("				throw new ParseException(\"" + field.name() + " size \" + temp_" + field.name() + ".size() + \" is greater than max \" + " + field.maxSize() + ");\n");
-            sb.append("			}\n");
-            sb.append("			temp_" + field.name() + " = addToMap(temp_" + field.name() + ", temp_$key, temp_$value);\n"
-                    .replace("$key", mapField.keyField().name())
-                    .replace("$value", mapField.valueField().name())
-            );
-            sb.append("		}\n");
+            sb.append(
+                """
+                if (__map_messageLength != 0) {
+                    if (temp_%s.size() >= %d) {
+                        throw new ParseException("%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                    }
+                    temp_%1$s = addToMap(temp_%1$s, temp_%s, temp_%s);
+                }
+                """.formatted(field.name(), field.maxSize(),
+                        mapField.keyField().name(), mapField.valueField().name()));
         } else {
-            sb.append("temp_" + field.name() + " = value;\n");
+            sb.append("temp_%s = value;\n".formatted(field.name()));
         }
         sb.append("}\n");
+        // spotless:on
     }
 
     static String readMethod(Field field) {
         if (field.optionalValueType()) {
             return switch (field.messageType()) {
-                case "StringValue" -> "readString(input, " + field.maxSize() + ")";
+                case "StringValue" -> "readString(input, %d)".formatted(field.maxSize());
                 case "Int32Value" -> "readInt32(input)";
                 case "UInt32Value" -> "readUint32(input)";
                 case "Int64Value" -> "readInt64(input)";
@@ -402,12 +424,14 @@ class CodecParseMethodGenerator {
                 case "FloatValue" -> "readFloat(input)";
                 case "DoubleValue" -> "readDouble(input)";
                 case "BoolValue" -> "readBool(input)";
-                case "BytesValue" -> "readBytes(input, " + field.maxSize() + ")";
-                default -> throw new PbjCompilerException("Optional message type [" + field.messageType() + "] not supported");
+                case "BytesValue" -> "readBytes(input, %d)".formatted(field.maxSize());
+                default -> throw new PbjCompilerException(
+                        "Optional message type [%s] not supported".formatted(field.messageType()));
             };
         }
         return switch (field.type()) {
-            case ENUM ->  Common.snakeToCamel(field.messageType(), true) + ".fromProtobufOrdinal(readEnum(input))";
+            case ENUM -> "%s.fromProtobufOrdinal(readEnum(input))"
+                    .formatted(Common.snakeToCamel(field.messageType(), true));
             case INT32 -> "readInt32(input)";
             case UINT32 -> "readUint32(input)";
             case SINT32 -> "readSignedInt32(input)";
@@ -420,9 +444,9 @@ class CodecParseMethodGenerator {
             case DOUBLE -> "readDouble(input)";
             case FIXED64 -> "readFixed64(input)";
             case SFIXED64 -> "readSignedFixed64(input)";
-            case STRING -> "readString(input, " + field.maxSize() + ")";
+            case STRING -> "readString(input, %d)".formatted(field.maxSize());
             case BOOL -> "readBool(input)";
-            case BYTES -> "readBytes(input, " + field.maxSize() + ")";
+            case BYTES -> "readBytes(input, %d)".formatted(field.maxSize());
             case MESSAGE -> field.parseCode();
             case ONE_OF -> throw new PbjCompilerException("Should never happen, oneOf handled elsewhere");
             case MAP -> throw new PbjCompilerException("Should never happen, map handled elsewhere");

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -26,8 +26,9 @@ final class CodecWriteMethodGenerator {
                 fields,
                 field -> "data.%s()".formatted(field.nameCamelFirstLower()),
                 true);
-
-        return """     
+        // spotless:off
+        return
+            """
             /**
              * Write out a $modelClass model to output stream in protobuf format.
              *
@@ -42,6 +43,7 @@ final class CodecWriteMethodGenerator {
             .replace("$modelClass", modelClassName)
             .replace("$fieldWriteLines", fieldWriteLines)
             .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 
     private static String buildFieldWriteLines(
@@ -68,18 +70,16 @@ final class CodecWriteMethodGenerator {
      */
     private static String generateFieldWriteLines(final Field field, final String modelClassName, String getValueCode, boolean skipDefault) {
         final String fieldDef = Common.camelToUpperSnake(field.name());
-        String prefix = "// ["+field.fieldNumber()+"] - "+field.name();
-        prefix += "\n";
+        String prefix = "// [%d] - %s%n".formatted(field.fieldNumber(), field.name());
 
         if (field.parent() != null) {
             final OneOfField oneOfField = field.parent();
-            final String oneOfType = modelClassName+"."+oneOfField.nameCamelFirstUpper()+"OneOfType";
-            getValueCode = "data."+oneOfField.nameCamelFirstLower()+"().as()";
-            prefix += "if (data."+oneOfField.nameCamelFirstLower()+"().kind() == "+ oneOfType +"."+
-                    Common.camelToUpperSnake(field.name())+")";
-            prefix += "\n";
+            final String oneOfType = "%s.%sOneOfType".formatted(modelClassName, oneOfField.nameCamelFirstUpper());
+            getValueCode = "data.%s().as()".formatted(oneOfField.nameCamelFirstLower());
+            prefix += "if (data.%s().kind() == %s.%s)%n"
+                    .formatted(oneOfField.nameCamelFirstLower(), oneOfType, Common.camelToUpperSnake(field.name()));
         }
-
+        // spotless:off
         final String writeMethodName = field.methodNameType();
         if (field.optionalValueType()) {
             return prefix + switch (field.messageType()) {
@@ -97,87 +97,86 @@ final class CodecWriteMethodGenerator {
                         .formatted(fieldDef, getValueCode);
                 case "BytesValue" -> "writeOptionalBytes(out, %s, %s);"
                         .formatted(fieldDef, getValueCode);
-                default -> throw new UnsupportedOperationException("Unhandled optional message type:"+field.messageType());
+                default -> throw new UnsupportedOperationException(
+                        "Unhandled optional message type:%s".formatted(field.messageType()));
             };
-        } else if (field.repeated()) {
-            return prefix + switch(field.type()) {
-                case ENUM -> "writeEnumList(out, %s, %s);"
-                        .formatted(fieldDef, getValueCode);
-                case MESSAGE -> "writeMessageList(out, $fieldDef, $valueCode, $codec);"
-                        .replace("$fieldDef", fieldDef)
-                        .replace("$valueCode", getValueCode)
-                        .replace("$codec", ((SingleField)field).messageTypeModelPackage() + "." +
-                                Common.capitalizeFirstLetter(field.messageType())+ ".PROTOBUF");
-                default -> "write%sList(out, %s, %s);"
-                        .formatted(writeMethodName, fieldDef, getValueCode);
-            };
-        } else if (field.type() == Field.FieldType.MAP) {
-            // https://protobuf.dev/programming-guides/proto3/#maps
-            // On the wire, a map is equivalent to:
-            //    message MapFieldEntry {
-            //      key_type key = 1;
-            //      value_type value = 2;
-            //    }
-            //    repeated MapFieldEntry map_field = N;
-            // NOTE: we serialize the map in the natural order of keys by design,
-            //       so that the binary representation of the map is deterministic.
-            // NOTE: protoc serializes default values (e.g. "") in maps, so we should too.
-            final MapField mapField = (MapField) field;
-            final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
-            final Function<Field, String> getValueBuilder = mapEntryField ->
-                    mapEntryField == mapField.keyField() ? "k" : (mapEntryField == mapField.valueField() ? "v" : null);
-            final String fieldWriteLines = buildFieldWriteLines(
-                    field.name(),
-                    mapEntryFields,
-                    getValueBuilder,
-                    false);
-            final String fieldSizeOfLines = CodecMeasureRecordMethodGenerator.buildFieldSizeOfLines(
-                    field.name(),
-                    mapEntryFields,
-                    getValueBuilder,
-                    false);
-            return prefix + """
-                        if (!$map.isEmpty()) {
-                            final Pbj$javaFieldType pbjMap = (Pbj$javaFieldType) $map;
-                            final int mapSize = pbjMap.size();
-                            for (int i = 0; i < mapSize; i++) {
-                                writeTag(out, $fieldDef, WIRE_TYPE_DELIMITED);
-                                $K k = pbjMap.getSortedKeys().get(i);
-                                $V v = pbjMap.get(k);
-                                int size = 0;
-                                $fieldSizeOfLines
-                                out.writeVarInt(size, false);
-                                $fieldWriteLines
-                            }
-                        }
-                        """
-                    .replace("$fieldDef", fieldDef)
-                    .replace("$map", getValueCode)
-                    .replace("$javaFieldType", mapField.javaFieldType())
-                    .replace("$K", mapField.keyField().type().boxedType)
-                    .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? ((SingleField)mapField.valueField()).messageType() : mapField.valueField().type().boxedType)
-                    .replace("$fieldWriteLines", fieldWriteLines.indent(DEFAULT_INDENT))
-                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
-
-                    ;
         } else {
-            return prefix + switch(field.type()) {
-                case ENUM -> "writeEnum(out, %s, %s);"
-                        .formatted(fieldDef, getValueCode);
-                case STRING -> "writeString(out, %s, %s, %s);"
-                        .formatted(fieldDef, getValueCode, skipDefault);
-                case MESSAGE -> "writeMessage(out, $fieldDef, $valueCode, $codec);"
+            final String codecReference = "%s.%s.PROTOBUF"
+                    .formatted(((SingleField)field).messageTypeModelPackage(),
+                            Common.capitalizeFirstLetter(field.messageType()));
+            if (field.repeated()) {
+                return prefix + switch(field.type()) {
+                    case ENUM -> "writeEnumList(out, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case MESSAGE -> "writeMessageList(out, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, codecReference);
+                    default -> "write%sList(out, %s, %s);"
+                            .formatted(writeMethodName, fieldDef, getValueCode);
+                };
+            } else if (field.type() == Field.FieldType.MAP) {
+                // https://protobuf.dev/programming-guides/proto3/#maps
+                // On the wire, a map is equivalent to:
+                //    message MapFieldEntry {
+                //      key_type key = 1;
+                //      value_type value = 2;
+                //    }
+                //    repeated MapFieldEntry map_field = N;
+                // NOTE: we serialize the map in the natural order of keys by design,
+                //       so that the binary representation of the map is deterministic.
+                // NOTE: protoc serializes default values (e.g. "") in maps, so we should too.
+                final MapField mapField = (MapField) field;
+                final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
+                final Function<Field, String> getValueBuilder = mapEntryField ->
+                        mapEntryField == mapField.keyField() ? "k" : (mapEntryField == mapField.valueField() ? "v" : null);
+                final String fieldWriteLines = buildFieldWriteLines(
+                        field.name(),
+                        mapEntryFields,
+                        getValueBuilder,
+                        false);
+                final String fieldSizeOfLines = CodecMeasureRecordMethodGenerator.buildFieldSizeOfLines(
+                        field.name(),
+                        mapEntryFields,
+                        getValueBuilder,
+                        false);
+                return prefix + """
+                            if (!$map.isEmpty()) {
+                                final Pbj$javaFieldType pbjMap = (Pbj$javaFieldType) $map;
+                                final int mapSize = pbjMap.size();
+                                for (int i = 0; i < mapSize; i++) {
+                                    writeTag(out, $fieldDef, WIRE_TYPE_DELIMITED);
+                                    $K k = pbjMap.getSortedKeys().get(i);
+                                    $V v = pbjMap.get(k);
+                                    int size = 0;
+                                    $fieldSizeOfLines
+                                    out.writeVarInt(size, false);
+                                    $fieldWriteLines
+                                }
+                            }
+                            """
                         .replace("$fieldDef", fieldDef)
-                        .replace("$valueCode", getValueCode)
-                        .replace("$codec", ((SingleField)field).messageTypeModelPackage() + "." +
-                                Common.capitalizeFirstLetter(field.messageType())+ ".PROTOBUF");
-                case BOOL -> "writeBoolean(out, %s, %s, %s);"
-                        .formatted(fieldDef, getValueCode, skipDefault);
-                case INT32, UINT32, SINT32, FIXED32, SFIXED32, INT64, SINT64, UINT64, FIXED64, SFIXED64, BYTES -> "write%s(out, %s, %s, %s);"
-                        .formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
-                default -> "write%s(out, %s, %s);"
-                        .formatted(writeMethodName, fieldDef, getValueCode);
-            };
+                        .replace("$map", getValueCode)
+                        .replace("$javaFieldType", mapField.javaFieldType())
+                        .replace("$K", mapField.keyField().type().boxedType)
+                        .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? ((SingleField)mapField.valueField()).messageType() : mapField.valueField().type().boxedType)
+                        .replace("$fieldWriteLines", fieldWriteLines.indent(DEFAULT_INDENT))
+                        .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT));
+            } else {
+                return prefix + switch(field.type()) {
+                    case ENUM -> "writeEnum(out, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case STRING -> "writeString(out, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case MESSAGE -> "writeMessage(out, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, codecReference);
+                    case BOOL -> "writeBoolean(out, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case INT32, UINT32, SINT32, FIXED32, SFIXED32, INT64, SINT64, UINT64, FIXED64, SFIXED64, BYTES ->
+                            "write%s(out, %s, %s, %s);".formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
+                    default -> "write%s(out, %s, %s);"
+                            .formatted(writeMethodName, fieldDef, getValueCode);
+                };
+            }
         }
+        // spotless:on
     }
 }


### PR DESCRIPTION
* In some files excluded large text blocks from formatting to protect the internal structure of those blocks and keep the file readble.
* Replaced string append chains with String.formatted in many places, which helped Spotless format effectively
* Disabled spotless formatting in a few other places where the palantir format simply could not be made readable, or where it was modifying the content of text blocks.
* Adjusted a few other blocks by introducing variables and simliar small refactors to "help" the formatter produce a readable result.
