### PR TITLE
feat: Use HTTP2 streams to improve GRPC client performance

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -562,6 +562,11 @@ public final class ServiceGenerator {
                             this.requestOptions = Objects.requireNonNull(requestOptions);
                         }
                 
+                        @Override
+                        public void close() {
+                            grpcClient.close();
+                        }
+
                 $methodImplementations
                     }
                 }

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -18,8 +18,6 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2StreamState;
-import io.helidon.webclient.api.ClientConnection;
-import io.helidon.webclient.http2.Http2ClientConnection;
 import io.helidon.webclient.http2.Http2ClientStream;
 import io.helidon.webclient.http2.StreamTimeoutException;
 import java.util.List;
@@ -62,7 +60,7 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
      * Create a new GRPC call, start a replies receiving loop in the underlying Helidon WebClient executor,
      * and send client HTTP2 headers.
      * @param grpcClient GRPC client
-     * @param clientConnection a client connection
+     * @param clientStream a client stream
      * @param requestOptions options such as the authority, content type, etc.
      * @param fullMethodName a full GRPC method name that includes the fully-qualified service name and the method name
      * @param requestCodec a PBJ codec for requests that MUST correspond to the content type in the requestOptions
@@ -71,7 +69,7 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
      */
     PbjGrpcCall(
             final PbjGrpcClient grpcClient,
-            final ClientConnection clientConnection,
+            final Http2ClientStream clientStream,
             final ServiceInterface.RequestOptions requestOptions,
             final String fullMethodName,
             final Codec<RequestT> requestCodec,
@@ -82,8 +80,7 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
         this.replyCodec = replyCodec;
         this.pipeline = pipeline;
 
-        final Http2ClientConnection connection = grpcClient.createHttp2ClientConnection(clientConnection);
-        this.clientStream = this.grpcClient.createPbjGrpcClientStream(connection, clientConnection);
+        this.clientStream = clientStream;
 
         // send HEADERS frame
         final WritableHeaders<?> headers = WritableHeaders.create();

--- a/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
@@ -105,8 +105,6 @@ public class PbjGrpcCallTest {
     private Headers headers;
 
     private PbjGrpcCall createCall(final ServiceInterface.RequestOptions options) {
-        doReturn(connection).when(grpcClient).createHttp2ClientConnection(clientConnection);
-        doReturn(grpcClientStream).when(grpcClient).createPbjGrpcClientStream(connection, clientConnection);
         doReturn(webClient).when(grpcClient).getWebClient();
         doReturn(executor).when(webClient).executor();
 
@@ -115,7 +113,7 @@ public class PbjGrpcCallTest {
         // The config is only read in the receiving loop:
         lenient().doReturn(config).when(grpcClient).getConfig();
 
-        return new PbjGrpcCall(grpcClient, clientConnection, options, METHOD_NAME, requestCodec, replyCodec, pipeline);
+        return new PbjGrpcCall(grpcClient, grpcClientStream, options, METHOD_NAME, requestCodec, replyCodec, pipeline);
     }
 
     @ParameterizedTest
@@ -125,9 +123,6 @@ public class PbjGrpcCallTest {
         final PbjGrpcCall call = createCall(
                 new Options(Optional.ofNullable(authority), ServiceInterface.RequestOptions.APPLICATION_GRPC));
         assertNotNull(call);
-
-        verify(grpcClient, times(1)).createHttp2ClientConnection(clientConnection);
-        verify(grpcClient, times(1)).createPbjGrpcClientStream(connection, clientConnection);
 
         final ArgumentCaptor<Http2Headers> http2HeadersCaptor = ArgumentCaptor.forClass(Http2Headers.class);
         verify(grpcClientStream, times(1)).writeHeaders(http2HeadersCaptor.capture(), eq(false));

--- a/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
+++ b/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
@@ -152,7 +152,7 @@ class PbjProtocolHandlerTest {
         assertThat(route.failedGrpcRequestCounter().count()).isZero();
         assertThat(route.failedHttpRequestCounter().count()).isZero();
         assertThat(route.failedUnknownRequestCounter().count()).isZero();
-        assertThat(handler.streamState()).isEqualTo(Http2StreamState.HALF_CLOSED_REMOTE);
+        assertThat(handler.streamState()).isEqualTo(Http2StreamState.CLOSED);
     }
 
     /**
@@ -177,7 +177,7 @@ class PbjProtocolHandlerTest {
         assertThat(route.failedGrpcRequestCounter().count()).isZero();
         assertThat(route.failedHttpRequestCounter().count()).isZero();
         assertThat(route.failedUnknownRequestCounter().count()).isZero();
-        assertThat(handler.streamState()).isEqualTo(Http2StreamState.HALF_CLOSED_REMOTE);
+        assertThat(handler.streamState()).isEqualTo(Http2StreamState.CLOSED);
     }
 
     /**
@@ -289,7 +289,7 @@ class PbjProtocolHandlerTest {
                 .contains(entry("Content-Type", "application/grpc+proto"), entry("grpc-accept-encoding", "identity"));
 
         // The stream should be closed
-        assertThat(handler.streamState()).isEqualTo(Http2StreamState.HALF_CLOSED_REMOTE);
+        assertThat(handler.streamState()).isEqualTo(Http2StreamState.CLOSED);
     }
 
     @Test

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
@@ -9,7 +9,7 @@ import com.hedera.pbj.runtime.Codec;
  * It's capable of creating GrpcCall objects that applications can use to send requests to a GRPC service
  * and receive replies from the service through the supplied Pipeline instance.
  */
-public interface GrpcClient {
+public interface GrpcClient extends AutoCloseable {
     /**
      * Create a new GRPC call.
      *
@@ -22,4 +22,9 @@ public interface GrpcClient {
      */
     <RequestT, ReplyT> GrpcCall<RequestT, ReplyT> createCall(
             String fullMethodName, Codec<RequestT> requestCodec, Codec<ReplyT> replyCodec, Pipeline<ReplyT> pipeline);
+
+    /**
+     * Closes this GrpcClient instance releasing all resources, such as open network connections etc.
+     */
+    void close();
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
@@ -50,7 +50,7 @@ import java.util.Optional;
  * In the application code, you will simply create a new class implementing the {@code HelloService} interface, and
  * register it with your webserver in whatever way is appropriate for your webserver.
  */
-public interface ServiceInterface {
+public interface ServiceInterface extends AutoCloseable {
     /** Represents the metadata of a method in a gRPC service. */
     interface Method {
         String name();
@@ -127,4 +127,9 @@ public interface ServiceInterface {
     Pipeline<? super Bytes> open(
             @NonNull Method method, @NonNull RequestOptions opts, @NonNull Pipeline<? super Bytes> responses)
             throws GrpcException;
+
+    /**
+     * Closes this ServiceInterface instance releasing all resources, such as open network connections etc.
+     */
+    default void close() {}
 }


### PR DESCRIPTION
**Description**:
The main goal of this PR is to improve the PBJ GRPC Client performance by establishing an HTTP2 connection only once and then re-using it by creating new HTTP2 streams to serve GRPC requests.

This fix also addresses a couple of bugs:
1. The client now properly closes the HTTP2 connection (via the `AutoClosable` interface that it now implements). Previously, it didn't, and the JVM process/system ran out of available client sockets after processing about 16K requests (back when we didn't use streams and opened a new connection for every request.) With this fix, even if we didn't switch to using streams, we'd still be able to release client sockets properly.
2. The server now properly closes the HTTP2 streams opened to serve client requests. W/o this fix and with default settings the server would run out of 8192 available streams and stop serving requests on an existing HTTP2 connection.

**Related issue(s)**:

Fixes #591 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
