### PR TITLE
feat: use proto package when java_package is missing

### DIFF
--- a/pbj-integration-tests/src/main/proto/noJavaPackage.proto
+++ b/pbj-integration-tests/src/main/proto/noJavaPackage.proto
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package proto.test.pkg;
+// Do not specify the java_package and the pbj.java_package options.
+// Test if PBJ can infer the Java package from the proto package specified above.
+option java_multiple_files = true;
+
+/**
+ * Sample protobuf.
+ */
+message MessageInProtoPackage {
+  bytes bytesField = 1;
+}


### PR DESCRIPTION
**Description**:
When both `java_package` and `pbj.java_package` are missing, PBJ will now try to use the Protobuf package as a Java package for generated classes. This is the same behavior as exhibited by Google protoc.

Also, PBJ no longer emits a warning if the `pbj.java_package` is missing because we aim to support 3rd-party .proto files natively.

**Related issue(s)**:

Fixes #218

**Notes for reviewer**:
A new test model is added. It wouldn't compile and would fail the PBJ integ tests build w/o this fix.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
