### PR TITLE
feat: support disabling tests generation

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompiler.java
@@ -36,7 +36,11 @@ public abstract class PbjCompiler {
      * @throws Exception
      */
     public static void compileFilesIn(
-            Iterable<File> sourceFiles, File mainOutputDir, File testOutputDir, String javaPackageSuffix)
+            Iterable<File> sourceFiles,
+            File mainOutputDir,
+            File testOutputDir,
+            String javaPackageSuffix,
+            boolean generateTestClasses)
             throws Exception {
         // first we do a scan of files to build lookup tables for imports, packages etc.
         final LookupHelper lookupHelper = new LookupHelper(sourceFiles, javaPackageSuffix);
@@ -54,8 +58,8 @@ public abstract class PbjCompiler {
                     for (final var topLevelDef : parsedDoc.topLevelDef()) {
                         final Protobuf3Parser.MessageDefContext msgDef = topLevelDef.messageDef();
                         if (msgDef != null) {
-                            final FileSetWriter writer =
-                                    FileSetWriter.create(mainOutputDir, testOutputDir, msgDef, contextualLookupHelper);
+                            final FileSetWriter writer = FileSetWriter.create(
+                                    mainOutputDir, testOutputDir, msgDef, contextualLookupHelper, generateTestClasses);
                             for (Map.Entry<Class<? extends Generator>, Function<FileSetWriter, JavaFileWriter>> entry :
                                     Generator.GENERATORS.entrySet()) {
                                 final var generator =

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerPlugin.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerPlugin.java
@@ -65,6 +65,7 @@ public abstract class PbjCompilerPlugin implements Plugin<Project> {
                     pbjTask.getJavaMainOutputDirectory().set(outputDirectoryMain);
                     pbjTask.getJavaTestOutputDirectory().set(outputDirectoryTest);
                     pbjTask.getJavaPackageSuffix().set(pbj.getJavaPackageSuffix());
+                    pbjTask.getGenerateTestClasses().set(pbj.getGenerateTestClasses());
                 });
 
         // 5) register fact that pbj should be run before compiling  by informing the 'java' part

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjCompilerTask.java
@@ -41,6 +41,11 @@ public abstract class PbjCompilerTask extends SourceTask {
     @Input
     public abstract Property<String> getJavaPackageSuffix();
 
+    /** An optional boolean that indicates if test classes for protobuf models should be generated, which is true by default. */
+    @Optional
+    @Input
+    public abstract Property<Boolean> getGenerateTestClasses();
+
     /**
      * Perform task action - Generates all the PBJ java source files
      *
@@ -54,6 +59,7 @@ public abstract class PbjCompilerTask extends SourceTask {
                 getSource(),
                 getJavaMainOutputDirectory().get().getAsFile(),
                 getJavaTestOutputDirectory().get().getAsFile(),
-                getJavaPackageSuffix().getOrNull());
+                getJavaPackageSuffix().getOrNull(),
+                getGenerateTestClasses().getOrElse(Boolean.TRUE));
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjExtension.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/PbjExtension.java
@@ -12,4 +12,11 @@ public interface PbjExtension {
      * @return the suffix property
      */
     Property<String> getJavaPackageSuffix();
+
+    /**
+     * An optional boolean that indicates if test classes for protobuf models should be generated,
+     * which is true by default.
+     * @return true if tests should be generated
+     */
+    Property<Boolean> getGenerateTestClasses();
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/FileSetWriter.java
@@ -14,20 +14,23 @@ public record FileSetWriter(
         JavaFileWriter schemaWriter,
         JavaFileWriter codecWriter,
         JavaFileWriter jsonCodecWriter,
-        JavaFileWriter testWriter) {
+        JavaFileWriter testWriter,
+        boolean generateTestClasses) {
 
     /** A factory to create a FileSetWriter instance for a given MessageDefContext. */
     public static FileSetWriter create(
             final File mainOutputDir,
             final File testOutputDir,
             final Protobuf3Parser.MessageDefContext msgDef,
-            final ContextualLookupHelper contextualLookupHelper) {
+            final ContextualLookupHelper contextualLookupHelper,
+            boolean generateTestClasses) {
         return new FileSetWriter(
                 JavaFileWriter.create(FileType.MODEL, mainOutputDir, msgDef, contextualLookupHelper),
                 JavaFileWriter.create(FileType.SCHEMA, mainOutputDir, msgDef, contextualLookupHelper),
                 JavaFileWriter.create(FileType.CODEC, mainOutputDir, msgDef, contextualLookupHelper),
                 JavaFileWriter.create(FileType.JSON_CODEC, mainOutputDir, msgDef, contextualLookupHelper),
-                JavaFileWriter.create(FileType.TEST, testOutputDir, msgDef, contextualLookupHelper));
+                JavaFileWriter.create(FileType.TEST, testOutputDir, msgDef, contextualLookupHelper),
+                generateTestClasses);
     }
 
     /** A utility method to write all the files at once. */
@@ -36,6 +39,8 @@ public record FileSetWriter(
         schemaWriter.writeFile();
         codecWriter.writeFile();
         jsonCodecWriter.writeFile();
-        testWriter.writeFile();
+        if (generateTestClasses) {
+            testWriter.writeFile();
+        }
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/CompareToNegativeTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/CompareToNegativeTest.java
@@ -45,6 +45,6 @@ class CompareToNegativeTest {
 
     private static void getCompileFilesIn(String fileName) throws Exception {
         URL fileUrl = CompareToNegativeTest.class.getClassLoader().getResource(fileName);
-        compileFilesIn(List.of(new File(fileUrl.toURI())), outputDir, outputDir, null);
+        compileFilesIn(List.of(new File(fileUrl.toURI())), outputDir, outputDir, null, true);
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SubTypesTest.java
@@ -34,6 +34,6 @@ public class SubTypesTest {
                     }
                 })
                 .toList();
-        compileFilesIn(files, outputDir, outputDir, null);
+        compileFilesIn(files, outputDir, outputDir, null, true);
     }
 }


### PR DESCRIPTION
**Description**:
PBJ generates test for models that mainly test the compatibility with Google protoc. Some projects may want to avoid a dependency on protoc, and hence they may not need the tests generated.

Solution: create a PBJ Gradle plugin parameter to disable tests generation.

This can be enabled (err.... disabled that is) in `build.gradle.kts` as:
```
pbj {
   generateTestClasses = false
}
```

**Related issue(s)**:

Fixes #489

**Notes for reviewer**:
All existing tests should pass. I've tried using this in the PBJ integration tests, and they obviously fail to build because there's hard-coded references to existing generated tests in, say, the FuzzTest and friends. But this exactly proves the fact that the new Gradle option works and actually prevents PBJ from generating the tests for models. So despite a negative result, it's a positive and successful test as far as this feature is concerned.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
