### PR TITLE
test: comprehensive GRPC client test

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -262,7 +262,7 @@ public final class ServiceGenerator {
                                 }
                                 @Override
                                 public void onComplete() {
-                                    call.halfClose();
+                                    call.completeRequests();
                                     replies.onComplete();
                                 }
                             };
@@ -382,7 +382,7 @@ public final class ServiceGenerator {
                                 }
                                 @Override
                                 public void onComplete() {
-                                    call.halfClose();
+                                    call.completeRequests();
                                     replies.onComplete();
                                 }
                             };

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -140,7 +140,7 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
     }
 
     @Override
-    public void halfClose() {
+    public void completeRequests() {
         clientStream.writeData(EMPTY_BUFFER_DATA, true);
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcCall.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcCall.java
@@ -21,19 +21,20 @@ public interface GrpcCall<RequestT, ReplyT> {
     void sendRequest(final RequestT request, final boolean endOfStream);
 
     /**
-     * Half-closes the call to indicate that it's complete from the request sender perspective.
-     * When using HTTP2 as a transport protocol, this is usually represented as sending an empty buffer
-     * of data with the endOfStream flag set to true.
+     * Indicate that the application is done sending requests.
+     * <p>
+     * When using HTTP2 as a transport protocol, this is usually called as "half-closed" and achieved
+     * by sending an empty buffer of data with the endOfStream flag set to true.
      * <p>
      * Note that an application can indicate this state using the `sendRequest` method above as well,
-     * but it requires a real, non-empty request to be sent prior to half-closing the call, so that method
-     * is most applicable to unary calls where the method implementation knows that there's just a single request
+     * but it requires a real, non-empty request to be sent, so that method is most applicable to unary
+     * or server-streaming calls where the method implementation knows that there's just a single request
      * to be sent.
      * <p>
-     * For other method types, such as client-streaming or bidi for example, this `halfClose()` method may be
+     * For other method types, such as client-streaming or bidi for example, this `completeRequests()` method may be
      * more convenient instead.
      * <p>
-     * Note that sending more requests after the call has been half-closed will result in an exception.
+     * Note that sending more requests after calling this method will result in an exception.
      */
-    void halfClose();
+    void completeRequests();
 }

--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -45,6 +45,7 @@ testModuleInfo {
     requires("io.helidon.webclient.api")
     runtimeOnly("io.helidon.webclient.http2")
     requires("io.helidon.webserver")
+    runtimeOnly("io.grpc.netty")
 
     runtimeOnly("org.junit.jupiter.engine")
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GoogleProtobufGrpcServerGreeterHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GoogleProtobufGrpcServerGreeterHandle.java
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
+import io.grpc.Server;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.concurrent.Flow;
+import pbj.integration.tests.GreeterGrpc;
+import pbj.integration.tests.HelloReply;
+import pbj.integration.tests.HelloRequest;
+
+/** A Greeter handle for the Google Protobuf GRPC server implementation. */
+class GoogleProtobufGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
+    /** Greeter service implementation for Google GRPC server. */
+    private class GreeterGrpcImpl extends GreeterGrpc.GreeterImplBase {
+        @Override
+        public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+            final pbj.integration.tests.pbj.integration.tests.HelloReply reply =
+                    GoogleProtobufGrpcServerGreeterHandle.this.sayHello(adaptRequest(request));
+            responseObserver.onNext(adaptReply(reply));
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void sayHelloStreamReply(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+            final Pipeline<pbj.integration.tests.pbj.integration.tests.HelloReply> replyPipeline = new Pipeline<>() {
+                @Override
+                public void onNext(pbj.integration.tests.pbj.integration.tests.HelloReply item)
+                        throws RuntimeException {
+                    responseObserver.onNext(adaptReply(item));
+                }
+
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    // no-op
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    responseObserver.onError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    responseObserver.onCompleted();
+                }
+            };
+            GoogleProtobufGrpcServerGreeterHandle.this.sayHelloStreamReply(adaptRequest(request), replyPipeline);
+        }
+
+        @Override
+        public StreamObserver<HelloRequest> sayHelloStreamRequest(StreamObserver<HelloReply> responseObserver) {
+            final Pipeline<pbj.integration.tests.pbj.integration.tests.HelloReply> replyPipeline = new Pipeline<>() {
+                @Override
+                public void onNext(pbj.integration.tests.pbj.integration.tests.HelloReply item)
+                        throws RuntimeException {
+                    responseObserver.onNext(adaptReply(item));
+                }
+
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    // no-op
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    responseObserver.onError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    responseObserver.onCompleted();
+                }
+            };
+            final Pipeline<? super pbj.integration.tests.pbj.integration.tests.HelloRequest> requestPipeline =
+                    GoogleProtobufGrpcServerGreeterHandle.this.sayHelloStreamRequest(replyPipeline);
+            return new StreamObserver<HelloRequest>() {
+                public void onNext(HelloRequest value) {
+                    requestPipeline.onNext(adaptRequest(value));
+                }
+
+                public void onError(Throwable t) {
+                    requestPipeline.onError(t);
+                }
+
+                public void onCompleted() {
+                    requestPipeline.onComplete();
+                }
+            };
+        }
+
+        @Override
+        public StreamObserver<HelloRequest> sayHelloStreamBidi(StreamObserver<HelloReply> responseObserver) {
+            final Pipeline<pbj.integration.tests.pbj.integration.tests.HelloReply> replyPipeline = new Pipeline<>() {
+                @Override
+                public void onNext(pbj.integration.tests.pbj.integration.tests.HelloReply item)
+                        throws RuntimeException {
+                    responseObserver.onNext(adaptReply(item));
+                }
+
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    // no-op
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    responseObserver.onError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    responseObserver.onCompleted();
+                }
+            };
+            final Pipeline<? super pbj.integration.tests.pbj.integration.tests.HelloRequest> requestPipeline =
+                    GoogleProtobufGrpcServerGreeterHandle.this.sayHelloStreamBidi(replyPipeline);
+            return new StreamObserver<HelloRequest>() {
+                public void onNext(HelloRequest value) {
+                    requestPipeline.onNext(adaptRequest(value));
+                }
+
+                public void onError(Throwable t) {
+                    requestPipeline.onError(t);
+                }
+
+                public void onCompleted() {
+                    requestPipeline.onComplete();
+                }
+            };
+        }
+    }
+
+    private final GreeterGrpcImpl greeterGrpc = new GreeterGrpcImpl();
+    private final int port;
+
+    private Server server;
+
+    public GoogleProtobufGrpcServerGreeterHandle(final int port) {
+        this.port = port;
+    }
+
+    @Override
+    public synchronized void start() {
+        if (server != null) {
+            throw new IllegalStateException("Server already started");
+        }
+        server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
+                .addService(greeterGrpc)
+                .build();
+        try {
+            server.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (server != null) {
+            server.shutdown();
+            server = null;
+        }
+    }
+
+    private static pbj.integration.tests.pbj.integration.tests.HelloRequest adaptRequest(HelloRequest request) {
+        return pbj.integration.tests.pbj.integration.tests.HelloRequest.newBuilder()
+                .name(request.getName())
+                .build();
+    }
+
+    private static HelloReply adaptReply(pbj.integration.tests.pbj.integration.tests.HelloReply reply) {
+        return HelloReply.newBuilder().setMessage(reply.message()).build();
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcClientComprehensiveTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcClientComprehensiveTest.java
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.grpc.GrpcClient;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.api.WebClient;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import pbj.integration.tests.pbj.integration.tests.GreeterInterface;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+/**
+ * A comprehensive test for the PBJ GRPC client. The testing is performed against multiple GRPC server implementations -
+ * currently using the PBJ GRPC server on top of the Helidon HTTP2 server, as well as Google Protobuf GRPC server
+ * on top of Netty. More server implementations can be added via the `testClassArguments()` method below.
+ * Each test allocates a unique port number and then creates a server and client instances, which allows all the tests
+ * to run in parallel.
+ */
+@ParameterizedClass
+@MethodSource("testClassArguments")
+public class GrpcClientComprehensiveTest {
+    private static final PortsAllocator PORTS = new PortsAllocator(8666, 10666);
+
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+
+    private static final Options PROTO_OPTIONS =
+            new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
+
+    private final Function<Integer, GrpcServerGreeterHandle> serverFactory;
+
+    static Stream<Arguments> testClassArguments() {
+        return Stream.of(
+                Arguments.of((Function<Integer, GrpcServerGreeterHandle>) PbjGrpcServerGreeterHandle::new),
+                Arguments.of((Function<Integer, GrpcServerGreeterHandle>) GoogleProtobufGrpcServerGreeterHandle::new));
+    }
+
+    public GrpcClientComprehensiveTest(Function<Integer, GrpcServerGreeterHandle> serverFactory) {
+        this.serverFactory = serverFactory;
+    }
+
+    private GrpcClient createGrpcClient(final int port, final ServiceInterface.RequestOptions requestOptions) {
+        final Tls tls = Tls.builder().enabled(false).build();
+        final WebClient webClient =
+                WebClient.builder().baseUri("http://localhost:" + port).tls(tls).build();
+
+        final PbjGrpcClientConfig config = new PbjGrpcClientConfig(
+                Duration.ofSeconds(10), tls, requestOptions.authority(), requestOptions.contentType());
+
+        return new PbjGrpcClient(webClient, config);
+    }
+
+    @Test
+    void testUnaryMethodHappyCase() {
+        try (final PortsAllocator.Port port = PORTS.acquire();
+                final GrpcServerGreeterHandle server = serverFactory.apply(port.port())) {
+            server.start();
+            server.setSayHello(request ->
+                    HelloReply.newBuilder().message("Hello " + request.name()).build());
+
+            final GrpcClient grpcClient = createGrpcClient(port.port(), PROTO_OPTIONS);
+            final GreeterInterface.GreeterClient client = new GreeterInterface.GreeterClient(grpcClient, PROTO_OPTIONS);
+
+            final HelloRequest request =
+                    HelloRequest.newBuilder().name("test name").build();
+            final HelloReply reply = client.sayHello(request);
+
+            assertEquals("Hello test name", reply.message());
+        }
+    }
+
+    @Test
+    void testServerStreamingMethodHappyCase() {
+        try (final PortsAllocator.Port port = PORTS.acquire();
+                final GrpcServerGreeterHandle server = serverFactory.apply(port.port())) {
+            server.start();
+            server.setSayHelloStreamReply(((request, replies) -> {
+                replies.onNext(HelloReply.newBuilder()
+                        .message("Hello 1 " + request.name())
+                        .build());
+                replies.onNext(HelloReply.newBuilder()
+                        .message("Hello 2 " + request.name())
+                        .build());
+                replies.onNext(HelloReply.newBuilder()
+                        .message("Hello 3 " + request.name())
+                        .build());
+                replies.onComplete();
+            }));
+
+            final GrpcClient grpcClient = createGrpcClient(port.port(), PROTO_OPTIONS);
+            final GreeterInterface.GreeterClient client = new GreeterInterface.GreeterClient(grpcClient, PROTO_OPTIONS);
+
+            final HelloRequest request =
+                    HelloRequest.newBuilder().name("test name").build();
+            final List<HelloReply> replies = new ArrayList<>();
+            final List<Throwable> errors = new ArrayList<>();
+            final AtomicBoolean completed = new AtomicBoolean(false);
+            client.sayHelloStreamReply(request, new Pipeline<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    // no-op
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    errors.add(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    completed.set(true);
+                }
+
+                @Override
+                public void onNext(HelloReply item) throws RuntimeException {
+                    replies.add(item);
+                }
+            });
+
+            assertEquals(
+                    List.of(
+                            HelloReply.newBuilder().message("Hello 1 test name").build(),
+                            HelloReply.newBuilder().message("Hello 2 test name").build(),
+                            HelloReply.newBuilder().message("Hello 3 test name").build()),
+                    replies);
+
+            // Log all errors (if any) and assert there's none
+            errors.forEach(System.err::println);
+            assertTrue(errors.isEmpty());
+
+            assertTrue(completed.get());
+        }
+    }
+
+    void testStreamingMethodsHappyCase(
+            final Consumer<GrpcServerGreeterHandle> serverConfigurer,
+            final BiFunction<GreeterInterface, Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> method,
+            final List<HelloReply> expectedReplies) {
+        try (final PortsAllocator.Port port = PORTS.acquire();
+                final GrpcServerGreeterHandle server = serverFactory.apply(port.port())) {
+            server.start();
+            serverConfigurer.accept(server);
+
+            final GrpcClient grpcClient = createGrpcClient(port.port(), PROTO_OPTIONS);
+            final GreeterInterface.GreeterClient client = new GreeterInterface.GreeterClient(grpcClient, PROTO_OPTIONS);
+
+            final HelloRequest request =
+                    HelloRequest.newBuilder().name("test name").build();
+            final List<HelloReply> replies = new ArrayList<>();
+            final List<Throwable> errors = new ArrayList<>();
+            final AtomicBoolean completed = new AtomicBoolean(false);
+            final Pipeline<? super HelloRequest> requests = method.apply(client, new Pipeline<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    // no-op
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    errors.add(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    completed.set(true);
+                }
+
+                @Override
+                public void onNext(HelloReply item) throws RuntimeException {
+                    replies.add(item);
+                }
+            });
+
+            requests.onNext(HelloRequest.newBuilder().name("test name 1").build());
+            requests.onNext(HelloRequest.newBuilder().name("test name 2").build());
+            requests.onNext(HelloRequest.newBuilder().name("test name 3").build());
+            requests.onComplete();
+
+            // NOTE: the test method isn't blocking (because it returns a requests pipeline.)
+            // So we have to wait a tad. Both server and client are running on the current host here
+            // (in the same JVM, in fact.) So 1 second should be sufficient, unless the computer is really-really slow.
+            // If we find this not working, then we'll come up with a longer timeout and will be watching the completed
+            // flag in a loop instead.
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+            }
+
+            assertEquals(expectedReplies, replies);
+
+            // Log all errors (if any) and assert there's none
+            errors.forEach(System.err::println);
+            assertTrue(errors.isEmpty());
+
+            assertTrue(completed.get());
+        }
+    }
+
+    @Test
+    void testClientStreamingMethodsHappyCase() {
+        testStreamingMethodsHappyCase(
+                server -> server.setSayHelloStreamRequest(replies -> {
+                    final List<HelloRequest> requests = new ArrayList<>();
+                    return new Pipeline<>() {
+                        @Override
+                        public void onSubscribe(Flow.Subscription subscription) {
+                            subscription.request(Long.MAX_VALUE); // turn off flow control
+                        }
+
+                        @Override
+                        public void onNext(HelloRequest item) {
+                            requests.add(item);
+                            if (requests.size() == 3) {
+                                final HelloReply reply = HelloReply.newBuilder()
+                                        .message("Hello "
+                                                + requests.stream()
+                                                        .map(HelloRequest::name)
+                                                        .collect(Collectors.joining(", "))
+                                                + "!")
+                                        .build();
+                                replies.onNext(reply);
+                                replies.onComplete();
+                            }
+                        }
+
+                        @Override
+                        public void onError(Throwable throwable) {
+                            replies.onError(throwable);
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            replies.onComplete();
+                        }
+                    };
+                }),
+                (client, replies) -> client.sayHelloStreamRequest(replies),
+                List.of(HelloReply.newBuilder()
+                        .message("Hello test name 1, test name 2, test name 3!")
+                        .build()));
+    }
+
+    @Test
+    void testBidiStreamingMethodsHappyCase() {
+        testStreamingMethodsHappyCase(
+                server -> server.setSayHelloStreamBidi(replies -> {
+                    // Here we receive info from the client. In this case, it is a stream of requests with
+                    // names. We will respond with a stream of replies.
+                    return new Pipeline<>() {
+                        @Override
+                        public void onSubscribe(Flow.Subscription subscription) {
+                            subscription.request(Long.MAX_VALUE); // turn off flow control
+                        }
+
+                        @Override
+                        public void onNext(HelloRequest item) {
+                            final HelloReply reply = HelloReply.newBuilder()
+                                    .message("Hello " + item.name())
+                                    .build();
+                            replies.onNext(reply);
+                        }
+
+                        @Override
+                        public void onError(Throwable throwable) {
+                            replies.onError(throwable);
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            replies.onComplete();
+                        }
+                    };
+                }),
+                (client, replies) -> client.sayHelloStreamBidi(replies),
+                List.of(
+                        HelloReply.newBuilder().message("Hello test name 1").build(),
+                        HelloReply.newBuilder().message("Hello test name 2").build(),
+                        HelloReply.newBuilder().message("Hello test name 3").build()));
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcServerGreeterHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcServerGreeterHandle.java
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import pbj.integration.tests.pbj.integration.tests.GreeterInterface;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+/**
+ * A handle for a GRPC server that implements the Greeter service using a PBJ-generated interface
+ * that can be used directly with the PBJ GRPC server. Other server implementations would have to
+ * wrap service calls to convert payloads and/or adapt to different APIs.
+ *
+ * A test must provide implementations for service methods that it will call. The default implementations
+ * are either no-ops, or return hard-coded results, or nulls which may kill the low-level server implementation.
+ */
+abstract class GrpcServerGreeterHandle implements GreeterInterface, AutoCloseable {
+
+    private Function<HelloRequest, HelloReply> sayHello;
+    private BiConsumer<HelloRequest, Pipeline<? super HelloReply>> sayHelloStreamReply;
+    private Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamRequest;
+    private Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamBidi;
+
+    abstract void start();
+
+    abstract void stop();
+
+    @Override
+    public void close() {
+        stop();
+    }
+
+    @NonNull
+    @Override
+    public HelloReply sayHello(@NonNull HelloRequest request) {
+        if (sayHello != null) {
+            return sayHello.apply(request);
+        }
+        return HelloReply.DEFAULT;
+    }
+
+    @Override
+    public void sayHelloStreamReply(@NonNull HelloRequest request, @NonNull Pipeline<? super HelloReply> replies) {
+        if (sayHelloStreamReply != null) {
+            sayHelloStreamReply.accept(request, replies);
+        }
+        // no-op otherwise
+    }
+
+    @NonNull
+    @Override
+    public Pipeline<? super HelloRequest> sayHelloStreamRequest(@NonNull Pipeline<? super HelloReply> replies) {
+        if (sayHelloStreamRequest != null) {
+            return sayHelloStreamRequest.apply(replies);
+        }
+        // this will likely kill the server, but it's not supposed to be invoked unless the test does that,
+        // in which case the test must provide an implementation.
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Pipeline<? super HelloRequest> sayHelloStreamBidi(@NonNull Pipeline<? super HelloReply> replies) {
+        if (sayHelloStreamBidi != null) {
+            return sayHelloStreamBidi.apply(replies);
+        }
+        // this will likely kill the server, but it's not supposed to be invoked unless the test does that,
+        // in which case the test must provide an implementation.
+        return null;
+    }
+
+    public void setSayHello(Function<HelloRequest, HelloReply> sayHello) {
+        this.sayHello = sayHello;
+    }
+
+    public void setSayHelloStreamReply(BiConsumer<HelloRequest, Pipeline<? super HelloReply>> sayHelloStreamReply) {
+        this.sayHelloStreamReply = sayHelloStreamReply;
+    }
+
+    public void setSayHelloStreamRequest(
+            Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamRequest) {
+        this.sayHelloStreamRequest = sayHelloStreamRequest;
+    }
+
+    public void setSayHelloStreamBidi(
+            Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamBidi) {
+        this.sayHelloStreamBidi = sayHelloStreamBidi;
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PbjGrpcServerGreeterHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PbjGrpcServerGreeterHandle.java
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import com.hedera.pbj.grpc.helidon.PbjRouting;
+import io.helidon.webserver.WebServer;
+
+/** A Greeter handle for the PBJ GRPC server implementation. */
+class PbjGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
+    private final int port;
+
+    private WebServer server;
+
+    public PbjGrpcServerGreeterHandle(final int port) {
+        this.port = port;
+    }
+
+    @Override
+    public synchronized void start() {
+        if (server != null) {
+            throw new IllegalStateException("Server already started");
+        }
+        server = WebServer.builder()
+                .port(port)
+                .addRouting(PbjRouting.builder().service(this))
+                .maxPayloadSize(10000)
+                .build()
+                .start();
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PortsAllocator.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PortsAllocator.java
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A utility to allocate AutoCloseable port numbers so that tests that start TCP servers can run in parallel.
+ */
+class PortsAllocator {
+    /** An AutoCloseable port number. */
+    public record Port(int port, PortsAllocator portsAllocator) implements AutoCloseable {
+        @Override
+        public void close() {
+            portsAllocator.release(port);
+        }
+    }
+
+    private final int min;
+    private final int max;
+
+    private final Set<Integer> busyPorts = new HashSet<>();
+
+    public PortsAllocator(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public Port acquire() {
+        synchronized (busyPorts) {
+            if (busyPorts.size() >= max - min + 1) {
+                // If this becomes too limiting, implement a more complex blocking behavior to wait until a port is free
+                throw new IllegalStateException("Too many busy ports. Reduce concurrency or increase the ports range.");
+            }
+            int port;
+            do {
+                port = (int) (Math.random() * (max - min + 1) + min);
+            } while (busyPorts.contains(port));
+            busyPorts.add(port);
+            return new Port(port, this);
+        }
+    }
+
+    private void release(final int port) {
+        synchronized (busyPorts) {
+            busyPorts.remove(port);
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
This is the first part of the comprehensive test for PBJ GRPC client. In this PR, a base test infrastructure is introduced that allows us to run GRPC client tests against multiple GRPC server implementations. Currently the infra supports two servers:
* PBJ GRPC server on top of Helidon HTTP2 server
* Google Protobuf GRPC server on top of Netty

More server implementations can be added in the future if desired.

Secondly, a happy case test is implemented which basically replicates the existing `GrpcClientTest.java`. However, it now verifies PBJ GRPC client behavior against those multiple GRPC server implementations as opposed to testing against our own PBJ server only. All the tests still pass, including against the Google GRPC server, which proves that our PBJ GRPC client implementation isn't too bad.

Thirdly, a minor renaming of an internal GrpcCall method is implemented per https://github.com/hashgraph/pbj/pull/524#discussion_r2159744771

In the future, we'll be adding more tests to check various scenarios and edge cases, and ensure our GRPC client works well with any GRPC server.

**Related issue(s)**:

Fixes #527 

**Notes for reviewer**:
All tests pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
