### PR TITLE
refactor: use JavaFileWriter in message generators

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
@@ -9,7 +9,7 @@ import static com.hedera.pbj.compiler.impl.Common.snakeToCamel;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Interface for SingleFields and OneOfFields
@@ -107,13 +107,13 @@ public interface Field {
     /**
      * Add all the needed imports for this field to the supplied set.
      *
-     * @param imports      set of imports to add to, this contains packages not classes. They are always imported as ".*".
+     * @param imports      collector of imports
      * @param modelImports if imports for this field's generated model classes should be added
      * @param codecImports if imports for this field's generated codec classes should be added
      * @param testImports  if imports for this field's generated test classes should be added
      */
     void addAllNeededImports(
-            Set<String> imports, boolean modelImports, boolean codecImports, final boolean testImports);
+            Consumer<String> imports, boolean modelImports, boolean codecImports, final boolean testImports);
 
     /**
      * Get the java code to parse the value for this field from input

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
@@ -16,9 +16,10 @@ public record FileSetWriter(
         JavaFileWriter jsonCodecWriter,
         JavaFileWriter testWriter) {
 
+    /** A factory to create a FileSetWriter instance for a given MessageDefContext. */
     public static FileSetWriter create(
-            File mainOutputDir,
-            File testOutputDir,
+            final File mainOutputDir,
+            final File testOutputDir,
             final Protobuf3Parser.MessageDefContext msgDef,
             final ContextualLookupHelper contextualLookupHelper) {
         return new FileSetWriter(

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl;
 
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -14,8 +16,21 @@ public record FileSetWriter(
         JavaFileWriter jsonCodecWriter,
         JavaFileWriter testWriter) {
 
+    public static FileSetWriter create(
+            File mainOutputDir,
+            File testOutputDir,
+            final Protobuf3Parser.MessageDefContext msgDef,
+            final ContextualLookupHelper contextualLookupHelper) {
+        return new FileSetWriter(
+                JavaFileWriter.create(FileType.MODEL, mainOutputDir, msgDef, contextualLookupHelper),
+                JavaFileWriter.create(FileType.SCHEMA, mainOutputDir, msgDef, contextualLookupHelper),
+                JavaFileWriter.create(FileType.CODEC, mainOutputDir, msgDef, contextualLookupHelper),
+                JavaFileWriter.create(FileType.JSON_CODEC, mainOutputDir, msgDef, contextualLookupHelper),
+                JavaFileWriter.create(FileType.TEST, testOutputDir, msgDef, contextualLookupHelper));
+    }
+
     /** A utility method to write all the files at once. */
-    public void writeFiles() throws IOException {
+    public void writeAllFiles() throws IOException {
         modelWriter.writeFile();
         schemaWriter.writeFile();
         codecWriter.writeFile();

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/JavaFileWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/JavaFileWriter.java
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl;
 
+import static com.hedera.pbj.compiler.impl.Common.getJavaFile;
+
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -47,6 +50,19 @@ public final class JavaFileWriter {
         if (javaPackage.isBlank()) {
             throw new IllegalArgumentException("javaPackage must not be blank, instead got: `" + javaPackage + "`");
         }
+    }
+
+    /** A factory to create JavaFileWriter for messages. */
+    public static JavaFileWriter create(
+            final FileType fileType,
+            final File outputDir,
+            final Protobuf3Parser.MessageDefContext msgDef,
+            final ContextualLookupHelper contextualLookupHelper) {
+        final String javaPackage = contextualLookupHelper.getPackageForMessage(fileType, msgDef);
+        return new JavaFileWriter(
+                getJavaFile(
+                        outputDir, javaPackage, contextualLookupHelper.getUnqualifiedClassForMessage(fileType, msgDef)),
+                javaPackage);
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
@@ -5,7 +5,7 @@ import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 import static com.hedera.pbj.compiler.impl.SingleField.getDeprecatedOption;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
-import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A field of type map.
@@ -143,16 +143,16 @@ public record MapField(
      */
     @Override
     public void addAllNeededImports(
-            final Set<String> imports,
+            final Consumer<String> imports,
             final boolean modelImports,
             final boolean codecImports,
             final boolean testImports) {
         if (modelImports) {
-            imports.add("java.util");
+            imports.accept("java.util.*");
         }
         if (codecImports) {
-            imports.add("java.util.stream");
-            imports.add("com.hedera.pbj.runtime.test");
+            imports.accept("java.util.stream.*");
+            imports.accept("com.hedera.pbj.runtime.test.*");
         }
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/OneOfField.java
@@ -4,7 +4,7 @@ package com.hedera.pbj.compiler.impl;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -111,8 +111,8 @@ public record OneOfField(
      */
     @Override
     public void addAllNeededImports(
-            final Set<String> imports, boolean modelImports, boolean codecImports, final boolean testImports) {
-        imports.add("com.hedera.pbj.runtime");
+            final Consumer<String> imports, boolean modelImports, boolean codecImports, final boolean testImports) {
+        imports.accept("com.hedera.pbj.runtime.*");
         for (var field : fields) {
             field.addAllNeededImports(imports, modelImports, codecImports, testImports);
         }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -5,7 +5,7 @@ import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Record for Field in Protobuf file. Contains all logic and special cases for fields
@@ -186,12 +186,12 @@ public record SingleField(
      */
     @Override
     public void addAllNeededImports(
-            Set<String> imports, boolean modelImports, boolean codecImports, final boolean testImports) {
-        if (repeated || optionalValueType()) imports.add("java.util");
-        if (type == FieldType.BYTES) imports.add("com.hedera.pbj.runtime.io.buffer");
-        if (messageTypeModelPackage != null && modelImports) imports.add(messageTypeModelPackage);
-        if (messageTypeCodecPackage != null && codecImports) imports.add(messageTypeCodecPackage);
-        if (messageTypeTestPackage != null && testImports) imports.add(messageTypeTestPackage);
+            Consumer<String> imports, boolean modelImports, boolean codecImports, final boolean testImports) {
+        if (repeated || optionalValueType()) imports.accept("java.util.*");
+        if (type == FieldType.BYTES) imports.accept("com.hedera.pbj.runtime.io.buffer.*");
+        if (messageTypeModelPackage != null && modelImports) imports.accept(messageTypeModelPackage + ".*");
+        if (messageTypeCodecPackage != null && codecImports) imports.accept(messageTypeCodecPackage + ".*");
+        if (messageTypeTestPackage != null && testImports) imports.accept(messageTypeTestPackage + ".*");
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/Generator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/Generator.java
@@ -2,12 +2,15 @@
 package com.hedera.pbj.compiler.impl.generators;
 
 import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
+import com.hedera.pbj.compiler.impl.FileSetWriter;
+import com.hedera.pbj.compiler.impl.JavaFileWriter;
 import com.hedera.pbj.compiler.impl.generators.json.JsonCodecGenerator;
 import com.hedera.pbj.compiler.impl.generators.protobuf.CodecGenerator;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Interface for a code generator from protobuf message definition
@@ -15,14 +18,14 @@ import java.util.List;
 public interface Generator {
 
     /**
-     * List of all generator classes
+     * All generators.
      */
-    List<Class<? extends Generator>> GENERATORS = List.of(
-            ModelGenerator.class,
-            SchemaGenerator.class,
-            CodecGenerator.class,
-            JsonCodecGenerator.class,
-            TestGenerator.class);
+    Map<Class<? extends Generator>, Function<FileSetWriter, JavaFileWriter>> GENERATORS = Map.of(
+            ModelGenerator.class, FileSetWriter::modelWriter,
+            SchemaGenerator.class, FileSetWriter::schemaWriter,
+            CodecGenerator.class, FileSetWriter::codecWriter,
+            JsonCodecGenerator.class, FileSetWriter::jsonCodecWriter,
+            TestGenerator.class, FileSetWriter::testWriter);
 
     /**
      * Generate a code from protobuf message type
@@ -35,6 +38,7 @@ public interface Generator {
      */
     void generate(
             final Protobuf3Parser.MessageDefContext msgDef,
+            final JavaFileWriter writer,
             final File destinationSrcDir,
             File destinationTestSrcDir,
             final ContextualLookupHelper lookupHelper)

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -1,23 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.compiler.impl.generators.json;
 
-import com.hedera.pbj.compiler.impl.Common;
 import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
 import com.hedera.pbj.compiler.impl.Field;
 import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.JavaFileWriter;
 import com.hedera.pbj.compiler.impl.MapField;
 import com.hedera.pbj.compiler.impl.OneOfField;
 import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.generators.Generator;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 /**
  * Code generator that parses protobuf files and generates writers for each message type.
@@ -30,93 +26,83 @@ public final class JsonCodecGenerator implements Generator {
      */
     public void generate(
             Protobuf3Parser.MessageDefContext msgDef,
+            final JavaFileWriter writer,
             final File destinationSrcDir,
             File destinationTestSrcDir,
             final ContextualLookupHelper lookupHelper)
             throws IOException {
         final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
         final String codecClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.JSON_CODEC, msgDef);
-        final String codecPackage = lookupHelper.getPackageForMessage(FileType.JSON_CODEC, msgDef);
-        final File javaFile = Common.getJavaFile(destinationSrcDir, codecPackage, codecClassName);
 
         final List<Field> fields = new ArrayList<>();
-        final Set<String> imports = new TreeSet<>();
-        imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
-        imports.add(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef));
+        writer.addImport(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef) + ".*");
+        writer.addImport(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef) + ".*");
 
         for (var item : msgDef.messageBody().messageElement()) {
             if (item.messageDef() != null) { // process sub messages
-                generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
+                // FUTURE WORK: reuse the current `writer` to inline inner messages
+                final JavaFileWriter subWriter =
+                        JavaFileWriter.create(FileType.JSON_CODEC, destinationSrcDir, item.messageDef(), lookupHelper);
+                generate(item.messageDef(), subWriter, destinationSrcDir, destinationTestSrcDir, lookupHelper);
+                subWriter.writeFile();
             } else if (item.oneof() != null) { // process one ofs
                 final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
                 fields.add(field);
-                field.addAllNeededImports(imports, true, true, false);
+                field.addAllNeededImports(writer::addImport, true, true, false);
             } else if (item.mapField() != null) { // process map fields
                 final MapField field = new MapField(item.mapField(), lookupHelper);
                 fields.add(field);
-                field.addAllNeededImports(imports, true, true, false);
+                field.addAllNeededImports(writer::addImport, true, true, false);
             } else if (item.field() != null && item.field().fieldName() != null) {
                 final var field = new SingleField(item.field(), lookupHelper);
                 fields.add(field);
-                field.addAllNeededImports(imports, true, true, false);
+                field.addAllNeededImports(writer::addImport, true, true, false);
             } else if (item.reserved() == null && item.optionStatement() == null) {
                 System.err.printf("WriterGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
             }
         }
         final String writeMethod = JsonCodecWriteMethodGenerator.generateWriteMethod(modelClassName, fields);
 
-        try (FileWriter javaWriter = new FileWriter(javaFile)) {
-            // spotless:off
-            javaWriter.write("""
-                    package $package;
-                    
-                    import com.hedera.pbj.runtime.*;
-                    import com.hedera.pbj.runtime.io.*;
-                    import com.hedera.pbj.runtime.io.buffer.*;
-                    import java.io.IOException;
-                    import java.nio.*;
-                    import java.nio.charset.*;
-                    import java.util.*;
-                    import edu.umd.cs.findbugs.annotations.NonNull;
-                    import edu.umd.cs.findbugs.annotations.Nullable;
-                    
-                    import $qualifiedModelClass;
-                    $imports
-                    import com.hedera.pbj.runtime.jsonparser.*;
-                    import static $schemaClass.*;
-                    import static com.hedera.pbj.runtime.JsonTools.*;
-                    
+        writer.addImport("com.hedera.pbj.runtime.*");
+        writer.addImport("com.hedera.pbj.runtime.io.*");
+        writer.addImport("com.hedera.pbj.runtime.io.buffer.*");
+        writer.addImport("java.io.IOException");
+        writer.addImport("java.nio.*");
+        writer.addImport("java.nio.charset.*");
+        writer.addImport("java.util.*");
+        writer.addImport("edu.umd.cs.findbugs.annotations.NonNull");
+        writer.addImport("edu.umd.cs.findbugs.annotations.Nullable");
+        writer.addImport(lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef));
+        writer.addImport("com.hedera.pbj.runtime.jsonparser.*");
+        writer.addImport("static " + lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef) + ".*");
+        writer.addImport("static com.hedera.pbj.runtime.JsonTools.*");
+
+        // spotless:off
+        writer.append("""
+                /**
+                 * JSON Codec for $modelClass model object. Generated based on protobuf schema.
+                 */
+                public final class $codecClass implements JsonCodec<$modelClass> {
+
                     /**
-                     * JSON Codec for $modelClass model object. Generated based on protobuf schema.
+                     * Empty constructor
                      */
-                    public final class $codecClass implements JsonCodec<$modelClass> {
-                    
-                        /**
-                         * Empty constructor
-                         */
-                         public $codecClass() {
-                             // no-op
-                         }
-                    
-                        $unsetOneOfConstants
-                        $parseObject
-                        $writeMethod
-                    }
-                    """
-                    .replace("$package", codecPackage)
-                    .replace("$imports", imports.isEmpty() ? "" : imports.stream()
-                            .filter(input -> !input.equals(codecPackage))
-                            .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
-                    .replace("$schemaClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef))
-                    .replace("$modelClass", modelClassName)
-                    .replace("$qualifiedModelClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef))
-                    .replace("$codecClass", codecClassName)
-                    .replace("$unsetOneOfConstants", JsonCodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
-                    .replace("$writeMethod", writeMethod)
-                    .replace("$parseObject", JsonCodecParseMethodGenerator.generateParseObjectMethod(modelClassName, fields))
-            );
+                     public $codecClass() {
+                         // no-op
+                     }
+
+                    $unsetOneOfConstants
+                    $parseObject
+                    $writeMethod
+                }
+                """
+                .replace("$modelClass", modelClassName)
+                .replace("$codecClass", codecClassName)
+                .replace("$unsetOneOfConstants", JsonCodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
+                .replace("$writeMethod", writeMethod)
+                .replace("$parseObject", JsonCodecParseMethodGenerator.generateParseObjectMethod(modelClassName, fields))
+        );
         // spotless:on
-        }
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -3,23 +3,19 @@ package com.hedera.pbj.compiler.impl.generators.protobuf;
 
 import static com.hedera.pbj.compiler.impl.generators.protobuf.CodecDefaultInstanceMethodGenerator.generateGetDefaultInstanceMethod;
 
-import com.hedera.pbj.compiler.impl.Common;
 import com.hedera.pbj.compiler.impl.ContextualLookupHelper;
 import com.hedera.pbj.compiler.impl.Field;
 import com.hedera.pbj.compiler.impl.FileType;
+import com.hedera.pbj.compiler.impl.JavaFileWriter;
 import com.hedera.pbj.compiler.impl.MapField;
 import com.hedera.pbj.compiler.impl.OneOfField;
 import com.hedera.pbj.compiler.impl.SingleField;
 import com.hedera.pbj.compiler.impl.generators.Generator;
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 /**
  * Code generator that parses protobuf files and generates writers for each message type.
@@ -32,6 +28,7 @@ public final class CodecGenerator implements Generator {
      */
     public void generate(
             Protobuf3Parser.MessageDefContext msgDef,
+            final JavaFileWriter writer,
             final File destinationSrcDir,
             File destinationTestSrcDir,
             final ContextualLookupHelper lookupHelper)
@@ -39,94 +36,84 @@ public final class CodecGenerator implements Generator {
         final String modelClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.MODEL, msgDef);
         final String codecClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.CODEC, msgDef);
         final String codecPackage = lookupHelper.getPackageForMessage(FileType.CODEC, msgDef);
-        final File javaFile = Common.getJavaFile(destinationSrcDir, codecPackage, codecClassName);
 
         final List<Field> fields = new ArrayList<>();
-        final Set<String> imports = new TreeSet<>();
-        imports.add(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef));
-        imports.add(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef));
+        writer.addImport(lookupHelper.getPackageForMessage(FileType.MODEL, msgDef) + ".*");
+        writer.addImport(lookupHelper.getPackageForMessage(FileType.SCHEMA, msgDef) + ".*");
 
         for (var item : msgDef.messageBody().messageElement()) {
             if (item.messageDef() != null) { // process sub messages
-                generate(item.messageDef(), destinationSrcDir, destinationTestSrcDir, lookupHelper);
+                // FUTURE WORK: reuse the current `writer` to inline inner messages
+                final JavaFileWriter subWriter =
+                        JavaFileWriter.create(FileType.CODEC, destinationSrcDir, item.messageDef(), lookupHelper);
+                generate(item.messageDef(), subWriter, destinationSrcDir, destinationTestSrcDir, lookupHelper);
+                subWriter.writeFile();
             } else if (item.oneof() != null) { // process one ofs
                 final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
                 fields.add(field);
-                field.addAllNeededImports(imports, true, true, false);
+                field.addAllNeededImports(writer::addImport, true, true, false);
             } else if (item.mapField() != null) { // process map fields
                 final MapField field = new MapField(item.mapField(), lookupHelper);
                 fields.add(field);
-                field.addAllNeededImports(imports, true, true, false);
+                field.addAllNeededImports(writer::addImport, true, true, false);
             } else if (item.field() != null && item.field().fieldName() != null) {
                 final var field = new SingleField(item.field(), lookupHelper);
                 fields.add(field);
-                field.addAllNeededImports(imports, true, true, false);
+                field.addAllNeededImports(writer::addImport, true, true, false);
             } else if (item.reserved() == null && item.optionStatement() == null) {
                 System.err.printf("WriterGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
             }
         }
         final String writeMethod = CodecWriteMethodGenerator.generateWriteMethod(modelClassName, fields);
 
-        try (FileWriter javaWriter = new FileWriter(javaFile)) {
-            // spotless:off
-            javaWriter.write("""
-                    package $package;
-                    
-                    import com.hedera.pbj.runtime.*;
-                    import com.hedera.pbj.runtime.io.*;
-                    import com.hedera.pbj.runtime.io.buffer.*;
-                    import com.hedera.pbj.runtime.io.stream.EOFException;
-                    import java.io.IOException;
-                    import java.nio.*;
-                    import java.nio.charset.*;
-                    import java.util.*;
-                    import edu.umd.cs.findbugs.annotations.NonNull;
-                    
-                    import $qualifiedModelClass;
-                    $imports
-                    import static $schemaClass.*;
-                    import static com.hedera.pbj.runtime.ProtoWriterTools.*;
-                    import static com.hedera.pbj.runtime.ProtoParserTools.*;
-                    import static com.hedera.pbj.runtime.ProtoConstants.*;
+        writer.addImport("com.hedera.pbj.runtime.*");
+        writer.addImport("com.hedera.pbj.runtime.io.*");
+        writer.addImport("com.hedera.pbj.runtime.io.buffer.*");
+        writer.addImport("com.hedera.pbj.runtime.io.stream.EOFException");
+        writer.addImport("java.io.IOException");
+        writer.addImport("java.nio.*");
+        writer.addImport("java.nio.charset.*");
+        writer.addImport("java.util.*");
+        writer.addImport("edu.umd.cs.findbugs.annotations.NonNull");
+        writer.addImport(lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef));
+        writer.addImport("static " + lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef) + ".*");
+        writer.addImport("static com.hedera.pbj.runtime.ProtoWriterTools.*");
+        writer.addImport("static com.hedera.pbj.runtime.ProtoParserTools.*");
+        writer.addImport("static com.hedera.pbj.runtime.ProtoConstants.*");
+
+        // spotless:off
+        writer.append("""
+                /**
+                 * Protobuf Codec for $modelClass model object. Generated based on protobuf schema.
+                 */
+                public final class $codecClass implements Codec<$modelClass> {
                 
                     /**
-                     * Protobuf Codec for $modelClass model object. Generated based on protobuf schema.
+                     * Empty constructor
                      */
-                    public final class $codecClass implements Codec<$modelClass> {
-                    
-                        /**
-                         * Empty constructor
-                         */
-                         public $codecClass() {
-                             // no-op
-                         }
-                    
-                    $unsetOneOfConstants
-                    $parseMethod
-                    $writeMethod
-                    $measureDataMethod
-                    $measureRecordMethod
-                    $fastEqualsMethod
-                    $getDefaultInstanceMethod
-                    }
-                    """
-                    .replace("$package", codecPackage)
-                    .replace("$imports", imports.isEmpty() ? "" : imports.stream()
-                            .filter(input -> !input.equals(codecPackage))
-                            .collect(Collectors.joining(".*;\nimport ","\nimport ",".*;\n")))
-                    .replace("$schemaClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef))
-                    .replace("$modelClass", modelClassName)
-                    .replace("$qualifiedModelClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.MODEL, msgDef))
-                    .replace("$codecClass", codecClassName)
-                    .replace("$unsetOneOfConstants", CodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
-                    .replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(modelClassName, fields))
-                    .replace("$writeMethod", writeMethod)
-                    .replace("$measureDataMethod", CodecMeasureDataMethodGenerator.generateMeasureMethod(modelClassName, fields))
-                    .replace("$measureRecordMethod", CodecMeasureRecordMethodGenerator.generateMeasureMethod(modelClassName, fields))
-                    .replace("$fastEqualsMethod", CodecFastEqualsMethodGenerator.generateFastEqualsMethod(modelClassName, fields))
-                    .replace("$getDefaultInstanceMethod", generateGetDefaultInstanceMethod(modelClassName))
-            );
+                     public $codecClass() {
+                         // no-op
+                     }
+
+                $unsetOneOfConstants
+                $parseMethod
+                $writeMethod
+                $measureDataMethod
+                $measureRecordMethod
+                $fastEqualsMethod
+                $getDefaultInstanceMethod
+                }
+                """
+                .replace("$modelClass", modelClassName)
+                .replace("$codecClass", codecClassName)
+                .replace("$unsetOneOfConstants", CodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
+                .replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(modelClassName, fields))
+                .replace("$writeMethod", writeMethod)
+                .replace("$measureDataMethod", CodecMeasureDataMethodGenerator.generateMeasureMethod(modelClassName, fields))
+                .replace("$measureRecordMethod", CodecMeasureRecordMethodGenerator.generateMeasureMethod(modelClassName, fields))
+                .replace("$fastEqualsMethod", CodecFastEqualsMethodGenerator.generateFastEqualsMethod(modelClassName, fields))
+                .replace("$getDefaultInstanceMethod", generateGetDefaultInstanceMethod(modelClassName))
+        );
         // spotless:on
-        }
     }
 }


### PR DESCRIPTION
**Description**:
In this fix we use the new `JavaFileWriter` in all the remaining message generator classes. With this fix, all the generators are no longer responsible for creating physical files for its own code that they generate - they simply emit all the generated data into the supplied writer, and the caller of the generator is responsible for calling `writeFile` on the writer to actually write a file on disk.

Please note that inner types are still written into separate files/classes. In general, as far as the actual generated code is concerned, it should be the same as before. This fix simply replaces the core mechanism of creating files on disk with using the new utilities that we've introduced recently. A switch to producing actual inner classes will happen in a separate fix in the future.

**Related issue(s)**:

Fixes #420 

**Notes for reviewer**:
All tests should continue to pass as before.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
