### PR TITLE
chore: increase buffer size for JSON serialization tests

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
@@ -22,7 +22,7 @@ public final class ProtoTestTools {
     private static final int BUFFER_SIZE = 1024 * 1024;
 
     /** Size for reusable test char buffers */
-    private static final int CHAR_BUFFER_SIZE = 2 * 1024 * 1024;
+    private static final int CHAR_BUFFER_SIZE = 8 * 1024 * 1024;
 
     /** Instance should never be created */
     private ProtoTestTools() {}


### PR DESCRIPTION
**Description**:
- As new messages are added to protobufs, the generated test objects can get bigger and `BufferOverflowException`s return for e.g. `PublishStreamRequestTest`.