### PR TITLE
build: run tests on module path

### DIFF
--- a/pbj-core/pbj-grpc-helidon/build.gradle.kts
+++ b/pbj-core/pbj-grpc-helidon/build.gradle.kts
@@ -30,4 +30,6 @@ testModuleInfo {
     requiresStatic("java.annotation")
     runtimeOnly("io.grpc.netty")
     runtimeOnly("io.helidon.webserver.observe.metrics")
+
+    exportsTo("com.google.protobuf") // for test protobufs
 }

--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.3.10" }
+plugins { id("org.hiero.gradle.build") version "0.4.0" }
 
 javaModules {
     directory(".") {

--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -3,7 +3,7 @@ import org.hiero.gradle.tasks.GitClone
 
 plugins {
     id("org.hiero.gradle.module.application")
-    id("org.gradlex.java-module-dependencies")
+    id("org.hiero.gradle.feature.legacy-classpath")
     // jmh for performance benchmarks
     id("org.hiero.gradle.feature.benchmark")
     // We depend on Google protobuf plugin as we generate protobuf code using it as well as pbj.

--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
     includeBuild("../pbj-core") // use locally built 'pbj-core' (Gradle plugin)
 }
 
-plugins { id("org.hiero.gradle.build") version "0.3.10" }
+plugins { id("org.hiero.gradle.build") version "0.4.0" }
 
 dependencyResolutionManagement {
     // To use locally built 'pbj-runtime'


### PR DESCRIPTION
**Description**:

Update _hiero-gradle-conventions_ to _0.4.0_ and by that run tests on the _module path_.

See https://github.com/hiero-ledger/hiero-consensus-node/pull/18922 for more details on how that works.