### PR TITLE
test: more tests for GRPC client

### DIFF
--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -4,13 +4,17 @@ package com.hedera.pbj.grpc.client.helidon;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.grpc.GrpcCall;
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.GrpcStatus;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2Headers;
@@ -23,6 +27,11 @@ import io.helidon.webclient.http2.Http2ClientStream;
 import io.helidon.webclient.http2.Http2StreamConfig;
 import io.helidon.webclient.http2.StreamTimeoutException;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 /**
  * A blocking, non-buffering wrapper around an HTTP2 stream that serves a single GRPC call.
@@ -44,6 +53,8 @@ import java.time.Duration;
 public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT> {
 
     private static final BufferData EMPTY_BUFFER_DATA = BufferData.empty();
+    private static final HeaderName GRPC_STATUS = HeaderNames.createFromLowercase("grpc-status");
+    private static final HeaderName GRPC_MESSAGE = HeaderNames.createFromLowercase("grpc-message");
 
     private final PbjGrpcClient grpcClient;
     private final Codec<RequestT> requestCodec;
@@ -159,21 +170,28 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
                     headersRead = true;
                 } catch (StreamTimeoutException ignored) {
                     // FUTURE WORK: implement an uber timeout to return
+
+                    // Ping the server on every timeout. This seems to create a bit of extra traffic.
+                    // However, this seems to be the only way to detect a broken connection. Otherwise, we'd never know
+                    // if the server died.
+                    // FUTURE WORK: consider a separate KeepAlive timeout for these pings, so that we don't flood the
+                    // network.
+                    // NOTE: Google GRPC server drops the connection if pinged right after receiving the headers - it
+                    // complains about the frame size of 64K with 16K max allowed. It's unclear how/why this even
+                    // happens. However, pinging on timeout seems to work smoothly so far.
+                    clientStream.sendPing();
                 }
-            } while (!headersRead);
+            } while (!headersRead && isStreamOpen());
 
             // read data from stream
             final PbjGrpcDatagramReader datagramReader = new PbjGrpcDatagramReader();
-            while (isStreamOpen()) {
-                if (clientStream.trailers().isDone() || !clientStream.hasEntity()) {
-                    // Trailers or EndOfStream received
-                    break;
-                }
-
+            while (isStreamOpen() && !clientStream.trailers().isDone() && clientStream.hasEntity()) {
                 final Http2FrameData frameData;
                 try {
                     frameData = clientStream.readOne(grpcClient.getConfig().readTimeout());
                 } catch (StreamTimeoutException e) {
+                    // Check if the connection is alive. See a comment above about the KeepAlive timeout.
+                    clientStream.sendPing();
                     // FUTURE WORK: implement an uber timeout to return
                     continue;
                 }
@@ -194,19 +212,92 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
                             pipeline.onNext(reply);
                         } catch (ParseException e) {
                             pipeline.onError(e);
+                            // We won't be able to proceed probably because parsing failed.
+                            // Also, we've just reported an error to the pipeline, which
+                            // means the GRPC call is done. So we finish the call.
+                            // We don't even bother processing headers/trailers at this point.
+                            // The goal is to avoid calling pipeline.onComplete() below.
+                            return;
                         }
                     }
                     // If there's no any complete datagrams yet, then simply keep spinning this loop until
                     // enough data is received.
                 }
             }
+
+            // Google GRPC server can report an erroneous grpc-status in the headers.
+            if (processHeaders(clientStream.readHeaders().httpHeaders())) {
+                return;
+            }
+            // PBJ GRPC server reports erroneous grpc-status in the trailer headers, because GRPC specification...
+            // Google GRPC server can also use trailers to report the status in certain circumstances, such as when it
+            // dies.
+            // However, when it dies, the connection is often closed before we manage to receive anything, so we end up
+            // with no errors and no replies whatsoever. In fact, we may never even receive the headers in a loop above,
+            // we'll exit the loop because the stream gets closed though.
+            try {
+                final Headers trailers = clientStream
+                        .trailers()
+                        .get(grpcClient.getConfig().readTimeout().toMillis(), TimeUnit.MILLISECONDS);
+                if (processHeaders(trailers)) {
+                    return;
+                }
+            } catch (InterruptedException ignored) {
+                // This is okayish. Reporting this as a replies error doesn't make sense. Re-throwing has no useful
+                // effect.
+            } catch (ExecutionException e) {
+                pipeline.onError(e);
+                return;
+            } catch (TimeoutException ignored) {
+                // This is okay, the server doesn't support trailers or died, or the trailers got lost.
+            }
+            // Luckily, there's no any other places through which a grpc-status can be reported,
+            // so the above two calls should cover all the possible cases.
+
+            pipeline.onComplete();
         } catch (Throwable t) {
             // This method runs in the Helidon WebClient executor, so there's no need to re-throw the exception
             // as this won't produce any useful effects. We only report it to the replies pipeline here for
             // the application code to handle it:
             pipeline.onError(t);
+        } finally {
+            clientStream.close();
         }
-        clientStream.close();
-        pipeline.onComplete();
+    }
+
+    /** Returns all values of a header, or empty list if header is missing. */
+    private static List<String> fetchHeader(final Headers headers, final HeaderName header) {
+        return headers.contains(header) ? headers.get(header).allValues() : List.of();
+    }
+
+    /**
+     * Process HTTP headers. This method checks the grpc-status header and reports errors to the pipeline
+     * if the status isn't OK. In the future, this method could process other headers as well.
+     * @param headers HTTP headers
+     * @return true if pipeline.onError() was called
+     */
+    private boolean processHeaders(final Headers headers) {
+        boolean onErrorCalled = false;
+        final String message = fetchHeader(headers, GRPC_MESSAGE).stream().collect(Collectors.joining(". "));
+
+        for (String value : fetchHeader(headers, GRPC_STATUS)) {
+            try {
+                final int grpcStatus = Integer.parseInt(value);
+                if (grpcStatus != 0) {
+                    // Not OK
+                    pipeline.onError(new GrpcException(
+                            grpcStatus < GrpcStatus.values().length
+                                    ? GrpcStatus.values()[grpcStatus]
+                                    : GrpcStatus.UNKNOWN,
+                            message));
+                    onErrorCalled = true;
+                }
+            } catch (NumberFormatException ignored) {
+                // a bad server sent an invalid header. This shouldn't happen really.
+                System.err.println(String.format("Invalid GRPC_STATUS: %s", value));
+            }
+        }
+
+        return onErrorCalled;
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GoogleProtobufGrpcServerGreeterHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GoogleProtobufGrpcServerGreeterHandle.java
@@ -13,15 +13,19 @@ import pbj.integration.tests.HelloReply;
 import pbj.integration.tests.HelloRequest;
 
 /** A Greeter handle for the Google Protobuf GRPC server implementation. */
-class GoogleProtobufGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
+public class GoogleProtobufGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
     /** Greeter service implementation for Google GRPC server. */
     private class GreeterGrpcImpl extends GreeterGrpc.GreeterImplBase {
         @Override
         public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
-            final pbj.integration.tests.pbj.integration.tests.HelloReply reply =
-                    GoogleProtobufGrpcServerGreeterHandle.this.sayHello(adaptRequest(request));
-            responseObserver.onNext(adaptReply(reply));
-            responseObserver.onCompleted();
+            try {
+                final pbj.integration.tests.pbj.integration.tests.HelloReply reply =
+                        GoogleProtobufGrpcServerGreeterHandle.this.sayHello(adaptRequest(request));
+                responseObserver.onNext(adaptReply(reply));
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                responseObserver.onError(e);
+            }
         }
 
         @Override
@@ -162,6 +166,17 @@ class GoogleProtobufGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
     public synchronized void stop() {
         if (server != null) {
             server.shutdown();
+            server = null;
+        }
+    }
+
+    @Override
+    public synchronized void stopNow() {
+        if (server != null) {
+            try {
+                server.shutdownNow().awaitTermination();
+            } catch (InterruptedException ignored) {
+            }
             server = null;
         }
     }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcServerGreeterHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcServerGreeterHandle.java
@@ -17,16 +17,21 @@ import pbj.integration.tests.pbj.integration.tests.HelloRequest;
  * A test must provide implementations for service methods that it will call. The default implementations
  * are either no-ops, or return hard-coded results, or nulls which may kill the low-level server implementation.
  */
-abstract class GrpcServerGreeterHandle implements GreeterInterface, AutoCloseable {
+public abstract class GrpcServerGreeterHandle implements GreeterInterface, AutoCloseable {
 
     private Function<HelloRequest, HelloReply> sayHello;
     private BiConsumer<HelloRequest, Pipeline<? super HelloReply>> sayHelloStreamReply;
     private Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamRequest;
     private Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamBidi;
 
-    abstract void start();
+    /** Start the server. */
+    public abstract void start();
 
-    abstract void stop();
+    /** Shutdown the server in an orderly manner. */
+    public abstract void stop();
+
+    /** Force shutdown, potentially breaking existing client connections. */
+    public abstract void stopNow();
 
     @Override
     public void close() {

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcTestUtils.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcTestUtils.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.grpc.GrpcClient;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.api.WebClient;
+import java.time.Duration;
+import java.util.Optional;
+
+/** Misc utils for GRPC tests. */
+public class GrpcTestUtils {
+    public static final PortsAllocator PORTS = new PortsAllocator(8666, 10666);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(1);
+
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+
+    public static final Options PROTO_OPTIONS =
+            new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
+
+    /** sleep() for non-blocking GRPC calls to wait for results to arrive. */
+    public static void sleep(final GrpcClient grpcClient) {
+        // Wait a tad longer than the read timeout:
+        try {
+            Thread.sleep(((PbjGrpcClient) grpcClient).getConfig().readTimeout().plusSeconds(2));
+        } catch (InterruptedException e) {
+        }
+    }
+
+    public static GrpcClient createGrpcClient(final int port, final ServiceInterface.RequestOptions requestOptions) {
+        final Tls tls = Tls.builder().enabled(false).build();
+        final WebClient webClient =
+                WebClient.builder().baseUri("http://localhost:" + port).tls(tls).build();
+
+        final PbjGrpcClientConfig config =
+                new PbjGrpcClientConfig(READ_TIMEOUT, tls, requestOptions.authority(), requestOptions.contentType());
+
+        return new PbjGrpcClient(webClient, config);
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PbjGrpcServerGreeterHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PbjGrpcServerGreeterHandle.java
@@ -5,7 +5,7 @@ import com.hedera.pbj.grpc.helidon.PbjRouting;
 import io.helidon.webserver.WebServer;
 
 /** A Greeter handle for the PBJ GRPC server implementation. */
-class PbjGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
+public class PbjGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
     private final int port;
 
     private WebServer server;
@@ -33,5 +33,14 @@ class PbjGrpcServerGreeterHandle extends GrpcServerGreeterHandle {
             server.stop();
             server = null;
         }
+    }
+
+    @Override
+    public void stopNow() {
+        // In Helidon, stop() actually closes the server socket on the spot.
+        // However, there's no way to abruptly kill open connections, other than by throwing exceptions maybe.
+        // We do have tests that throw exceptions on the server thread, so I think we cover those cases.
+        // We also have tests that run the server in a separate JVM and kill the process, so we do cover all the cases.
+        stop();
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PortsAllocator.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PortsAllocator.java
@@ -7,7 +7,7 @@ import java.util.Set;
 /**
  * A utility to allocate AutoCloseable port numbers so that tests that start TCP servers can run in parallel.
  */
-class PortsAllocator {
+public class PortsAllocator {
     /** An AutoCloseable port number. */
     public record Port(int port, PortsAllocator portsAllocator) implements AutoCloseable {
         @Override

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/SeparateJVMRunner.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/SeparateJVMRunner.java
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc.specialized;
+
+import com.hedera.pbj.integration.test.grpc.GrpcServerGreeterHandle;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+/**
+ * Utility to run a GRPC server in a separate process.
+ * While it inherits from the GrpcServerGreeterHandle to allow calling start/stop,
+ * it does NOT support setting service implementations directly. The specializedClass
+ * must implement the specialized behavior for the service, and it will run in a separate JVM
+ * using the exact same class path as the current JVM.
+ */
+public class SeparateJVMRunner extends GrpcServerGreeterHandle {
+    private final Class<?> specializedClass;
+    private final int port;
+    private final List<String> args;
+
+    private Process process;
+
+    public SeparateJVMRunner(Class<?> specializedClass, int port, List<String> args) {
+        this.specializedClass = specializedClass;
+        this.port = port;
+        this.args = args;
+    }
+
+    @Override
+    public void start() {
+        final String javaHome = System.getProperty("java.home");
+        final Path javaPath = Paths.get(javaHome, "bin", "java");
+
+        final ProcessBuilder pb = new ProcessBuilder(
+                javaPath.toString(),
+                "-cp",
+                ManagementFactory.getRuntimeMXBean().getClassPath(),
+                specializedClass.getName(),
+                Integer.toString(port));
+        if (args != null && !args.isEmpty()) {
+            pb.command(Stream.concat(pb.command().stream(), args.stream()).toList());
+        }
+
+        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+
+        try {
+            process = pb.start();
+
+            // Block until the specializedClass main() indicates the server is running:
+            process.inputReader().read();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        process.destroy();
+    }
+
+    @Override
+    public void stopNow() {
+        process.destroyForcibly();
+        process.onExit().join();
+    }
+
+    @Override
+    public void setSayHello(Function<HelloRequest, HelloReply> sayHello) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSayHelloStreamReply(BiConsumer<HelloRequest, Pipeline<? super HelloReply>> sayHelloStreamReply) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSayHelloStreamRequest(
+            Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamRequest) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSayHelloStreamBidi(
+            Function<Pipeline<? super HelloReply>, Pipeline<? super HelloRequest>> sayHelloStreamBidi) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/dying/DyingServerTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/dying/DyingServerTest.java
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc.specialized.dying;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.integration.test.grpc.GrpcServerGreeterHandle;
+import com.hedera.pbj.integration.test.grpc.GrpcTestUtils;
+import com.hedera.pbj.integration.test.grpc.PortsAllocator;
+import com.hedera.pbj.integration.test.grpc.specialized.SeparateJVMRunner;
+import com.hedera.pbj.runtime.grpc.GrpcClient;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import pbj.integration.tests.pbj.integration.tests.GreeterInterface;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+@ParameterizedClass
+@MethodSource("testClassArguments")
+public class DyingServerTest {
+    private final Class<? extends GrpcServerGreeterHandle> serverClass;
+
+    public DyingServerTest(Class<? extends GrpcServerGreeterHandle> serverClass) {
+        this.serverClass = serverClass;
+    }
+
+    static Stream<Arguments> testClassArguments() {
+        return Stream.of(
+                Arguments.of(PbjGrpcServerGreeterClientStreamingHandle.class),
+                Arguments.of(GoogleProtobufGrpcServerGreeterClientStreamingHandle.class));
+    }
+
+    /**
+     * Test when a server dies in the middle of client streaming requests, or in its onComplete.
+     * @param dieInOnComplete true if server dies in onComplete, false if it dies in the middle
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testClientStreamingMethodServerDiesInTheMiddle(final boolean dieInOnComplete) {
+        try (final PortsAllocator.Port port = GrpcTestUtils.PORTS.acquire();
+                final GrpcServerGreeterHandle server =
+                        new SeparateJVMRunner(serverClass, port.port(), List.of(Boolean.toString(dieInOnComplete)))) {
+            server.start();
+
+            final GrpcClient grpcClient = GrpcTestUtils.createGrpcClient(port.port(), GrpcTestUtils.PROTO_OPTIONS);
+            final GreeterInterface.GreeterClient client =
+                    new GreeterInterface.GreeterClient(grpcClient, GrpcTestUtils.PROTO_OPTIONS);
+
+            final List<HelloReply> replies = new ArrayList<>();
+            final List<Throwable> errors = new ArrayList<>();
+            final AtomicBoolean completed = new AtomicBoolean(false);
+            final Pipeline<? super HelloRequest> requests = client.sayHelloStreamRequest(new Pipeline<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    // no-op
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    errors.add(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    completed.set(true);
+                }
+
+                @Override
+                public void onNext(HelloReply item) throws RuntimeException {
+                    replies.add(item);
+                }
+            });
+
+            requests.onNext(HelloRequest.newBuilder().name("test name 1").build());
+            requests.onNext(HelloRequest.newBuilder().name("test name 2").build());
+            if (!dieInOnComplete) { // == die in the middle then
+                // Here we kill the server process:
+                server.stopNow();
+                assertThrows(
+                        UncheckedIOException.class,
+                        () -> requests.onNext(
+                                HelloRequest.newBuilder().name("test name 3").build()));
+            } else {
+                requests.onNext(HelloRequest.newBuilder().name("test name 3").build());
+                requests.onComplete();
+            }
+
+            GrpcTestUtils.sleep(grpcClient);
+
+            assertEquals(List.of(), replies);
+
+            assertEquals(1, errors.size());
+            assertTrue(errors.get(0) instanceof UncheckedIOException);
+
+            assertFalse(completed.get());
+        }
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/dying/GoogleProtobufGrpcServerGreeterClientStreamingHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/dying/GoogleProtobufGrpcServerGreeterClientStreamingHandle.java
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc.specialized.dying;
+
+import com.hedera.pbj.integration.test.grpc.GoogleProtobufGrpcServerGreeterHandle;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.stream.Collectors;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+/** A specialized GRPC server handle implementation for SeparateJVMRunner. */
+public class GoogleProtobufGrpcServerGreeterClientStreamingHandle extends GoogleProtobufGrpcServerGreeterHandle {
+    public GoogleProtobufGrpcServerGreeterClientStreamingHandle(int port) {
+        super(port);
+    }
+
+    public static void main(String[] args) throws Exception {
+        // This is an internal class. If someone calls it w/o proper args, let it error out as is.
+        final int port = Integer.parseInt(args[0]);
+        final boolean dieInOnComplete = args.length > 1 ? Boolean.parseBoolean(args[1]) : false;
+
+        final GoogleProtobufGrpcServerGreeterClientStreamingHandle handle =
+                new GoogleProtobufGrpcServerGreeterClientStreamingHandle(port);
+        handle.setSayHelloStreamRequest(replies -> {
+            final List<HelloRequest> requests = new ArrayList<>();
+            return new Pipeline<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    subscription.request(Long.MAX_VALUE); // turn off flow control
+                }
+
+                @Override
+                public void onNext(HelloRequest item) {
+                    requests.add(item);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    replies.onError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    if (dieInOnComplete) {
+                        // Die here and now, no clean up:
+                        Runtime.getRuntime().halt(-666);
+                    }
+                    final HelloReply reply = HelloReply.newBuilder()
+                            .message("Hello "
+                                    + requests.stream().map(HelloRequest::name).collect(Collectors.joining(", "))
+                                    + "!")
+                            .build();
+                    replies.onNext(reply);
+                    replies.onComplete();
+                }
+            };
+        });
+        handle.start();
+
+        // Tell the SeparateJVMRunner we're up and running:
+        System.out.print('k');
+
+        // Keep running main() until the process is killed externally.
+        while (true) {
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/dying/PbjGrpcServerGreeterClientStreamingHandle.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/specialized/dying/PbjGrpcServerGreeterClientStreamingHandle.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc.specialized.dying;
+
+import com.hedera.pbj.integration.test.grpc.PbjGrpcServerGreeterHandle;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.stream.Collectors;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+/** A specialized GRPC server handle implementation for SeparateJVMRunner. */
+public class PbjGrpcServerGreeterClientStreamingHandle extends PbjGrpcServerGreeterHandle {
+    public PbjGrpcServerGreeterClientStreamingHandle(int port) {
+        super(port);
+    }
+
+    public static void main(String[] args) throws Exception {
+        // This is an internal class. If someone calls it w/o proper args, let it error out as is.
+        final int port = Integer.parseInt(args[0]);
+        final boolean dieInOnComplete = args.length > 1 ? Boolean.parseBoolean(args[1]) : false;
+
+        final PbjGrpcServerGreeterClientStreamingHandle handle = new PbjGrpcServerGreeterClientStreamingHandle(port);
+        handle.setSayHelloStreamRequest(replies -> {
+            final List<HelloRequest> requests = new ArrayList<>();
+            return new Pipeline<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    subscription.request(Long.MAX_VALUE); // turn off flow control
+                }
+
+                @Override
+                public void onNext(HelloRequest item) {
+                    requests.add(item);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    replies.onError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    if (dieInOnComplete) {
+                        // Die here and now, no clean up:
+                        Runtime.getRuntime().halt(-666);
+                    }
+                    final HelloReply reply = HelloReply.newBuilder()
+                            .message("Hello "
+                                    + requests.stream().map(HelloRequest::name).collect(Collectors.joining(", "))
+                                    + "!")
+                            .build();
+                    replies.onNext(reply);
+                    replies.onComplete();
+                }
+            };
+        });
+        handle.start();
+
+        // Tell the SeparateJVMRunner we're up and running:
+        System.out.print('k');
+
+        // Keep running main() until the process is killed externally.
+        while (true) {
+            Thread.sleep(1000);
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
Adding more tests for PBJ GRPC client to verify various scenarios, especially failures, including a GRPC server dying. In addition to existing tests that run both the server and the client in the current JVM, 4 more tests are added that run the server in a separate JVM, allowing us to kill the server process w/o any clean up or a chance to close the call gracefully, and then see what happens on the client side.

I believe we're covering many if not all possible scenarios. If you have more ideas, please let me know in the PR comments and I'll file more issues and will open more PRs in the future. Otherwise, we'll consider this to be the final PR to complete the PBJ GRPC client testing for now.

**Related issue(s)**:

Fixes #531 

**Notes for reviewer**:
All tests pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
