### PR TITLE
chore: Increase JSON test buffer size again

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
@@ -22,7 +22,7 @@ public final class ProtoTestTools {
     private static final int BUFFER_SIZE = 1024 * 1024;
 
     /** Size for reusable test char buffers */
-    private static final int CHAR_BUFFER_SIZE = 8 * 1024 * 1024;
+    private static final int CHAR_BUFFER_SIZE = 16 * 1024 * 1024;
 
     /** Instance should never be created */
     private ProtoTestTools() {}


### PR DESCRIPTION
**Description**:
 - Generated `BlockTest` on [this PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/20430) fails again with,
```
java.nio.BufferOverflowException
	at java.base/java.nio.HeapCharBuffer.put(HeapCharBuffer.java:346)
	at java.base/java.nio.CharBuffer.put(CharBuffer.java:1461)
	at com.hedera.pbj.runtime@0.11.6/com.hedera.pbj.runtime.test.CharBufferToWritableSequentialData.writeUTF8(CharBufferToWritableSequentialData.java:65)
	at com.hedera.pbj.runtime@0.11.6/com.hedera.pbj.runtime.JsonCodec.write(JsonCodec.java:57)
	at com.hedera.node.hapi@0.65.0-SNAPSHOT/com.hedera.hapi.block.stream.tests.BlockTest.testBlockAgainstProtoC(BlockTest.java:106)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
```