### PR TITLE
fix: support random doc comments in oneofs

### DIFF
--- a/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
+++ b/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
@@ -78,9 +78,9 @@ fieldNumber
   ;
 
 // Oneof and oneof field
-// Note, oneOf isn't a message or field, so docComment is odd to include here...
+// The DOC_COMMENT option in the list below is to support commented-out oneof variants, or just random doc comments inside oneofs.
 oneof
-  : docComment ONEOF oneofName LC ( optionStatement | oneofField | emptyStatement_ )* RC
+  : docComment ONEOF oneofName LC ( optionStatement | oneofField | emptyStatement_ | DOC_COMMENT )* RC
   ;
 
 oneofField

--- a/pbj-integration-tests/src/main/proto/docComments.proto
+++ b/pbj-integration-tests/src/main/proto/docComments.proto
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
 package pbj.integ.tests;
 option java_multiple_files = true;

--- a/pbj-integration-tests/src/main/proto/docComments.proto
+++ b/pbj-integration-tests/src/main/proto/docComments.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+package pbj.integ.tests;
+option java_multiple_files = true;
+
+message DocumentCommentTest {
+  /**
+   * This will fail "cannot find type [reserved]".
+   * Actually, it will no longer fail because `reserved` allows a docCommnet prefix now.
+   */
+  reserved 5;
+
+  /**
+   * This is fine.
+   */
+  uint32 number = 1;
+
+  /**
+   * This is fine, too. One can have random doc comments inside messages.
+   */
+
+  /**
+   * oneof with a commented field; this will fail compilation
+   * "OneofFieldContext.fieldNumber is null".
+   * This will no longer fail as well as oneof now allows one to add random doc comments inside.
+   */
+  oneof sample {
+    /**
+     * A text field
+     */
+    string text = 2;
+
+    /**
+     * A flag indicating FCOJ futures bids are enabled.
+     */
+    // removed for now.
+    // bool futures_enabled = 3;
+  }
+
+  /**
+   * And this is fine, as well. Let's finish with a doc comment.
+   */
+}
+
+/**
+ * One can have doc comments even here, because why not?
+ */


### PR DESCRIPTION
**Description**:
Allow one to have free-standing doc comments inside oneof fields. Also test doc comments in various random locations.

**Related issue(s)**:

Fixes #319

**Notes for reviewer**:
A new test model is added to PBJ integ tests that previously failed to compile. It's an extended version of the sample model from the description of the issue.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
