### PR TITLE
fix: handle partially-qualified inner message names

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -132,8 +132,7 @@ public final class LookupHelper {
         }
     }
 
-    private String getFullyQualifiedProtoMessageName(
-            final String messageType, final File protoSrcFile, final ParserRuleContext context) {
+    private String getFullyQualifiedProtoMessageName(final String messageType, final ParserRuleContext context) {
         // messageType can be a fully qualified name already, or it may be an unqualified, or partially qualified name.
         // Check all known fully qualified names, both local and imported:
         if (pbjPackageMap.containsKey(messageType)) {
@@ -151,8 +150,7 @@ public final class LookupHelper {
         while ((parentContext = parentContext.getParent()) != null) {
             if (parentContext instanceof MessageDefContext ctx) {
                 final String msgName = ctx.messageName().getText();
-                final String tryName =
-                        getFullyQualifiedProtoMessageName(msgName + "." + messageType, protoSrcFile, ctx);
+                final String tryName = getFullyQualifiedProtoMessageName(msgName + "." + messageType, ctx);
                 if (tryName != null) {
                     return tryName;
                 }
@@ -161,8 +159,10 @@ public final class LookupHelper {
                 // statements, so simply try each:
                 for (final Protobuf3Parser.PackageStatementContext psc : ctx.packageStatement()) {
                     final String packageName = psc.fullIdent().getText();
-                    final String prefix = (packageName == null || packageName.isBlank()) ? "" : (packageName + ".");
-                    final String tryName = getFullyQualifiedProtoMessageName(prefix + messageType, protoSrcFile, ctx);
+                    if (packageName == null || packageName.isBlank()) {
+                        continue;
+                    }
+                    final String tryName = getFullyQualifiedProtoMessageName(packageName + "." + messageType, ctx);
                     if (tryName != null) {
                         return tryName;
                     }
@@ -195,8 +195,7 @@ public final class LookupHelper {
                 return messageType;
             }
 
-            final String fullyQualifiedProtoMessageName =
-                    getFullyQualifiedProtoMessageName(messageType, protoSrcFile, context);
+            final String fullyQualifiedProtoMessageName = getFullyQualifiedProtoMessageName(messageType, context);
             if (fullyQualifiedProtoMessageName != null) {
                 return fullyQualifiedProtoMessageName;
             }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -132,6 +132,48 @@ public final class LookupHelper {
         }
     }
 
+    private String getFullyQualifiedProtoMessageName(
+            final String messageType, final File protoSrcFile, final ParserRuleContext context) {
+        // messageType can be a fully qualified name already, or it may be an unqualified, or partially qualified name.
+        // Check all known fully qualified names, both local and imported:
+        if (pbjPackageMap.containsKey(messageType)) {
+            // It's a known fully-qualified name already
+            return messageType;
+        }
+
+        // We know this is a partial, non-fully-qualified name at this point. It may be defined
+        // as an inner type in the current message that we're parsing, or as an inner type
+        // in the next-level-outer-message and so on recursively, or it can be a top-level
+        // type in the current file.
+        // It can also be an imported type from another file that is in the same proto package.
+        // Just walk up the parsing tree recursively and try every level as a prefix:
+        ParserRuleContext parentContext = context;
+        while ((parentContext = parentContext.getParent()) != null) {
+            if (parentContext instanceof MessageDefContext ctx) {
+                final String msgName = ctx.messageName().getText();
+                final String tryName =
+                        getFullyQualifiedProtoMessageName(msgName + "." + messageType, protoSrcFile, ctx);
+                if (tryName != null) {
+                    return tryName;
+                }
+            } else if (parentContext instanceof Protobuf3Parser.ProtoContext ctx) {
+                // We've reached the top-level context. Weirdly, the grammar allows for multiple package
+                // statements, so simply try each:
+                for (final Protobuf3Parser.PackageStatementContext psc : ctx.packageStatement()) {
+                    final String packageName = psc.fullIdent().getText();
+                    final String prefix = (packageName == null || packageName.isBlank()) ? "" : (packageName + ".");
+                    final String tryName = getFullyQualifiedProtoMessageName(prefix + messageType, protoSrcFile, ctx);
+                    if (tryName != null) {
+                        return tryName;
+                    }
+                }
+            }
+        }
+
+        // Well, we searched everywhere and couldn't find any matching names.
+        return null;
+    }
+
     /**
      * Get the fully qualified proto name for a message, enum or a message type. For example
      * "proto.GetAccountDetailsResponse.AccountDetails" would return
@@ -144,31 +186,21 @@ public final class LookupHelper {
     public String getFullyQualifiedProtoName(final File protoSrcFile, final ParserRuleContext context) {
         if (context instanceof final MessageTypeContext msgTypeContext) {
             final String messageType = msgTypeContext.getText();
-            // check if fully qualified
-            if (messageType.contains(".")) {
+
+            // Ugly, but this is how PBJ implements the built-in "support" for Google Protobuf boxed types...
+            // Imports for "google/protobuf/wrappers.proto" are ignored elsewhere in PBJ,
+            // so we cannot really refer to the real Google types that we refuse to import physically.
+            // This is the only option for now:
+            if (messageType.startsWith("google.protobuf.")) {
                 return messageType;
             }
-            // check local file message types
-            final var messageMapLocal = msgAndEnumByFile.get(protoSrcFile.getAbsolutePath());
-            if (messageMapLocal == null) {
-                throw new PbjCompilerException(FAILED_TO_FIND_LOCAL_MSG_MAP_MESSAGE.formatted(protoSrcFile));
+
+            final String fullyQualifiedProtoMessageName =
+                    getFullyQualifiedProtoMessageName(messageType, protoSrcFile, context);
+            if (fullyQualifiedProtoMessageName != null) {
+                return fullyQualifiedProtoMessageName;
             }
-            final String nameFoundInLocalFile = messageMapLocal.get(messageType);
-            if (nameFoundInLocalFile != null) {
-                return nameFoundInLocalFile;
-            }
-            // message type is not from local file so check imported files
-            for (final var importedProtoFilePath : protoFileImports.get(protoSrcFile.getAbsolutePath())) {
-                final var messageMap = msgAndEnumByFile.get(importedProtoFilePath);
-                if (messageMap == null) {
-                    throw new PbjCompilerException(
-                            FAILED_TO_FIND_LOCAL_MSG_MAP_MESSAGE.formatted(importedProtoFilePath));
-                }
-                final var found = messageMap.get(messageType);
-                if (found != null) {
-                    return found;
-                }
-            }
+
             // we failed to find
             final Object[] importsArray =
                     protoFileImports.get(protoSrcFile.getAbsolutePath()).toArray();
@@ -176,6 +208,10 @@ public final class LookupHelper {
             throw new PbjCompilerException(
                     FAILED_TO_FIND_MSG_TYPE_MESSAGE.formatted(messageType, protoSrcFile, importsString));
         } else if (context instanceof MessageDefContext || context instanceof EnumDefContext) {
+            // It's unclear what exactly is being handled in this branch. However, the symbol maps
+            // inside msgAndEnumByFile use unqualified names as keys, meaning that this code doesn't support
+            // having multiple inner classes with the same name located in different outer classes.
+            // We'll get back to fixing this in the second part of https://github.com/hashgraph/pbj/issues/263
             final Map<String, String> fileMap = msgAndEnumByFile.get(protoSrcFile.getAbsolutePath());
             if (fileMap == null) {
                 throw new PbjCompilerException(FAILED_TO_FIND_LOCAL_MSG_MAP_MESSAGE.formatted(protoSrcFile));

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
@@ -1,9 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.integration.test;
 
 import static com.hedera.pbj.compiler.PbjCompiler.compileFilesIn;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.net.URI;
@@ -11,6 +9,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class SubTypesTest {
     @TempDir

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
@@ -1,0 +1,39 @@
+package com.hedera.pbj.integration.test;
+
+import static com.hedera.pbj.compiler.PbjCompiler.compileFilesIn;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+public class SubTypesTest {
+    @TempDir
+    private static File outputDir;
+
+    @Test
+    void testSubTypes() throws Exception {
+        // Verify if we're able to reference inner and imported types w/o using fully qualified names
+        getCompileFilesIn("sub_types.proto", "sub_types_import.proto");
+    }
+
+    private static void getCompileFilesIn(String... fileNames) throws Exception {
+        final List<File> files = Arrays.stream(fileNames)
+                .map(fileName -> {
+                    try {
+                        final URL url = SubTypesTest.class.getClassLoader().getResource(fileName);
+                        final URI uri = url.toURI();
+                        return new File(uri);
+                    } catch (URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .toList();
+        compileFilesIn(files, outputDir, outputDir);
+    }
+}

--- a/pbj-integration-tests/src/test/resources/sub_types.proto
+++ b/pbj-integration-tests/src/test/resources/sub_types.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+import "sub_types_import.proto";
+
+message PartitionResponse {
+  oneof response {
+    // Verify if we're able to reference inner and imported types w/o using fully qualified names
+    FullResponse.Acknowledgement acknowledgement = 1;
+    FullResponse.EndOfStream status = 2;
+    ImportedChildAcknowledgement imported_ack = 3;
+    OuterImportedMessage.InnerImportedMessage inner_imported_ack = 4;
+  }
+}
+
+message FullResponse {
+  message Acknowledgement {
+    oneof acknowledgements {
+      FullResponse.ChildAcknowledgement child_ack = 271;
+      FullResponse.ParentAcknowledgement parent_ack = 272;
+    }
+  }
+  message ParentAcknowledgement {
+    uint32 child_count = 872;
+  }
+  message ChildAcknowledgement {
+    uint32 partition_count = 1438;
+  }
+  enum EndOfStream {
+    UNKNOWN = 0;
+    CANCELED = 1;
+  }
+}

--- a/pbj-integration-tests/src/test/resources/sub_types_import.proto
+++ b/pbj-integration-tests/src/test/resources/sub_types_import.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+message ImportedChildAcknowledgement {
+  uint32 some_number = 111111;
+}
+message OuterImportedMessage {
+  message InnerImportedMessage {
+    uint32 other_number = 222222;
+  }
+}
+


### PR DESCRIPTION
**Description**:
Re-implementing fully qualified names look-up that now allows one to use partially qualified names to refer to inner and/or imported messages. This is the first part of a bigger issue described at https://github.com/hashgraph/pbj/issues/263.

**Related issue(s)**:

Fixes #414

**Notes for reviewer**:
A new test is added to verify the new behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
