### PR TITLE
test: cover PbjGrpcClient

### DIFF
--- a/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientTest.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientTest.java
@@ -47,7 +47,6 @@ public class PbjGrpcClientTest {
 
         final PbjGrpcClient client = new PbjGrpcClient(webClient, config);
 
-        assertNotNull(client);
         assertEquals(webClient, client.getWebClient());
         assertEquals(http2Client, client.getHttp2Client());
         assertEquals(config, client.getConfig());


### PR DESCRIPTION
**Description**:
Covering `PbjGrpcClient` with unit tests.

There's only two factory methods that are impossible to cover because they call deep into Helidon classes, including their package-private methods, which is impossible/too-very-difficult to mock (it would require using PowerMock, which doesn't support Java modules.)

This is fine because there's not any logic inside those factory methods. So we're not missing a lot.

**Related issue(s)**:

Fixes #589 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
