### PR TITLE
Fix circular dependency for atomic batch

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -110,11 +110,11 @@ public final class TestGenerator implements Generator {
                     %s
                     }
                     """.formatted(testPackage, imports.isEmpty() ? "" : imports.stream()
-                                    .filter(input -> !input.equals(testPackage))
-                                    .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")),
-                            modelClassName, testClassName,
-                            generateTestMethod(modelClassName, protoCJavaFullQualifiedClass).indent(DEFAULT_INDENT),
-                            generateModelTestArgumentsMethod(modelClassName, fields).indent(DEFAULT_INDENT)
+                                .filter(input -> !input.equals(testPackage))
+                                .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")),
+                        modelClassName, testClassName,
+                        generateTestMethod(modelClassName, protoCJavaFullQualifiedClass).indent(DEFAULT_INDENT),
+                        generateModelTestArgumentsMethod(modelClassName, fields).indent(DEFAULT_INDENT)
                     )
             );
         }
@@ -153,22 +153,22 @@ public final class TestGenerator implements Generator {
                     return ARGUMENTS.stream().map(NoToStringWrapper::new);
                 }
                 """.formatted(modelClassName,fields.stream()
-                                .filter(field -> !field.javaFieldType().equals(modelClassName))
-                                .map(f -> "final var %sList = %s;".formatted(f.nameCamelFirstLower(),
-                                        generateTestData(modelClassName, f, f.optionalValueType(), f.repeated())))
-                                .collect(Collectors.joining("\n")).indent(DEFAULT_INDENT),
-                        fields.stream().filter(field -> !field.javaFieldType().equals(modelClassName))
-                                .map(f -> f.nameCamelFirstLower()+"List.size()")
-                                .collect(Collectors.collectingAndThen(Collectors.toList(),
-                                        list -> list.isEmpty() ? Stream.of("0") : list.stream()))
-                                .collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 2),
-                        modelClassName,
-                        fields.stream().map(field -> field.javaFieldType().equals(modelClassName)
-                                        ? field.javaFieldType() + ".newBuilder().build()"
-                                        : "$nameList.get(Math.min(i, $nameList.size()-1))"
-                                        .replace("$name", field.nameCamelFirstLower()))
-                                .collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 4),
-                        modelClassName, modelClassName
+                            .filter(field -> !field.javaFieldType().equals(modelClassName))
+                            .map(f -> "final var %sList = %s;".formatted(f.nameCamelFirstLower(),
+                                    generateTestData(modelClassName, f, f.optionalValueType(), f.repeated())))
+                            .collect(Collectors.joining("\n")).indent(DEFAULT_INDENT),
+                    fields.stream().filter(field -> !field.javaFieldType().equals(modelClassName))
+                            .map(f -> f.nameCamelFirstLower()+"List.size()")
+                            .collect(Collectors.collectingAndThen(Collectors.toList(),
+                                    list -> list.isEmpty() ? Stream.of("0") : list.stream()))
+                            .collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 2),
+                    modelClassName,
+                    fields.stream().map(field -> field.javaFieldType().equals(modelClassName)
+                            ? field.javaFieldType() + ".newBuilder().build()"
+                            : "$nameList.get(Math.min(i, $nameList.size()-1))"
+                                    .replace("$name", field.nameCamelFirstLower()))
+                            .collect(Collectors.joining(",\n")).indent(DEFAULT_INDENT * 4),
+                    modelClassName, modelClassName
                 );
         // spotless:on
     }
@@ -217,7 +217,7 @@ public final class TestGenerator implements Generator {
                         %s
                     ).flatMap(List::stream).toList()"""
                     .formatted(((OneOfField) field).className(), classDotField,
-                            String.join(",\n", options).indent(DEFAULT_INDENT)).indent(DEFAULT_INDENT * 2);
+                        String.join(",\n", options).indent(DEFAULT_INDENT)).indent(DEFAULT_INDENT * 2);
             // spotless:on
         } else if (field instanceof final MapField mapField) {
             // e.g. INTEGER_TESTS_LIST


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
As part of HIP-551, we introduce new `atomic batch` transaction. But due to circular dependency, pbj tests are failing in [services CI](https://github.com/hashgraph/hedera-services/actions/runs/12799628521/job/35686260360).
This PR adds the atomic batch transaction body in a list together with the other circular dependency fields in `TestGenerator`.

**Related issue(s)**:

Fixes [17318](https://github.com/hashgraph/hedera-services/issues/17318)

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
