### PR TITLE
chore: upgrade org.hiero.gradle.build and byte-buddy

### DIFF
--- a/pbj-core/hiero-dependency-versions/build.gradle.kts
+++ b/pbj-core/hiero-dependency-versions/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies.constraints {
     api("com.google.guava:guava:33.4.8-jre") { because("com.google.common") }
     api("com.google.protobuf:protobuf-java:$protobuf") { because("com.google.protobuf") }
     api("com.google.protobuf:protobuf-java-util:$protobuf") { because("com.google.protobuf.util") }
+    api("net.bytebuddy:byte-buddy:1.17.6") { because("net.bytebuddy") }
     api("org.assertj:assertj-core:3.27.3") { because("org.assertj.core") }
     api("org.junit.jupiter:junit-jupiter-api:$junit5") { because("org.junit.jupiter.api") }
     api("org.junit.jupiter:junit-jupiter-engine:$junit5") { because("org.junit.jupiter.engine") }

--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.4.3" }
+plugins { id("org.hiero.gradle.build") version "0.4.9" }
 
 javaModules {
     directory(".") {


### PR DESCRIPTION
**Description**:
Upgrading dependencies to make things work and use the latest build scripts.

See https://github.com/hiero-ledger/hiero-block-node/issues/1332#issuecomment-3034619999 for more info.

**Related issue(s)**:

Fixes #541

**Notes for reviewer**:
Builds and tests should work.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
