### PR TITLE
feat: support adding Java package suffix for PBJ models

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
@@ -24,10 +24,20 @@ public abstract class PbjCompiler {
     private static final int MAX_TRACE_FRAMES = 8;
     private static final String STACK_ELEMENT_INDENT = "    ";
 
-    public static void compileFilesIn(Iterable<File> sourceFiles, File mainOutputDir, File testOutputDir)
+    /**
+     * Compile source files and generate PBJ models.
+     *
+     * @param sourceFiles all the source files to compile
+     * @param mainOutputDir output directory for generated model, codecs, and schema ("main" files)
+     * @param testOutputDir output directory for generated tests ("test" files)
+     * @param javaPackageSuffix an optional, nullable suffix to add to the Java package name in generated classes, e.g. ".pbj",
+     *                          when an explicit `pbj.java_package` option is missing
+     * @throws Exception
+     */
+    public static void compileFilesIn(Iterable<File> sourceFiles, File mainOutputDir, File testOutputDir, String javaPackageSuffix)
             throws Exception {
         // first we do a scan of files to build lookup tables for imports, packages etc.
-        final LookupHelper lookupHelper = new LookupHelper(sourceFiles);
+        final LookupHelper lookupHelper = new LookupHelper(sourceFiles, javaPackageSuffix);
         // for each proto src directory generate code
         for (final File protoFile : sourceFiles) {
             if (protoFile.exists()

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
@@ -34,7 +34,8 @@ public abstract class PbjCompiler {
      *                          when an explicit `pbj.java_package` option is missing
      * @throws Exception
      */
-    public static void compileFilesIn(Iterable<File> sourceFiles, File mainOutputDir, File testOutputDir, String javaPackageSuffix)
+    public static void compileFilesIn(
+            Iterable<File> sourceFiles, File mainOutputDir, File testOutputDir, String javaPackageSuffix)
             throws Exception {
         // first we do a scan of files to build lookup tables for imports, packages etc.
         final LookupHelper lookupHelper = new LookupHelper(sourceFiles, javaPackageSuffix);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
@@ -45,6 +45,7 @@ public abstract class PbjCompilerTask extends SourceTask {
         PbjCompiler.compileFilesIn(
                 getSource(),
                 getJavaMainOutputDirectory().get().getAsFile(),
-                getJavaTestOutputDirectory().get().getAsFile());
+                getJavaTestOutputDirectory().get().getAsFile(),
+                null);
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -71,6 +72,13 @@ public final class LookupHelper {
             "Import \"%s\" in proto file \"%s\" can not be found in src files.";
 
     /**
+     * A non-null suffix to add to the Java package name of generated PBJ classes when an explicit `pbj.java_package`
+     * is missing and PBJ instead derives the Java package for PBJ models from the standard `java_package` option
+     * or otherwise. May be empty.
+     */
+    private final String javaPackageSuffix;
+
+    /**
      * Map from fully qualified msgDef name to fully qualified pbj java package, not including java
      * class
      */
@@ -113,8 +121,10 @@ public final class LookupHelper {
      * protobuf files extracting what is needed.
      *
      * @param allSrcFiles collection of all proto src files
+     * @param javaPackageSuffix an optional, nullable suffix to add to the Java package name in generated classes, e.g. ".pbj"
      */
-    public LookupHelper(final Iterable<File> allSrcFiles) {
+    public LookupHelper(final Iterable<File> allSrcFiles, final String javaPackageSuffix) {
+        this.javaPackageSuffix = javaPackageSuffix == null ? "" : javaPackageSuffix.trim();
         build(allSrcFiles);
     }
 
@@ -513,7 +523,7 @@ public final class LookupHelper {
                         }
                     }
                     // process message and enum defs
-                    final String fileLevelJavaPackage = (pbjJavaPackage != null) ? pbjJavaPackage : protocJavaPackage;
+                    final String fileLevelJavaPackage = (pbjJavaPackage != null) ? pbjJavaPackage : (protocJavaPackage + javaPackageSuffix);
                     for (final var item : parsedDoc.topLevelDef()) {
                         if (item.messageDef() != null)
                             buildMessage(fullQualifiedFile, fileLevelJavaPackage, protocJavaPackage, item.messageDef());

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/LookupHelper.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -523,7 +522,8 @@ public final class LookupHelper {
                         }
                     }
                     // process message and enum defs
-                    final String fileLevelJavaPackage = (pbjJavaPackage != null) ? pbjJavaPackage : (protocJavaPackage + javaPackageSuffix);
+                    final String fileLevelJavaPackage =
+                            (pbjJavaPackage != null) ? pbjJavaPackage : (protocJavaPackage + javaPackageSuffix);
                     for (final var item : parsedDoc.topLevelDef()) {
                         if (item.messageDef() != null)
                             buildMessage(fullQualifiedFile, fileLevelJavaPackage, protocJavaPackage, item.messageDef());

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/CompareToNegativeTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/CompareToNegativeTest.java
@@ -45,6 +45,6 @@ class CompareToNegativeTest {
 
     private static void getCompileFilesIn(String fileName) throws Exception {
         URL fileUrl = CompareToNegativeTest.class.getClassLoader().getResource(fileName);
-        compileFilesIn(List.of(new File(fileUrl.toURI())), outputDir, outputDir);
+        compileFilesIn(List.of(new File(fileUrl.toURI())), outputDir, outputDir, null);
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
@@ -34,6 +34,6 @@ public class SubTypesTest {
                     }
                 })
                 .toList();
-        compileFilesIn(files, outputDir, outputDir);
+        compileFilesIn(files, outputDir, outputDir, null);
     }
 }


### PR DESCRIPTION
**Description**:
Introducing a feature in the `PbjCompiler` implementation that allows one to pass an optional suffix that PBJ will add to the Java package names of models that don't specify the `pbj.java_package` option explicitly. This is to support using 3rd-party protobuf models in PBJ integration test that would otherwise clash with the models generated by Google protoc compiler.

Please note that this is the core feature implementation only. A support for passing the suffix as a parameter and enabling it in the integration tests will be implemented in a separate PR under #435 .

**Related issue(s)**:

Fixes #436 

**Notes for reviewer**:
Until #435 is implemented, there's not any easy way to test this feature in an automated fashion. However, I've tested this fix manually by overriding the suffix value in the `PbjCompiler.compileFilesIn()` method and then adding the following model to the PBJ integration tests `main` source set:
```
// SPDX-License-Identifier: Apache-2.0
syntax = "proto3";

package proto;

// Test when only the java_package is specified. Do not specify the pbj.java_package option.
option java_package = "com.hedera.pbj.test.proto";
option java_multiple_files = true;

/**
 * Sample protobuf.
 */
message MessageInAPackage {
  bytes bytesField = 1;
}
```

Today, w/o the suffix specified, the presence of this model would fail the PBJ integration tests compilation because the PBJ and protoc models would clash. However, when the suffix is overridden in `PbjCompiler.compileFilesIn()`, then the compilation succeeds and all the integration tests actually pass. I will add this model to the repository as a part of a fix for #435 .

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
