### PR TITLE
bug: Fix a couple errors in pbj-integration that slipped in recent PRs

### DIFF
--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/NonSynchronizedByteArrayInputStream.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/NonSynchronizedByteArrayInputStream.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Objects;
-import org.jetbrains.annotations.NotNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Faster non-synchronized ByteArrayInputStream. This class is not thread safe, and does not require synchronization.
@@ -68,7 +68,7 @@ public final class NonSynchronizedByteArrayInputStream extends InputStream {
      * {@inheritDoc}
      */
     @Override
-    public byte @NotNull [] readAllBytes() {
+    public @NonNull byte[] readAllBytes() {
         byte[] result = Arrays.copyOfRange(buf, pos, count);
         pos = count;
         return result;

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/TestHashFunctions.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/TestHashFunctions.java
@@ -69,13 +69,14 @@ public final class TestHashFunctions {
         }
         if (hashEval.subObject() != Hasheval.DEFAULT.subObject()) {
             TimestampTest sub = hashEval.subObject();
-            if (sub.nanos() != sub.DEFAULT.nanos()) {
+            if (sub.nanos() != TimestampTest.DEFAULT.nanos()) {
                 result = 31 * result + Integer.hashCode(sub.nanos());
             }
-            if (sub.seconds() != sub.DEFAULT.seconds()) {
+            if (sub.seconds() != TimestampTest.DEFAULT.seconds()) {
                 result = 31 * result + Long.hashCode(sub.seconds());
             }
         }
+        //noinspection StringEquality
         if (hashEval.text() != Hasheval.DEFAULT.text()) {
             result = 31 * result + hashEval.text().hashCode();
         }


### PR DESCRIPTION
* Fixed TestHashFunctions class that had trivial warnings which fail compilation due to Heiro "Warnings are errors" setting.
   * Introduced in PR #109, but only became an error recently.
* Fixed a random annotation in NonSynchronizedByteArrayInputStream that was referencing the Jetbrains annotation and _between_ `byte` and `[]` in a `byte[]` return type.
   * Introduced in PR #348 and not detected because pbj-integration-tests is not running in the PBJ CI suite. ([example build scan](https://scans.gradle.com/s/3cjan7qcca5ny); the gradle cache skips the entire run).


@jjohannes Could you look into why the gradle tasks are skipping everything in most CI runs?