### PR TITLE
refactor: use JavaFileWriter in EnumGenerator

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler;
 
+import static com.hedera.pbj.compiler.impl.Common.getJavaFile;
+
 import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
+import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.JavaFileWriter;
 import com.hedera.pbj.compiler.impl.LookupHelper;
 import com.hedera.pbj.compiler.impl.generators.EnumGenerator;
 import com.hedera.pbj.compiler.impl.generators.Generator;
@@ -45,7 +49,16 @@ public abstract class PbjCompiler {
                         final Protobuf3Parser.EnumDefContext enumDef = topLevelDef.enumDef();
                         if (enumDef != null) {
                             // run just enum generators for enum
-                            EnumGenerator.generateEnumFile(enumDef, mainOutputDir, contextualLookupHelper);
+                            final String javaPackage =
+                                    contextualLookupHelper.getPackageForEnum(FileType.MODEL, enumDef);
+                            final JavaFileWriter writer = new JavaFileWriter(
+                                    getJavaFile(
+                                            mainOutputDir,
+                                            javaPackage,
+                                            enumDef.enumName().getText()),
+                                    javaPackage);
+                            EnumGenerator.generateEnum(enumDef, writer, contextualLookupHelper);
+                            writer.writeFile();
                         }
                     }
                 } catch (Exception e) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
@@ -6,9 +6,8 @@ import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 
 import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
 import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.JavaFileWriter;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,12 +28,14 @@ public final class EnumGenerator {
      * Generate a Java enum from protobuf enum
      *
      * @param enumDef the parsed enum def
-     * @param destinationSrcDir The destination source directory to generate into
+     * @param writer the writer to append the generated enum to
      * @param lookupHelper Lookup helper for package information
      * @throws IOException if there was a problem writing generated code
      */
-    public static void generateEnumFile(
-            Protobuf3Parser.EnumDefContext enumDef, File destinationSrcDir, final ContextualLookupHelper lookupHelper)
+    public static void generateEnum(
+            final Protobuf3Parser.EnumDefContext enumDef,
+            final JavaFileWriter writer,
+            final ContextualLookupHelper lookupHelper)
             throws IOException {
         final String enumName = enumDef.enumName().getText();
         final String modelPackage = lookupHelper.getPackageForEnum(FileType.MODEL, enumDef);
@@ -90,12 +91,8 @@ public final class EnumGenerator {
                 System.err.printf("EnumGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
             }
         }
-        try (FileWriter javaWriter = new FileWriter(getJavaFile(destinationSrcDir, modelPackage, enumName))) {
-            javaWriter.write("package %s;\n\n%s"
-                    .formatted(
-                            modelPackage,
-                            createEnum(javaDocComment, deprecated, enumName, maxIndex, enumValues, false)));
-        }
+
+        writer.append(createEnum(javaDocComment, deprecated, enumName, maxIndex, enumValues, false));
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
@@ -5,7 +5,6 @@ import static com.hedera.pbj.compiler.impl.Common.*;
 import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 
 import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
-import com.hedera.pbj.compiler.impl.FileType;
 import com.hedera.pbj.compiler.impl.JavaFileWriter;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import java.io.IOException;
@@ -38,7 +37,6 @@ public final class EnumGenerator {
             final ContextualLookupHelper lookupHelper)
             throws IOException {
         final String enumName = enumDef.enumName().getText();
-        final String modelPackage = lookupHelper.getPackageForEnum(FileType.MODEL, enumDef);
         final String javaDocComment = (enumDef.docComment() == null)
                 ? ""
                 : cleanDocStr(enumDef.docComment().getText().replaceAll("\n \\*\s*\n", "\n * <br>\n"));


### PR DESCRIPTION
**Description**:
This is the very beginning of us using the new `JavaFileWriter` class. This PR simply refactors the `EnumGenerator` to use this class instead of creating a physical file on its own.

**Related issue(s)**:

Fixes #419

**Notes for reviewer**:
All tests must continue passing. This fix is not expected to change anything in the generated code per se.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
