### PR TITLE
build: bump 'org.hiero.gradle.build' to 0.3.9

### DIFF
--- a/pbj-core/hiero-dependency-versions/build.gradle.kts
+++ b/pbj-core/hiero-dependency-versions/build.gradle.kts
@@ -16,6 +16,8 @@ val protobuf = "4.30.2"
 val junit5 = "5.12.1"
 val mockito = "5.17.0"
 
+dependencies { api(platform("io.netty:netty-bom:4.2.0.Final")) }
+
 dependencies.constraints {
     api("org.antlr:antlr4-runtime:$antlr") { because("org.antlr.antlr4.runtime") }
     api("com.github.spotbugs:spotbugs-annotations:4.9.3") {

--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.3.8" }
+plugins { id("org.hiero.gradle.build") version "0.3.9" }
 
 javaModules {
     directory(".") {

--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -3,15 +3,7 @@ pluginManagement {
     includeBuild("../pbj-core") // use locally built 'pbj-core' (Gradle plugin)
 }
 
-plugins { id("org.hiero.gradle.build") version "0.3.8" }
-
-// Downgrade 'dependency-analysis-gradle-plugin' due to regression in 2.7.0
-// https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1364
-buildscript {
-    dependencies.constraints {
-        classpath("com.autonomousapps:dependency-analysis-gradle-plugin:2.6.0!!")
-    }
-}
+plugins { id("org.hiero.gradle.build") version "0.3.9" }
 
 dependencyResolutionManagement {
     // To use locally built 'pbj-runtime'


### PR DESCRIPTION
...and with that [update dependency-analysis-gradle-plugin to 2.16.0](https://github.com/hiero-ledger/hiero-gradle-conventions/releases/tag/v0.3.9).

The PR also introduces explicitly managing the Netty version that we use in tests (indirectly through `io.grpc.netty`). The latest Netty version ships with `module-info.class` files and is thus [no longer patched](https://github.com/hiero-ledger/hiero-gradle-conventions/releases/tag/v0.3.9).
