### PR TITLE
ci: re-enable integration tests on CI and align Java version on CI

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -6,7 +6,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "21.0.3"
+        default: "21.0.5"
       java-distribution:
         description: "Java JDK Distribution:"
         type: string
@@ -103,7 +103,7 @@ jobs:
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
         with:
           distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
-          java-version: ${{ github.event.inputs.java-version || '21.0.3' }}
+          java-version: ${{ github.event.inputs.java-version || '21.0.5' }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2

--- a/.github/workflows/zxc-compile-pbj-code.yaml
+++ b/.github/workflows/zxc-compile-pbj-code.yaml
@@ -26,7 +26,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "21.0.3"
+        default: "21.0.5"
       gradle-version:
         description: "Gradle Version:"
         type: string
@@ -122,7 +122,7 @@ jobs:
 
       - name: Gradle Assemble (PBJ Integration)
         id: gradle-integration-build
-        if: ${{ (inputs.enable-integration-tests || inputs.enable-jmh-tests) && steps.gradle-publish-local.conclusion == 'success' && !cancelled() }}
+        if: ${{ (inputs.enable-integration-tests || inputs.enable-jmh-tests) && !cancelled() }}
         working-directory: ${{ env.PBJ_INTEGRATION_TESTS }}
         run: ./gradlew assemble
 

--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -27,7 +27,6 @@ mainModuleInfo {
 
     requires("com.google.common")
     requires("com.google.protobuf")
-    requires("com.google.protobuf.util")
     requires("io.grpc")
     requires("io.grpc.protobuf")
     requires("io.grpc.stub")
@@ -38,10 +37,14 @@ mainModuleInfo {
 testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
+    requires("com.google.protobuf.util")
     runtimeOnly("org.junit.jupiter.engine")
 }
 
-jmhModuleInfo { requires("com.hedera.pbj.runtime") }
+jmhModuleInfo {
+    requires("com.hedera.pbj.runtime")
+    requires("com.google.protobuf.util")
+}
 
 // IMPROVE: Disable module-info transform for 'testRuntimeClasspath' which leads to an error
 // possible caused by a cycle produced by depending on 'pbj-compiler' in multiple ways which

--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -5,6 +5,14 @@ pluginManagement {
 
 plugins { id("org.hiero.gradle.build") version "0.3.1" }
 
+// Downgrade 'dependency-analysis-gradle-plugin' due to regression in 2.7.0
+// https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1364
+buildscript {
+    dependencies.constraints {
+        classpath("com.autonomousapps:dependency-analysis-gradle-plugin:2.6.0!!")
+    }
+}
+
 dependencyResolutionManagement {
     // To use locally built 'pbj-runtime'
     includeBuild("../pbj-core")


### PR DESCRIPTION


**Description**:
- Make sure 'PBJ Integration' steps are no longer skipped (issue likely introduced in #302)
- Set Java version on CI to same version defined in 'toolchain-versions.properties' files
- Fix exist quality check issues in `pbj-integration-tests`

**Related issue(s)**:

#302

