### PR TITLE
build: update hiero-gradle-conventions to v0.4.5

### DIFF
--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
     includeBuild("../pbj-core") // use locally built 'pbj-core' (Gradle plugin)
 }
 
-plugins { id("org.hiero.gradle.build") version "0.4.3" }
+plugins { id("org.hiero.gradle.build") version "0.4.5" }
 
 dependencyResolutionManagement {
     // To use locally built 'pbj-runtime'


### PR DESCRIPTION
**Description**:

Update hiero-gradle-conventions to v0.4.5 to fix issue with OSSRH URL in Maven Central.

**Related Issue(s)**:

Fixes #534
