### PR TITLE
fix: 552 Increased `Field.DEFAULT_MAX_SIZE` to 16M

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Field.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 public interface Field {
 
     /** The default maximum size of a repeated or length-encoded field (Bytes, String, Message, etc.). */
-    public static final long DEFAULT_MAX_SIZE = 2 * 1024 * 1024;
+    public static final long DEFAULT_MAX_SIZE = 16 * 1024 * 1024;
 
     /**
      * Is this field a repeated field. Repeated fields are lists of values rather than a single value.


### PR DESCRIPTION
**Description**:

This fix increases the message size to 16M

**Related issue(s)**:

Fixes #552 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
