### PR TITLE
feat: introduce JavaFileWriter and FileSetWriter

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
@@ -10,7 +10,7 @@ import java.io.IOException;
  * There's not a lot of logic around the set of JavaFileWriter objects, and for this reason they
  * are exposed as `public final` fields directly.
  */
-public class FileSetWriter {
+public final class FileSetWriter {
     public final JavaFileWriter modelWriter;
     public final JavaFileWriter schemaWriter;
     public final JavaFileWriter codecWriter;

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
@@ -4,34 +4,17 @@ package com.hedera.pbj.compiler.impl;
 import java.io.IOException;
 
 /**
- * This is essentially a set of JavaFileWriter objects that are necessary to support the generation
- * of a single top-level .proto model implementation in Java.
- *
- * There's not a lot of logic around the set of JavaFileWriter objects, and for this reason they
- * are exposed as `public final` fields directly.
+ * This is essentially a set of all the JavaFileWriter objects that are necessary to support the generation
+ * of a single top-level .proto model implementation in Java, such as a model writer, a codec writer, etc.
  */
-public final class FileSetWriter {
-    public final JavaFileWriter modelWriter;
-    public final JavaFileWriter schemaWriter;
-    public final JavaFileWriter codecWriter;
-    public final JavaFileWriter jsonCodecWriter;
-    public final JavaFileWriter testWriter;
+public record FileSetWriter(
+        JavaFileWriter modelWriter,
+        JavaFileWriter schemaWriter,
+        JavaFileWriter codecWriter,
+        JavaFileWriter jsonCodecWriter,
+        JavaFileWriter testWriter) {
 
-    /** Creates a new FileSetWriter object. */
-    public FileSetWriter(
-            final JavaFileWriter modelWriter,
-            final JavaFileWriter schemaWriter,
-            final JavaFileWriter codecWriter,
-            final JavaFileWriter jsonCodecWriter,
-            final JavaFileWriter testWriter) {
-        this.modelWriter = modelWriter;
-        this.schemaWriter = schemaWriter;
-        this.codecWriter = codecWriter;
-        this.jsonCodecWriter = jsonCodecWriter;
-        this.testWriter = testWriter;
-    }
-
-    /** A utility method to write all files at once. */
+    /** A utility method to write all the files at once. */
     public void writeFiles() throws IOException {
         modelWriter.writeFile();
         schemaWriter.writeFile();

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.compiler.impl;
+
+import java.io.IOException;
+
+/**
+ * This is essentially a set of JavaFileWriter objects that are necessary to support the generation
+ * of a single top-level .proto model implementation in Java.
+ *
+ * There's not a lot of logic around the set of JavaFileWriter objects, and for this reason they
+ * are exposed as `public final` fields directly.
+ */
+public class FileSetWriter {
+    public final JavaFileWriter modelWriter;
+    public final JavaFileWriter schemaWriter;
+    public final JavaFileWriter codecWriter;
+    public final JavaFileWriter jsonCodecWriter;
+    public final JavaFileWriter testWriter;
+
+    /** Creates a new FileSetWriter object. */
+    public FileSetWriter(
+            final JavaFileWriter modelWriter,
+            final JavaFileWriter schemaWriter,
+            final JavaFileWriter codecWriter,
+            final JavaFileWriter jsonCodecWriter,
+            final JavaFileWriter testWriter) {
+        this.modelWriter = modelWriter;
+        this.schemaWriter = schemaWriter;
+        this.codecWriter = codecWriter;
+        this.jsonCodecWriter = jsonCodecWriter;
+        this.testWriter = testWriter;
+    }
+
+    /** A utility method to write all files at once. */
+    public void writeFiles() throws IOException {
+        modelWriter.writeFile();
+        schemaWriter.writeFile();
+        codecWriter.writeFile();
+        jsonCodecWriter.writeFile();
+        testWriter.writeFile();
+    }
+}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/JavaFileWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/JavaFileWriter.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * This abstraction provides support for maintaining a set of import statements that may be required by any java
  * entities being generated using this abstraction.
  *
- * Note: the `generate()` method currently hard-codes a particular license header by design. It may be made configurable
+ * Note: the `writeFile()` method currently hard-codes a particular license header by design. It may be made configurable
  * in the future if required.
  */
 public final class JavaFileWriter {
@@ -70,7 +70,7 @@ public final class JavaFileWriter {
      * It's technically possible to call this method multiple times. It's even possible to add more imports
      * or append more text between the calls. However, it will overwrite the exact same file each time,
      * although it will write all the latest updates to the imports and the text on each invocation.
-     * If the imports and/or text are updated and this `generate()` method is not invoked after the update,
+     * If the imports and/or text are updated and this `writeFile()` method is not invoked after the update,
      * then the latest updates will not be persisted.
      *
      * @throws IOException if an I/O error occurs

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/JavaFileWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/JavaFileWriter.java
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.compiler.impl;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An abstraction that allows various Java entity generators to populate a text buffer and then write it to disk
+ * as a single .java file. This is useful for supporting inner entities (e.g. classes, enums, etc.) when all of them
+ * have to be a part of the same outer entity, and hence have to be written into the same, single file.
+ *
+ * This abstraction provides support for maintaining a set of import statements that may be required by any java
+ * entities being generated using this abstraction.
+ *
+ * Note: the `generate()` method currently hard-codes a particular license header by design. It may be made configurable
+ * in the future if required.
+ */
+public final class JavaFileWriter {
+
+    /** A java file to generate. */
+    private final File javaFile;
+
+    /** E.g. "com.package.proto", or "com.package.proto.codec", etc. */
+    private final String javaPackage;
+
+    /** All the imported symbols. */
+    private final Set<String> imports = new HashSet<>();
+
+    /** The actual text to be written, likely a top-level class or enum definition. */
+    private final StringBuilder stringBuilder = new StringBuilder();
+
+    /** Creates a new JavaFileWriter. */
+    public JavaFileWriter(final File javaFile, final String javaPackage) {
+        this.javaFile = javaFile;
+        this.javaPackage = javaPackage;
+    }
+
+    /**
+     * Add an imported symbol, including the `static ` prefix and/or `.*` suffix if necessary,
+     * but w/o the opening `import ` or closing `;`.
+     *
+     * @param symbol the symbol to add to imports
+     */
+    public void addImport(final String symbol) {
+        imports.add(symbol);
+    }
+
+    /**
+     * Append a string to the generated text.
+     * This should generally be a top-level class or enum definition with any inner definitions,
+     * including inner classes or enums, embedded inside. The caller can call this method multiple times
+     * to keep building their text.
+     *
+     * @param str a string to append
+     */
+    public void append(final String str) {
+        stringBuilder.append(str);
+    }
+
+    /**
+     * Generate the actual file on disk with a proper license header, `package`, `import` directives,
+     * and finally the text that has been built by calling the `append()` method.
+     * <p>
+     * It's technically possible to call this method multiple times. It's even possible to add more imports
+     * or append more text between the calls. However, it will overwrite the exact same file each time,
+     * although it will write all the latest updates to the imports and the text on each invocation.
+     * If the imports and/or text are updated and this `generate()` method is not invoked after the update,
+     * then the latest updates will not be persisted.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeFile() throws IOException {
+        try (Writer writer = new BufferedWriter(new FileWriter(javaFile))) {
+            // Hard-coding the license header for now. Can make it configurable in the future if need be.
+            writer.append("// SPDX-License-Identifier: Apache-2.0\n");
+            writer.append("package ").append(javaPackage).append(";\n");
+
+            if (!imports.isEmpty()) {
+                writer.append(imports.stream().sorted().collect(Collectors.joining(";\nimport ", "\nimport ", ";\n")));
+            }
+
+            writer.append("\n").append(stringBuilder.toString()).append("\n");
+        }
+    }
+}

--- a/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/JavaFileWriterTest.java
+++ b/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/JavaFileWriterTest.java
@@ -17,14 +17,14 @@ public class JavaFileWriterTest {
     @Test
     void testWriteFile() throws IOException {
         final File file = new File(outputDir, UUID.randomUUID().toString());
-        final JavaFileWriter generator = new JavaFileWriter(file, "my.test.java.package");
+        final JavaFileWriter writer = new JavaFileWriter(file, "my.test.java.package");
 
-        generator.addImport("java.util.*");
-        generator.addImport("java.io.File");
+        writer.addImport("java.util.*");
+        writer.addImport("java.io.File");
 
-        generator.append("class MyTestJavaClass { /* blah */ }");
+        writer.append("class MyTestJavaClass { /* blah */ }");
 
-        generator.writeFile();
+        writer.writeFile();
 
         final String string = Files.readString(file.toPath());
         assertEquals(

--- a/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/JavaFileWriterTest.java
+++ b/pbj-core/pbj-compiler/src/test/java/com/hedera/pbj/compiler/impl/JavaFileWriterTest.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.compiler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JavaFileWriterTest {
+    @TempDir
+    private static File outputDir;
+
+    @Test
+    void testWriteFile() throws IOException {
+        final File file = new File(outputDir, UUID.randomUUID().toString());
+        final JavaFileWriter generator = new JavaFileWriter(file, "my.test.java.package");
+
+        generator.addImport("java.util.*");
+        generator.addImport("java.io.File");
+
+        generator.append("class MyTestJavaClass { /* blah */ }");
+
+        generator.writeFile();
+
+        final String string = Files.readString(file.toPath());
+        assertEquals(
+                """
+                // SPDX-License-Identifier: Apache-2.0
+                package my.test.java.package;
+
+                import java.io.File;
+                import java.util.*;
+
+                class MyTestJavaClass { /* blah */ }
+                """,
+                string);
+    }
+}


### PR DESCRIPTION
**Description**:
Under https://github.com/hashgraph/pbj/issues/416 , we want to start generating real inner classes for inner .proto sub-types.

Currently, PBJ generators accept `File` objects pointing to main/test source directories and create files for every model on their own. In order to support generating inner classes, we need to remove this responsibility from the generators to allow them to build their generated text continuously, including all the inner classes that they may need to generate. The responsibility of creating actual physical files on disk will be with the caller of the generators.

This PR introduces utilities that will help implement the above transfer of responsibilities in the future.

**Related issue(s)**:

Fixes #417

**Notes for reviewer**:
A new simple test is added to verify the file writer.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
