### PR TITLE
feat: introduce PbjGrpcClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ striving for.
     * ### [**PBJ Runtime Library** `pbj-runtime`](pbj-core/pbj-runtime/README.md)
     * ### [**Grpc Helidon** `pbj-grpc-helidon`](pbj-core/pbj-grpc-helidon/README.md)
     * ### [**Grpc Helidon Config** `pbj-grpc-helidon-config](pbj-core/pbj-grpc-helidon-config/README.md)
+    * ### [**Grpc Client Helidon** `pbj-grpc-client-helidon`](pbj-core/pbj-grpc-client-helidon/README.md)
   * ### [**Integration Tests** `pbj-integration-tests`](pbj-integration-tests/README.md) 
 
 ## Build Libraries

--- a/pbj-core/gradle/aggregation/build.gradle.kts
+++ b/pbj-core/gradle/aggregation/build.gradle.kts
@@ -6,4 +6,7 @@ plugins {
     id("org.hiero.gradle.check.spotless-kotlin")
 }
 
-dependencies { implementation(project(":pbj-grpc-helidon")) }
+dependencies {
+    implementation(project(":pbj-grpc-helidon"))
+    implementation(project(":pbj-grpc-client-helidon"))
+}

--- a/pbj-core/pbj-grpc-client-helidon/README.md
+++ b/pbj-core/pbj-grpc-client-helidon/README.md
@@ -1,0 +1,5 @@
+# PBJ GRPC Helidon
+
+This project produces a module with a PBJ gRPC client that uses the Helidon HTTP2 webclient.
+
+It produces `pbj-grpc-client-helidon-VERSION.jar`

--- a/pbj-core/pbj-grpc-client-helidon/build.gradle.kts
+++ b/pbj-core/pbj-grpc-client-helidon/build.gradle.kts
@@ -6,4 +6,7 @@ plugins {
 
 description = "A PBJ gRPC client with Helidon HTTP2 webclient"
 
-testModuleInfo {}
+testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requiresStatic("java.annotation")
+}

--- a/pbj-core/pbj-grpc-client-helidon/build.gradle.kts
+++ b/pbj-core/pbj-grpc-client-helidon/build.gradle.kts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+plugins {
+    id("org.hiero.gradle.module.library")
+    id("org.hiero.gradle.feature.protobuf") // protobuf plugin is only used for tests
+}
+
+description = "A PBJ gRPC client with Helidon HTTP2 webclient"
+
+testModuleInfo {}

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.grpc.client.helidon;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2StreamState;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.http2.Http2ClientConnection;
+import io.helidon.webclient.http2.Http2ClientImpl;
+import io.helidon.webclient.http2.Http2ClientStream;
+import io.helidon.webclient.http2.Http2StreamConfig;
+import io.helidon.webclient.http2.StreamTimeoutException;
+import java.time.Duration;
+
+/**
+ * A blocking, non-buffering wrapper around an HTTP2 stream that serves a single GRPC call.
+ * A client can send requests via the sendRequest() method, and receive replies via a pipeline
+ * that this call has been created with via the PbjGrpcClient.createCall() method.
+ * <p>
+ * The blocking nature of the implementation allows us to delegate the flow control to the underlying
+ * HTTP2 layer entirely. This, of course, assumes that the Pipeline.onNext() method is blocking as well.
+ * <p>
+ * If the onNext() method is not blocking and instead simply buffers incoming replies, then the pipeline
+ * implementation is responsible for the flow control implementation by making the onNext() call block
+ * sometimes, and/or delaying sending more requests via the sendRequest() method until buffered replies
+ * have been processed. Without a proper flow control, a non-blocking pipeline risks running into OOMs
+ * or otherwise causing resources starvation.
+ *
+ * @param <RequestT> request type
+ * @param <ReplyT> reply type
+ */
+public class PbjGrpcCall<RequestT, ReplyT> {
+
+    private final PbjGrpcClient grpcClient;
+    private final Codec<RequestT> requestCodec;
+    private final Codec<ReplyT> replyCodec;
+    private final Pipeline<ReplyT> pipeline;
+
+    private final Http2ClientStream clientStream;
+
+    /**
+     * Create a new GRPC call, start a replies receiving loop in the underlying Helidon WebClient executor,
+     * and send client HTTP2 headers.
+     * @param grpcClient GRPC client
+     * @param clientConnection a client connection
+     * @param requestOptions options such as the authority, content type, etc.
+     * @param fullMethodName a full GRPC method name that includes the fully-qualified service name and the method name
+     * @param requestCodec a PBJ codec for requests that MUST correspond to the content type in the requestOptions
+     * @param replyCodec a PBJ codec for replies that MUST correspond to the content type in the requestOptions
+     * @param pipeline a pipeline for receiving replies
+     */
+    PbjGrpcCall(
+            final PbjGrpcClient grpcClient,
+            final ClientConnection clientConnection,
+            final ServiceInterface.RequestOptions requestOptions,
+            final String fullMethodName,
+            final Codec<RequestT> requestCodec,
+            final Codec<ReplyT> replyCodec,
+            final Pipeline<ReplyT> pipeline) {
+        this.grpcClient = grpcClient;
+        this.requestCodec = requestCodec;
+        this.replyCodec = replyCodec;
+        this.pipeline = pipeline;
+
+        final HelidonSocket socket = clientConnection.helidonSocket();
+        final Http2ClientConnection connection =
+                Http2ClientConnection.create((Http2ClientImpl) grpcClient.getHttp2Client(), clientConnection, true);
+
+        this.clientStream = new PbjGrpcClientStream(
+                connection,
+                Http2Settings.create(),
+                socket,
+                new Http2StreamConfig() {
+                    @Override
+                    public boolean priorKnowledge() {
+                        return true;
+                    }
+
+                    @Override
+                    public int priority() {
+                        return 0;
+                    }
+
+                    @Override
+                    public Duration readTimeout() {
+                        return grpcClient.getConfig().readTimeout();
+                    }
+                },
+                null,
+                connection.streamIdSequence());
+
+        grpcClient.getWebClient().executor().submit(this::receiveRepliesLoop);
+
+        // send HEADERS frame
+        WritableHeaders<?> headers = WritableHeaders.create();
+        requestOptions.authority().ifPresent(authority -> headers.add(Http2Headers.AUTHORITY_NAME, authority));
+        headers.add(Http2Headers.METHOD_NAME, "POST");
+        headers.add(Http2Headers.PATH_NAME, "/" + fullMethodName);
+        headers.add(Http2Headers.SCHEME_NAME, "http");
+        headers.add(HeaderValues.create(HeaderNames.CONTENT_TYPE, requestOptions.contentType()));
+        headers.add(HeaderValues.create(HeaderNames.ACCEPT_ENCODING, "identity"));
+        clientStream.writeHeaders(Http2Headers.create(headers), false);
+    }
+
+    /**
+     * Send a request to the service.
+     * @param request a request object
+     * @param endOfStream a flag indicating if this is the last request, useful for unary or server-streaming methods
+     */
+    public void sendRequest(final RequestT request, final boolean endOfStream) {
+        final Bytes bytes = requestCodec.toBytes(request);
+        final BufferData bufferData = BufferData.create(5 + Math.toIntExact(bytes.length()));
+
+        // GRPC datagram header
+        bufferData.write(0); // 0 means no compression
+        bufferData.writeUnsignedInt32(Math.toIntExact(bytes.length()));
+
+        // GRPC datagram data payload
+        bufferData.write(bytes.toByteArray());
+
+        clientStream.writeData(bufferData, endOfStream);
+    }
+
+    private boolean isStreamOpen() {
+        return clientStream.streamState() != Http2StreamState.HALF_CLOSED_REMOTE
+                && clientStream.streamState() != Http2StreamState.CLOSED;
+    }
+
+    private void receiveRepliesLoop() {
+        boolean headersRead = false;
+        do {
+            try {
+                clientStream.readHeaders();
+                // FUTURE WORK: examine the headers to check the content type, encoding, custom headers, etc.
+                headersRead = true;
+            } catch (StreamTimeoutException ignored) {
+                // FUTURE WORK: implement an uber timeout to return
+            }
+        } while (!headersRead);
+
+        // read data from stream
+        final PbjGrpcDatagramReader datagramReader = new PbjGrpcDatagramReader();
+        while (isStreamOpen()) {
+            if (clientStream.trailers().isDone() || !clientStream.hasEntity()) {
+                // Trailers or EndOfStream received
+                break;
+            }
+
+            final Http2FrameData frameData;
+            try {
+                frameData = clientStream.readOne(grpcClient.getConfig().readTimeout());
+            } catch (StreamTimeoutException e) {
+                // FUTURE WORK: implement an uber timeout to return
+                continue;
+            }
+            if (frameData != null) {
+                BufferData bufferData = frameData.data();
+
+                // Add data to the reader...
+                datagramReader.add(bufferData);
+
+                // ...and then feed all complete GRPC datagrams to the pipeline:
+                BufferData data;
+                while ((data = datagramReader.extractNextDatagram()) != null) {
+                    final byte[] array = data.readBytes();
+                    final Bytes bytes = Bytes.wrap(array);
+
+                    try {
+                        final ReplyT reply = replyCodec.parse(bytes);
+                        pipeline.onNext(reply);
+                    } catch (ParseException e) {
+                        pipeline.onError(e);
+                    }
+                }
+                // If there's no any complete datagrams yet, then simply keep spinning this loop until
+                // enough data is received.
+            }
+        }
+
+        pipeline.onComplete();
+    }
+}

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -122,7 +122,8 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
     @Override
     public void sendRequest(final RequestT request, final boolean endOfStream) {
         final Bytes bytes = requestCodec.toBytes(request);
-        final BufferData bufferData = BufferData.create(5 + Math.toIntExact(bytes.length()));
+        final BufferData bufferData =
+                BufferData.create(PbjGrpcDatagramReader.PREFIX_LENGTH + Math.toIntExact(bytes.length()));
 
         // GRPC datagram header
         bufferData.write(0); // 0 means no compression

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.grpc.client.helidon;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.grpc.GrpcCall;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -40,7 +41,7 @@ import java.time.Duration;
  * @param <RequestT> request type
  * @param <ReplyT> reply type
  */
-public class PbjGrpcCall<RequestT, ReplyT> {
+public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT> {
 
     private final PbjGrpcClient grpcClient;
     private final Codec<RequestT> requestCodec;
@@ -118,6 +119,7 @@ public class PbjGrpcCall<RequestT, ReplyT> {
      * @param request a request object
      * @param endOfStream a flag indicating if this is the last request, useful for unary or server-streaming methods
      */
+    @Override
     public void sendRequest(final RequestT request, final boolean endOfStream) {
         final Bytes bytes = requestCodec.toBytes(request);
         final BufferData bufferData = BufferData.create(5 + Math.toIntExact(bytes.length()));

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
@@ -50,13 +50,13 @@ public class PbjGrpcClient implements GrpcClient {
      * @param pipeline a pipeline for receiving replies
      */
     @Override
-    public <RequestT, ReplyT, T extends GrpcCall<RequestT, ReplyT>> T createCall(
+    public <RequestT, ReplyT> GrpcCall<RequestT, ReplyT> createCall(
             final String fullMethodName,
             final Codec<RequestT> requestCodec,
             final Codec<ReplyT> replyCodec,
             final Pipeline<ReplyT> pipeline) {
         final ClientConnection clientConnection = createClientConnection();
-        return (T) new PbjGrpcCall(
+        return new PbjGrpcCall(
                 this,
                 clientConnection,
                 new Options(config.authority(), config.contentType()),

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
@@ -2,6 +2,8 @@
 package com.hedera.pbj.grpc.client.helidon;
 
 import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.grpc.GrpcCall;
+import com.hedera.pbj.runtime.grpc.GrpcClient;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import io.helidon.webclient.api.ClientConnection;
@@ -20,7 +22,7 @@ import java.util.Optional;
 /**
  * A PBJ GRPC client that uses the Helidon WebClient and its HTTP2 client implementation to call remote GRPC services.
  */
-public class PbjGrpcClient {
+public class PbjGrpcClient implements GrpcClient {
     private final WebClient webClient;
     private final PbjGrpcClientConfig config;
 
@@ -47,13 +49,14 @@ public class PbjGrpcClient {
      * @param replyCodec a PBJ codec for replies that MUST correspond to the content type in the PbjGrpcClientConfig
      * @param pipeline a pipeline for receiving replies
      */
-    public <RequestT, ReplyT> PbjGrpcCall createCall(
+    @Override
+    public <RequestT, ReplyT, T extends GrpcCall<RequestT, ReplyT>> T createCall(
             final String fullMethodName,
             final Codec<RequestT> requestCodec,
             final Codec<ReplyT> replyCodec,
             final Pipeline<ReplyT> pipeline) {
         final ClientConnection clientConnection = createClientConnection();
-        return new PbjGrpcCall(
+        return (T) new PbjGrpcCall(
                 this,
                 clientConnection,
                 new Options(config.authority(), config.contentType()),

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.grpc.client.helidon;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.DefaultDnsResolver;
+import io.helidon.webclient.api.DnsAddressLookup;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.TcpClientConnection;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientImpl;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * A PBJ GRPC client that uses the Helidon WebClient and its HTTP2 client implementation to call remote GRPC services.
+ */
+public class PbjGrpcClient {
+    private final WebClient webClient;
+    private final PbjGrpcClientConfig config;
+
+    private final Http2Client http2Client;
+
+    /**
+     * Create a new PBJ GRPC client.
+     * @param webClient Helidon WebClient instance that MUST specify the baseURI for the service
+     * @param config a configuration for this client
+     */
+    public PbjGrpcClient(final WebClient webClient, final PbjGrpcClientConfig config) {
+        this.webClient = webClient;
+        this.config = config;
+        this.http2Client = webClient.client(Http2Client.PROTOCOL);
+    }
+
+    /**
+     * Create a new GRPC call.
+     *
+     * @param <RequestT> request type
+     * @param <ReplyT> reply type
+     * @param fullMethodName a full GRPC method name that includes the fully-qualified service name and the method name
+     * @param requestCodec a PBJ codec for requests that MUST correspond to the content type in the PbjGrpcClientConfig
+     * @param replyCodec a PBJ codec for replies that MUST correspond to the content type in the PbjGrpcClientConfig
+     * @param pipeline a pipeline for receiving replies
+     */
+    public <RequestT, ReplyT> PbjGrpcCall createCall(
+            final String fullMethodName,
+            final Codec<RequestT> requestCodec,
+            final Codec<ReplyT> replyCodec,
+            final Pipeline<ReplyT> pipeline) {
+        final ClientConnection clientConnection = createClientConnection();
+        return new PbjGrpcCall(
+                this,
+                clientConnection,
+                new Options(config.authority(), config.contentType()),
+                fullMethodName,
+                requestCodec,
+                replyCodec,
+                pipeline);
+    }
+
+    WebClient getWebClient() {
+        return webClient;
+    }
+
+    Http2Client getHttp2Client() {
+        return http2Client;
+    }
+
+    /**
+     * @return the PbjGrpcClientConfig of this client
+     */
+    public PbjGrpcClientConfig getConfig() {
+        return config;
+    }
+
+    /** Simple implementation of the {@link ServiceInterface.RequestOptions} interface. */
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+
+    private ClientConnection createClientConnection() {
+        final ClientUri clientUri = ((Http2ClientImpl) http2Client)
+                .prototype()
+                .baseUri()
+                .orElseThrow(() -> new IllegalStateException("No base URI provided in the WebClient."));
+        final ConnectionKey connectionKey = new ConnectionKey(
+                clientUri.scheme(),
+                clientUri.host(),
+                clientUri.port(),
+                config.readTimeout(),
+                config.tls(),
+                DefaultDnsResolver.create(),
+                DnsAddressLookup.defaultLookup(),
+                Proxy.noProxy());
+        return TcpClientConnection.create(
+                        webClient, connectionKey, Collections.emptyList(), connection -> false, connection -> {})
+                .connect();
+    }
+}

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientConfig.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientConfig.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.grpc.client.helidon;
+
+import io.helidon.common.tls.Tls;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Configuration for PBJ GRPC client.
+ */
+public record PbjGrpcClientConfig(
+        /** A read timeout. Duration.ofSeconds(10) is a good default. */
+        Duration readTimeout,
+        /** TLS configuration. */
+        Tls tls,
+        /** An optional authority string. */
+        Optional<String> authority,
+        /** A content type, such as "application/grpc+proto" or "application/grpc+json". */
+        String contentType) {}

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientStream.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientStream.java
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.grpc.client.helidon;
+
+import io.helidon.common.socket.SocketContext;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.webclient.http2.Http2ClientConfig;
+import io.helidon.webclient.http2.Http2ClientConnection;
+import io.helidon.webclient.http2.Http2ClientStream;
+import io.helidon.webclient.http2.Http2StreamConfig;
+import io.helidon.webclient.http2.LockingStreamIdSequence;
+
+/**
+ * A package-private class that extends a Helidon client stream class only for the purpose
+ * of accessing its only protected constructor. While the Http2ClientStream is marked as "not for applications use"
+ * in Helidon, a GRPC client implementation must use this stream class in order to implement the GRPC protocol.
+ */
+class PbjGrpcClientStream extends Http2ClientStream {
+    PbjGrpcClientStream(
+            final Http2ClientConnection connection,
+            final Http2Settings serverSettings,
+            final SocketContext ctx,
+            final Http2StreamConfig http2StreamConfig,
+            final Http2ClientConfig http2ClientConfig,
+            final LockingStreamIdSequence streamIdSeq) {
+        super(connection, serverSettings, ctx, http2StreamConfig, http2ClientConfig, streamIdSeq);
+    }
+}

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcDatagramReader.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcDatagramReader.java
@@ -25,7 +25,7 @@ import java.nio.BufferOverflowException;
 class PbjGrpcDatagramReader {
 
     // These are arbitrary limits, but they seem sane and support the immediate use-case.
-    // It would be nice to make them configurable. However, note that this is a Helidon-internal class.
+    // It would be nice to make them configurable in the future.
     private static final int INITIAL_BUFFER_SIZE = 1024;
     private static final int MAX_BUFFER_SIZE = 10 * 1024 * 1024;
 

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcDatagramReader.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcDatagramReader.java
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.grpc.client.helidon;
+
+import io.helidon.common.buffers.BufferData;
+import java.nio.BufferOverflowException;
+
+/**
+ * An abstraction responsible for building complete GRPC datagrams out of individual data frames.
+ * <p>
+ * Each datagram has a prefix consisting of a compression flag
+ * and a size of the datagram. Note that this class doesn't support compression currently.
+ * However, due to the HTTP2 flow control, a single GRPC datagram may be split accross multiple
+ * individual data frames, and the GRPC client must use the size of the datagram in order to reconstruct
+ * the entire datagram so that its content can actually be parsed by a reply type marshaler.
+ * This is exactly what this class is doing, along with some required buffering because
+ * the last data frame may in fact contain a beginning of a new GRPC datagram which we'll
+ * need to fully receive and process as well in the future.
+ * <p>
+ * Typically, the client would call the PbjGrpcDatagramReader.add(BufferData) method as it receives data
+ * from the network, and then call the PbjGrpcDatagramReader.extractNextDatagram() to check if a complete
+ * datagram is available.
+ * <p>
+ * This class is not thread-safe. The client is responsible for synchronizing access to its APIs.
+ */
+class PbjGrpcDatagramReader {
+
+    // These are arbitrary limits, but they seem sane and support the immediate use-case.
+    // It would be nice to make them configurable. However, note that this is a Helidon-internal class.
+    private static final int INITIAL_BUFFER_SIZE = 1024;
+    private static final int MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
+    /**
+     * A buffer for incoming data. We copy the incoming BufferData objects into this buffer
+     * on purpose because existing BufferData implementations aren't immutable. Further, the code
+     * that creates the BufferData objects may reuse the underlying byte arrays now or in the future.
+     * So we cannot just maintain a list of BufferData objects added to the reader, although that would be nice.
+     * <p>
+     * The io.helidon.common.buffers.GrowingBufferData is nice, too. However, it seems to create interim
+     * byte arrays when adding data to the buffer. Also, it doesn't support a capacity limit which
+     * may be important to prevent OOM. For this reason, we use a low-level circular byte array here.
+     */
+    private byte[] buffer = new byte[INITIAL_BUFFER_SIZE];
+
+    /** Where we read data from. */
+    private int readPosition = 0;
+
+    /** Where we write new data to. */
+    private int writePosition = 0;
+
+    /** The length of the actual data added to the reader. Note that the buffer is circular. */
+    private int length = 0;
+
+    /**
+     * Add a new piece of data to this reader. It may be a complete GRPC datagram, or a piece of it,
+     * maybe even a piece containing a tail of one datagram and a head of another.
+     * The client should call the extractNextDatagram() method to see if there's a complete datagram yet.
+     * @param bufferData a piece of data to add to the reader
+     */
+    void add(final BufferData bufferData) {
+        ensureCapacity(bufferData.available());
+
+        // Avoid creating interim arrays. Fill up the tail of the buffer first...
+        final int firstPartMaxLengthForWriting = buffer.length - writePosition;
+        int read =
+                bufferData.read(buffer, writePosition, Math.min(bufferData.available(), firstPartMaxLengthForWriting));
+
+        // ...and flip to the head if necessary
+        if (bufferData.available() > 0) {
+            read += bufferData.read(buffer, 0, bufferData.available());
+        }
+
+        // Adjust the length and the writePosition
+        length += read;
+        writePosition += read;
+        writePosition %= buffer.length;
+    }
+
+    /** Return the size of the next complete datagram, or -1 if it's incomplete yet. */
+    private int getNextSize() {
+        // Check if we have a complete datagram
+        if (length < 5) {
+            // We don't even have a complete GRPC header yet
+            return -1;
+        }
+
+        // We only remove complete datagrams from the buffer, so the readPosition is guaranteed to point
+        // to the beginning of a new datagram.
+
+        // Read big endian (unsigned, but oh well...) int32 size from the GRPC header first
+        // (ignoring the first byte which is a compression flag)
+        final int size = buffer[(readPosition + 1) % buffer.length] << 24
+                | (buffer[(readPosition + 2) % buffer.length] << 16)
+                | (buffer[(readPosition + 3) % buffer.length] << 8)
+                | (buffer[(readPosition + 4) % buffer.length]);
+
+        if (length < 5 + size) {
+            // We don't have enough data yet. More data needs to be added to the reader to complete this datagram.
+            return -1;
+        }
+
+        return size;
+    }
+
+    /**
+     * Read the next complete GRPC datagram and return a BufferData with its data payload,
+     * or return null if the datagram is incomplete yet and more data needs to be added to this reader.
+     * @return the GRPC datagram data payload, or null if not ready yet
+     */
+    BufferData extractNextDatagram() {
+        final int size = getNextSize();
+        if (size == -1) {
+            return null;
+        }
+
+        // We have a complete datagram (and perhaps also a start of the next datagram) in the buffer.
+        // Let's extract the complete one. Note that we only return the data bytes because higher level code
+        // shouldn't be concerned with the details of the GRPC header.
+        // So if we want to support compression in the future, it has to be implemented here somewhere.
+        final BufferData data = BufferData.create(size);
+
+        // Skip the header because we've already read the size, and we ignore the compression:
+        readPosition += 5;
+        readPosition %= buffer.length;
+
+        final int firstPartMaxLengthForReading = buffer.length - readPosition;
+        data.write(buffer, readPosition, Math.min(firstPartMaxLengthForReading, size));
+        // and read the head of the buffer if needed:
+        if (size > firstPartMaxLengthForReading) {
+            data.write(buffer, 0, size - firstPartMaxLengthForReading);
+        }
+
+        // Advance the readPosition
+        readPosition += size;
+        readPosition %= buffer.length;
+        // Adjust the length
+        length -= 5 + size;
+
+        return data;
+    }
+
+    /** Ensure there's enough capacity to write more data, or throw BufferOverflowException. */
+    private void ensureCapacity(final int minCapacity) {
+        final int currentCapacity = buffer.length - length;
+        if (currentCapacity >= minCapacity) {
+            return;
+        }
+
+        final int newLength = buffer.length + (minCapacity - currentCapacity);
+        if (newLength > MAX_BUFFER_SIZE) {
+            throw new BufferOverflowException();
+        }
+
+        // Prefer to double the size each time. But resort to the newLength if it's greater, and respect the max limit.
+        final int actualNewLength = Math.min(Math.max(buffer.length * 2, newLength), MAX_BUFFER_SIZE);
+        final byte[] newBuffer = new byte[actualNewLength];
+
+        if (length > 0) {
+            final int firstPartMaxLength = buffer.length - readPosition;
+            System.arraycopy(buffer, readPosition, newBuffer, 0, Math.min(length, firstPartMaxLength));
+            if (firstPartMaxLength < length) {
+                // The data has the second part in the head of our circular buffer:
+                System.arraycopy(buffer, 0, newBuffer, firstPartMaxLength, length - firstPartMaxLength);
+            }
+        }
+
+        buffer = newBuffer;
+        readPosition = 0;
+        writePosition = length;
+    }
+}

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/package-info.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/package-info.java
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * An implementation of a PBJ gRPC client with the Helidon HTTP2 webclient.
+ */
+package com.hedera.pbj.grpc.client.helidon;

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/module-info.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+/** PBJ gRPC client implementation. */
+module com.hedera.pbj.grpc.client.helidon {
+    requires transitive com.hedera.pbj.runtime;
+    requires transitive io.helidon.common.tls;
+    requires transitive io.helidon.webclient.api;
+    requires io.helidon.common.buffers;
+    requires io.helidon.common.socket;
+    requires io.helidon.http.http2;
+    requires io.helidon.http;
+    requires io.helidon.webclient.http2;
+
+    exports com.hedera.pbj.grpc.client.helidon;
+}

--- a/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcDatagramReaderTest.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcDatagramReaderTest.java
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.grpc.client.helidon;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.helidon.common.buffers.BufferData;
+import java.nio.BufferOverflowException;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class PbjGrpcDatagramReaderTest {
+    @Test
+    void checkBufferOverflow() {
+        PbjGrpcDatagramReader reader = new PbjGrpcDatagramReader();
+
+        // First, test the happy case, fill up the buffer to the current max limit (note that it's hard-coded here):
+        BufferData goodData = BufferData.create("a".repeat(10 * 1024 * 1024));
+        reader.add(goodData);
+
+        // Now try to add some more, 1 byte should be enough:
+        BufferData badData = BufferData.create("b");
+        assertThrows(BufferOverflowException.class, () -> reader.add(badData));
+    }
+
+    @Test
+    void testSingleCompleteDatagram() {
+        PbjGrpcDatagramReader reader = new PbjGrpcDatagramReader();
+
+        // Trivial case of a zero-size datagram
+        BufferData zeroData = BufferData.create(new byte[] {0, 0, 0, 0, 0});
+        reader.add(zeroData);
+        BufferData bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(0, bufferData.available());
+
+        // 1 byte long datagram
+        BufferData oneData = BufferData.create(new byte[] {0, 0, 0, 0, 1, 66});
+        reader.add(oneData);
+        bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(1, bufferData.available());
+        assertEquals(66, bufferData.read());
+
+        // Many bytes long datagram
+        String data = "Some test data here...";
+        BufferData manyData = BufferData.create(5 + data.getBytes().length);
+        manyData.write(0);
+        manyData.writeInt32(data.getBytes().length);
+        manyData.write(data.getBytes());
+        reader.add(manyData);
+        bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(data.getBytes().length, bufferData.available());
+        assertEquals(data, bufferData.readString(data.getBytes().length));
+    }
+
+    @Test
+    void testSplitDatagram() {
+        PbjGrpcDatagramReader reader = new PbjGrpcDatagramReader();
+
+        // This is very similar to the many bytes long datagram test above, but we feed the reader
+        // little by little instead of adding the entire datagram at once:
+        String data = "Some test data here...";
+
+        reader.add(BufferData.create(new byte[] {0}));
+        assertNull(reader.extractNextDatagram());
+
+        BufferData someData = BufferData.create(4);
+        someData.writeInt32(data.getBytes().length);
+        reader.add(someData);
+        assertNull(reader.extractNextDatagram());
+
+        BufferData someMoreData = BufferData.create(Arrays.copyOf(data.getBytes(), 8));
+        reader.add(someMoreData);
+        assertNull(reader.extractNextDatagram());
+
+        BufferData finalData = BufferData.create(Arrays.copyOfRange(data.getBytes(), 8, data.getBytes().length));
+        reader.add(finalData);
+
+        BufferData bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(data.getBytes().length, bufferData.available());
+        assertEquals(data, bufferData.readString(data.getBytes().length));
+    }
+}

--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -277,8 +277,6 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
             // used to decide on the best way to parse or handle the request.
             final var options = new Options(
                     Optional.ofNullable(headers.authority()), // the client (see http2 spec)
-                    contentType.equals(APPLICATION_GRPC_PROTO),
-                    contentType.equals(APPLICATION_GRPC_JSON),
                     contentType);
 
             // Setup the subscribers. The "outgoing" subscriber will send messages to the client.
@@ -714,8 +712,7 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
     }
 
     /** Simple implementation of the {@link ServiceInterface.RequestOptions} interface. */
-    private record Options(Optional<String> authority, boolean isProtobuf, boolean isJson, String contentType)
-            implements ServiceInterface.RequestOptions {}
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
 
     /**
      * A {@link ScheduledFuture} that does nothing. This is used when there is no deadline set for

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcCall.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcCall.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.grpc;
+
+/**
+ * An interface for a GRPC call.
+ * <p>
+ * It's capable of sending requests to a GRPC service via the sendRequest() method declared here.
+ * <p>
+ * An implementation of this interface is supposed to maintain a reference to a {@code Pipeline<ReplyT>}
+ * through which the call will send replies from the GRPC service to the application code.
+ *
+ * @param <RequestT> request type
+ * @param <ReplyT> reply type
+ */
+public interface GrpcCall<RequestT, ReplyT> {
+    /**
+     * Send a request to the service.
+     * @param request a request object
+     * @param endOfStream a flag indicating if this is the last request, useful for unary or server-streaming methods
+     */
+    void sendRequest(final RequestT request, final boolean endOfStream);
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
@@ -15,12 +15,11 @@ public interface GrpcClient {
      *
      * @param <RequestT> request type
      * @param <ReplyT> reply type
-     * @param <T> a GrpcCall type
      * @param fullMethodName a full GRPC method name that includes the fully-qualified service name and the method name
      * @param requestCodec a PBJ codec for requests
      * @param replyCodec a PBJ codec for replies
      * @param pipeline a pipeline for receiving replies
      */
-    <RequestT, ReplyT, T extends GrpcCall<RequestT, ReplyT>> T createCall(
+    <RequestT, ReplyT> GrpcCall<RequestT, ReplyT> createCall(
             String fullMethodName, Codec<RequestT> requestCodec, Codec<ReplyT> replyCodec, Pipeline<ReplyT> pipeline);
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.grpc;
+
+import com.hedera.pbj.runtime.Codec;
+
+/**
+ * An interface for GRPC client.
+ * <p>
+ * It's capable of creating GrpcCall objects that applications can use to send requests to a GRPC service
+ * and receive replies from the service through the supplied Pipeline instance.
+ */
+public interface GrpcClient {
+    /**
+     * Create a new GRPC call.
+     *
+     * @param <RequestT> request type
+     * @param <ReplyT> reply type
+     * @param <T> a GrpcCall type
+     * @param fullMethodName a full GRPC method name that includes the fully-qualified service name and the method name
+     * @param requestCodec a PBJ codec for requests
+     * @param replyCodec a PBJ codec for replies
+     * @param pipeline a pipeline for receiving replies
+     */
+    <RequestT, ReplyT, T extends GrpcCall<RequestT, ReplyT>> T createCall(
+            String fullMethodName, Codec<RequestT> requestCodec, Codec<ReplyT> replyCodec, Pipeline<ReplyT> pipeline);
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
@@ -79,13 +79,17 @@ public interface ServiceInterface {
          * Gets whether the content type describes a protobuf message. This will be true if the {@link #contentType()}
          * is equal to {@link #APPLICATION_GRPC_PROTO} or {@link #APPLICATION_GRPC}.
          */
-        boolean isProtobuf();
+        default boolean isProtobuf() {
+            return APPLICATION_GRPC_PROTO.equals(contentType()) || APPLICATION_GRPC.equals(contentType());
+        }
 
         /**
          * Gets whether the content type describes a JSON message. This will be true if the {@link #contentType()}
          * is equal to {@link #APPLICATION_GRPC_JSON}.
          */
-        boolean isJson();
+        default boolean isJson() {
+            return APPLICATION_GRPC_JSON.equals(contentType());
+        }
 
         /**
          * Gets the content type of the request. This is the value of the "content-type" header in the HTTP/2 request.


### PR DESCRIPTION
**Description**:
Introducing a PBJ GRPC client that only depends on the Helidon HTTP2 web client. In particular, this implementation avoids a dependency on the `io.grpc` libraries which we consider unwanted (see https://github.com/hashgraph/pbj/blob/066a5f7c1be14855e3f7793d92846eac3e828a71/pbj-core/pbj-grpc-helidon/docs/design.md?plain=1#L15-L22 ).

**Related issue(s)**:

Fixes #518

**Notes for reviewer**:
Please see javadocs for the new classes. Integration tests for this code will be added in a future PR where we'll introduce PBJ GRPC client stubs generation.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
