### PR TITLE
fix: handling empty msg in helidon plugin

### DIFF
--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -380,8 +380,17 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
                             // would break the application. So we need a new buffer each time :-(
                             entityBytes = new byte[(int) length];
                             entityBytesIndex = 0;
-                            // done with length now, so move on to next state
-                            currentReadState = ReadState.READ_ENTITY_BYTES;
+
+                            // In this case we have a request with no message, like an empty unary request
+                            if (length == 0) {
+                                final Bytes bytes = Bytes.wrap(entityBytes);
+                                pipeline.onNext(bytes);
+                                entityBytes = null;
+                                currentReadState = ReadState.START;
+                            } else {
+                                // done with length now, so move on to next state
+                                currentReadState = ReadState.READ_ENTITY_BYTES;
+                            }
                         }
                         break;
                     }
@@ -483,8 +492,8 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
                                 case "m" -> TimeUnit.MILLISECONDS;
                                 case "u" -> TimeUnit.MICROSECONDS;
                                 case "n" -> TimeUnit.NANOSECONDS;
-                                    // This should NEVER be reachable, because the matcher
-                                    // would not have matched.
+                                // This should NEVER be reachable, because the matcher
+                                // would not have matched.
                                 default -> throw new GrpcException(GrpcStatus.INTERNAL, "Invalid unit: " + unit);
                             });
             return deadlineDetector.scheduleDeadline(deadline, () -> {

--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -373,21 +373,20 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
                                 throw new GrpcException(
                                         GrpcStatus.INVALID_ARGUMENT, "Message size exceeds maximum allowed size");
                             }
-                            // Create a buffer to hold the message. We sadly cannot reuse this buffer
-                            // because once we have filled it and wrapped it in Bytes and sent it to the
-                            // handler, some user code may grab and hold that Bytes object for an arbitrary
-                            // amount of time, and if we were to scribble into the same byte array, we
-                            // would break the application. So we need a new buffer each time :-(
-                            entityBytes = new byte[(int) length];
-                            entityBytesIndex = 0;
 
                             // In this case we have a request with no message, like an empty unary request
                             if (length == 0) {
-                                final Bytes bytes = Bytes.wrap(entityBytes);
+                                final Bytes bytes = Bytes.EMPTY;
                                 pipeline.onNext(bytes);
-                                entityBytes = null;
                                 currentReadState = ReadState.START;
                             } else {
+                                // Create a buffer to hold the message. We sadly cannot reuse this buffer
+                                // because once we have filled it and wrapped it in Bytes and sent it to the
+                                // handler, some user code may grab and hold that Bytes object for an arbitrary
+                                // amount of time, and if we were to scribble into the same byte array, we
+                                // would break the application. So we need a new buffer each time :-(
+                                entityBytes = new byte[(int) length];
+                                entityBytesIndex = 0;
                                 // done with length now, so move on to next state
                                 currentReadState = ReadState.READ_ENTITY_BYTES;
                             }

--- a/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
+++ b/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
@@ -160,14 +160,14 @@ class PbjProtocolHandlerTest {
      */
     @Test
     void requestIsSuccessfulOnEmptyData() {
-        final var h = WritableHeaders.create();
+        final WritableHeaders<?> h = WritableHeaders.create();
         h.add(HeaderNames.CONTENT_TYPE, "application/grpc");
         headers = Http2Headers.create(h);
-        final var handler = new PbjProtocolHandler(
+        final PbjProtocolHandler handler = new PbjProtocolHandler(
                 headers, streamWriter, streamId, flowControl, currentStreamState, config, route, deadlineDetector);
         handler.init();
 
-        final var emptyData = createRequestData("");
+        final Bytes emptyData = createRequestData("");
         sendAllData(handler, emptyData);
 
         assertThat(service.calledMethod).isSameAs(ServiceInterfaceStub.METHOD);


### PR DESCRIPTION
**Description**:
Adds handing of empty requests. In those cases we receive 5 bytes, where first one is compression flag and the rest 4 are the lenght of the message that usually follows. However in case of empty request, such as [ServerStatusRequest](https://github.com/hashgraph/hedera-protobufs/blob/v0.62.1/block/block_service.proto#L837) data() method receive exactly 5 bytes, which results in not reaching onNext call on the pipeline and the client hangs, as it's waiting for the respons.
In this PR we add a condition where length is 0, so that we can continue the flow corrrectly and reset the state for the next messages. More info in the issue #483 

**Related issue(s)**:

Fixes #483 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
