### PR TITLE
chore: upgrade to org.hiero.gradle.build 0.4.10

### DIFF
--- a/pbj-core/settings.gradle.kts
+++ b/pbj-core/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.4.9" }
+plugins { id("org.hiero.gradle.build") version "0.4.10" }
 
 javaModules {
     directory(".") {

--- a/pbj-integration-tests/settings.gradle.kts
+++ b/pbj-integration-tests/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
     includeBuild("../pbj-core") // use locally built 'pbj-core' (Gradle plugin)
 }
 
-plugins { id("org.hiero.gradle.build") version "0.4.9" }
+plugins { id("org.hiero.gradle.build") version "0.4.10" }
 
 dependencyResolutionManagement {
     // To use locally built 'pbj-runtime'


### PR DESCRIPTION
**Description**:
A follow-up for https://github.com/hashgraph/pbj/pull/542 to upgrade Hiero build scripts further in order to fix the snapshot publishing GitHub action as seen at https://github.com/hashgraph/pbj/actions/runs/16280450252/job/45968810413 and suggested at 
https://github.com/hiero-ledger/hiero-block-node/issues/1332#issuecomment-3073670825
and
https://github.com/hiero-ledger/hiero-block-node/issues/1332#issuecomment-3074040872

**Related issue(s)**:

Fixes #541 

**Notes for reviewer**:
Build should succeed.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
