### PR TITLE
feat: add service name constats to service interfaces

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -215,6 +215,12 @@ public final class ServiceGenerator {
         writer.append("""
                 $javaDocComment
                 $deprecated$public interface $serviceName$suffix extends ServiceInterface {
+                    /** The simple name of the service. */
+                    public static final String SERVICE_NAME = "$serviceName";
+                
+                    /** The full name of the service. */
+                    public static final String FULL_NAME = "$fullyQualifiedProtoServiceName";
+                
                     enum $serviceNameMethod implements Method {
                 $methodNames
                     }
@@ -223,12 +229,12 @@ public final class ServiceGenerator {
                 
                     @NonNull
                     default String serviceName() {
-                        return "$serviceName";
+                        return $serviceName$suffix.SERVICE_NAME;
                     }
                 
                     @NonNull
                     default String fullName() {
-                        return "$fullyQualifiedProtoServiceName";
+                        return $serviceName$suffix.FULL_NAME;
                     }
                 
                     @NonNull


### PR DESCRIPTION
**Description**:
In addition to the existing `ServiceInterface.serviceName()` and `ServiceInterface.fullName()`, adding two `public static final String` constants to the generated interfaces that expose these values.

**Related issue(s)**:

Fixes #486

**Notes for reviewer**:
All existing tests should continue to pass. As an example, in the `TokenServiceInterface` this now looks like:
```
public interface TokenServiceInterface extends ServiceInterface {
    /** The simple name of the service. */
    public static final String SERVICE_NAME = "TokenService";

    /** The full name of the service. */
    public static final String FULL_NAME = "proto.TokenService";
```
and the corresponding getter methods simply return these constants.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
