### PR TITLE
Fix NPE at CodecWriteMethodGenerator

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -100,9 +100,11 @@ final class CodecWriteMethodGenerator {
                         "Unhandled optional message type:%s".formatted(field.messageType()));
             };
         } else {
-            final String codecReference = "%s.%s.PROTOBUF"
-                    .formatted(((SingleField)field).messageTypeModelPackage(),
-                            Common.capitalizeFirstLetter(field.messageType()));
+            String codecReference = "";
+            if (Field.FieldType.MESSAGE.equals(field.type())) {
+                codecReference = "%s.%s.PROTOBUF".formatted(((SingleField) field).messageTypeModelPackage(),
+                        Common.capitalizeFirstLetter(field.messageType()));
+            }
             if (field.repeated()) {
                 return prefix + switch(field.type()) {
                     case ENUM -> "writeEnumList(out, %s, %s);"


### PR DESCRIPTION
**Description**:
Fix a NPE which is a regression of https://github.com/hashgraph/pbj/pull/366/files#diff-961773b27ac110f66f524db9b5fecaadedef721ff0c0895dc1fdf2f3a08de9d3

Stack trace:
```
java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "name" is null
    com.hedera.pbj.compiler.impl.Common.capitalizeFirstLetter(Common.java:58)
    com.hedera.pbj.compiler.impl.generators.protobuf.CodecWriteMethodGenerator.generateFieldWriteLines(CodecWriteMethodGenerator.java:105)
    com.hedera.pbj.compiler.impl.generators.protobuf.CodecWriteMethodGenerator.lambda$buildFieldWriteLines$2(CodecWriteMethodGenerator.java:55)
    java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
    java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
    java.base/java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:395)
    java.base/java.util.stream.Sink$ChainedReference.end(Sink.java:261)
    java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
```
Task :generatePbjSource FAILED

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
