### PR TITLE
feat: implement PbjMessage interface

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -645,15 +645,13 @@ public final class ModelGenerator implements Generator {
         return """
                 /** Protobuf codec for reading and writing in protobuf format */
                 public static final Codec<$modelClass> PROTOBUF = new $qualifiedCodecClass();
-                /** {@inheritDoc} */ @Override public Codec<$modelClass> getProtobufCodec() { return PROTOBUF; }
+                /** {@inheritDoc} */ @Override public Codec<$modelClass> PROTOBUF() { return PROTOBUF; }
 
                 /** JSON codec for reading and writing in JSON format */
                 public static final JsonCodec<$modelClass> JSON = new $qualifiedJsonCodecClass();
-                /** {@inheritDoc} */ @Override public JsonCodec<$modelClass> getJsonCodec() { return JSON; }
 
                 /** Default instance with all fields set to default values */
                 public static final $modelClass DEFAULT = newBuilder().build();
-                /** {@inheritDoc} */ @Override public $modelClass getDefaultMessage() { return DEFAULT; }
                 """
                 .replace("$modelClass", javaRecordName)
                 .replace("$qualifiedCodecClass", lookupHelper.getFullyQualifiedMessageClassname(FileType.CODEC, msgDef))

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjMessage.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjMessage.java
@@ -3,21 +3,13 @@ package com.hedera.pbj.runtime;
 
 /**
  * An interface implemented by a PBJ-generated Java message object.
- * This interface provides easy access to a few static fields declared in every message, allowing
- * the code to reference them directly, w/o knowing the concrete Java class of the message
- * at compile time and w/o a need to use Java reflection for this purpose.
+ * This interface allows one to retrieve a PROTOBUF codec for this message which is normally available via the static
+ * T.PROTOBUF member without knowing the actual Java class of the message at compile time and without a need to use
+ * Java reflection.
  *
  * @param <T> a concrete type of PBJ-generated Java message
  */
 public interface PbjMessage<T> {
     /** Get the Protobuf codec for this message, also accessible via the T.PROTOBUF static field. */
-    Codec<T> getProtobufCodec();
-
-    /** Get the JSON codec for this message, also accessible via the T.JSON static field. */
-    JsonCodec<T> getJsonCodec();
-
-    /**
-     * Get the default instance with all fields set to default values, also accessible via the T.DEFAULT static field.
-     */
-    T getDefaultMessage();
+    Codec<T> PROTOBUF();
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjMessage.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjMessage.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime;
+
+/**
+ * An interface implemented by a PBJ-generated Java message object.
+ * This interface provides easy access to a few static fields declared in every message, allowing
+ * the code to reference them directly, w/o knowing the concrete Java class of the message
+ * at compile time and w/o a need to use Java reflection for this purpose.
+ *
+ * @param <T> a concrete type of PBJ-generated Java message
+ */
+public interface PbjMessage<T> {
+    /** Get the Protobuf codec for this message, also accessible via the T.PROTOBUF static field. */
+    Codec<T> getProtobufCodec();
+
+    /** Get the JSON codec for this message, also accessible via the T.JSON static field. */
+    JsonCodec<T> getJsonCodec();
+
+    /**
+     * Get the default instance with all fields set to default values, also accessible via the T.DEFAULT static field.
+     */
+    T getDefaultMessage();
+}


### PR DESCRIPTION
**Description**:
Introducing `PbjMessage<T>` interface that every generated message implements. The interface allows a code having a PBJ object to access its static fields (e.g. the `<ModelClass>.PROTOBUF` codec) w/o knowing the concrete class of the model at compile time. This allows for more robust and simple code: instead of passing both the model object and its codec object to a serialization method, the application can now pass the model object only, and the serialization method can retrieve the correct codec directly from the model.

A need for this was previously discovered at https://github.com/hiero-ledger/hiero-consensus-node/pull/15417 where the code currently has to ensure it passes the correct codec for a given model which may sometimes be error-prone.

**Related issue(s)**:

Fixes #287 

**Notes for reviewer**:
The changes are trivial as we add three simple getters to each model. All tests should continue to pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
