### PR TITLE
perf: introduce GoogleGrpcBench

### DIFF
--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GoogleGreeterService.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GoogleGreeterService.java
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.grpc.google;
+
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import pbj.integration.tests.GreeterGrpc;
+import pbj.integration.tests.HelloReply;
+import pbj.integration.tests.HelloRequest;
+
+/** Greeter service implementation for Google GRPC server. */
+class GoogleGreeterService extends GreeterGrpc.GreeterImplBase {
+    static final HelloRequest EMPTY_REQUEST =
+            HelloRequest.newBuilder().setName("").build();
+    static final HelloReply EMPTY_REPLY = HelloReply.newBuilder().setMessage("").build();
+
+    private final GooglePayloadWeight weight;
+    private final int streamCount;
+
+    /**
+     * Constructor.
+     */
+    public GoogleGreeterService(final GooglePayloadWeight weight, final int streamCount) {
+        this.weight = weight;
+        this.streamCount = streamCount;
+    }
+
+    @Override
+    public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+        responseObserver.onNext(weight.replyProvider.apply(request));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void sayHelloStreamReply(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+        for (int i = 0; i < streamCount; i++) {
+            responseObserver.onNext(weight.replyProvider.apply(request));
+        }
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public StreamObserver<HelloRequest> sayHelloStreamRequest(StreamObserver<HelloReply> responseObserver) {
+        final boolean realFast = weight == GooglePayloadWeight.LIGHT;
+        final AtomicInteger counter = realFast ? new AtomicInteger() : null;
+        final List<HelloRequest> requests = realFast ? null : new ArrayList<>();
+        return new StreamObserver<HelloRequest>() {
+            public void onNext(HelloRequest request) {
+                if (realFast) {
+                    if (counter.incrementAndGet() == streamCount) {
+                        responseObserver.onNext(weight.replyProvider.apply(request));
+                        responseObserver.onCompleted();
+                    }
+                } else {
+                    requests.add(request);
+                    if (requests.size() == streamCount) {
+                        responseObserver.onNext(HelloReply.newBuilder()
+                                .setMessage(requests.stream()
+                                        .map(HelloRequest::getName)
+                                        .collect(Collectors.joining(",")))
+                                .build());
+                        responseObserver.onCompleted();
+                    }
+                }
+            }
+
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            public void onCompleted() {
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    public StreamObserver<HelloRequest> sayHelloStreamBidi(StreamObserver<HelloReply> responseObserver) {
+        final AtomicInteger counter = new AtomicInteger();
+        return new StreamObserver<HelloRequest>() {
+            public void onNext(HelloRequest request) {
+                for (int i = 0; i < streamCount; i++) {
+                    responseObserver.onNext(weight.replyProvider.apply(request));
+                }
+                if (counter.incrementAndGet() == streamCount) {
+                    responseObserver.onCompleted();
+                }
+            }
+
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            public void onCompleted() {
+                responseObserver.onCompleted();
+            }
+        };
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GoogleGrpcBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GoogleGrpcBench.java
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.grpc.google;
+
+import com.hedera.pbj.integration.grpc.GrpcTestUtils;
+import com.hedera.pbj.integration.grpc.PortsAllocator;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import pbj.integration.tests.GreeterGrpc;
+import pbj.integration.tests.HelloReply;
+import pbj.integration.tests.HelloRequest;
+
+/**
+ * A Google GRPC-based implementation of the GrpcBench, so that we can compare the performance
+ * between Google and PBJ.
+ * While the Google and PBJ APIs differ, the implementations are supposed to be otherwise identical,
+ * so that we compare apples to apples.
+ */
+@SuppressWarnings("unused")
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class GoogleGrpcBench {
+    private static final int INVOCATIONS = 20_000;
+
+    private record ServerHandle(Server server) implements AutoCloseable {
+        @Override
+        public void close() {
+            try {
+                server.shutdownNow().awaitTermination();
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        static ServerHandle start(final int port, final GoogleGreeterService service) {
+            try {
+                return new ServerHandle(Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
+                        .addService(service)
+                        .build()
+                        .start());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private record ClientHandle(ManagedChannel channel, GreeterGrpc.GreeterStub client) implements AutoCloseable {
+        @Override
+        public void close() {
+            channel.shutdown();
+        }
+
+        static ClientHandle createClient(final int port) {
+            final ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", port)
+                    .usePlaintext()
+                    .build();
+            return new ClientHandle(channel, GreeterGrpc.newStub(channel));
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class UnaryState {
+        @Param
+        GooglePayloadWeight weight;
+
+        PortsAllocator.Port port;
+        ServerHandle server;
+        ClientHandle client;
+
+        void setup(int streamCount) {
+            port = GrpcTestUtils.PORTS.acquire();
+            server = ServerHandle.start(port.port(), new GoogleGreeterService(weight, streamCount));
+            client = ClientHandle.createClient(port.port());
+        }
+
+        @Setup(Level.Invocation)
+        public void setup() {
+            setup(1);
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown() {
+            client.close();
+            client = null;
+            server.close();
+            server = null;
+            port.close();
+            port = null;
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class StreamingState {
+        @Param
+        GooglePayloadWeight weight;
+
+        @Param({"1", "10"})
+        int streamCount;
+
+        PortsAllocator.Port port;
+        ServerHandle server;
+        ClientHandle client;
+
+        void setup(int streamCount) {
+            port = GrpcTestUtils.PORTS.acquire();
+            server = ServerHandle.start(port.port(), new GoogleGreeterService(weight, streamCount));
+            client = ClientHandle.createClient(port.port());
+        }
+
+        @Setup(Level.Invocation)
+        public void setup() {
+            setup(streamCount);
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown() {
+            client.close();
+            client = null;
+            server.close();
+            server = null;
+            port.close();
+            port = null;
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchUnary(final UnaryState state, final Blackhole blackhole) {
+        for (int i = 1; i <= INVOCATIONS; i++) {
+            try {
+                final CountDownLatch latch = new CountDownLatch(1);
+                state.client.client.sayHello(state.weight.requestSupplier.get(), new StreamObserver<HelloReply>() {
+                    @Override
+                    public void onNext(HelloReply helloReply) {
+                        blackhole.consume(helloReply);
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        new RuntimeException(throwable).printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        latch.countDown();
+                    }
+                });
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } catch (Exception e) {
+                // Keep running because network may fail sometimes.
+                new RuntimeException(e).printStackTrace();
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchServerStreaming(final StreamingState state, final Blackhole blackhole) {
+        for (int i = 1; i <= INVOCATIONS; i++) {
+            try {
+                final CountDownLatch latch = new CountDownLatch(1);
+                state.client.client.sayHelloStreamReply(
+                        state.weight.requestSupplier.get(), new StreamObserver<HelloReply>() {
+                            @Override
+                            public void onNext(HelloReply helloReply) {
+                                blackhole.consume(helloReply);
+                            }
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                                new RuntimeException(throwable).printStackTrace();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                latch.countDown();
+                            }
+                        });
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } catch (Exception e) {
+                // Keep running because network may fail sometimes.
+                new RuntimeException(e).printStackTrace();
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchClientStreaming(final StreamingState state, final Blackhole blackhole) {
+        for (int i = 1; i <= INVOCATIONS; i++) {
+            try {
+                final CountDownLatch latch = new CountDownLatch(1);
+                final StreamObserver<HelloRequest> requests =
+                        state.client.client.sayHelloStreamRequest(new StreamObserver<HelloReply>() {
+                            @Override
+                            public void onNext(HelloReply helloReply) {
+                                blackhole.consume(helloReply);
+                            }
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                                new RuntimeException(throwable).printStackTrace();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                latch.countDown();
+                            }
+                        });
+                for (int j = 0; j < state.streamCount; j++) {
+                    requests.onNext(state.weight.requestSupplier.get());
+                }
+
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } catch (Exception e) {
+                // Keep running because network may fail sometimes.
+                new RuntimeException(e).printStackTrace();
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchBidiStreaming(final StreamingState state, final Blackhole blackhole) {
+        for (int i = 1; i <= INVOCATIONS; i++) {
+            try {
+                final CountDownLatch latch = new CountDownLatch(1);
+                final StreamObserver<HelloRequest> requests =
+                        state.client.client.sayHelloStreamBidi(new StreamObserver<HelloReply>() {
+                            @Override
+                            public void onNext(HelloReply helloReply) {
+                                blackhole.consume(helloReply);
+                            }
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                                new RuntimeException(throwable).printStackTrace();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                latch.countDown();
+                            }
+                        });
+                for (int j = 0; j < state.streamCount; j++) {
+                    requests.onNext(state.weight.requestSupplier.get());
+                }
+
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } catch (Exception e) {
+                // Keep running because network may fail sometimes.
+                new RuntimeException(e).printStackTrace();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(GoogleGrpcBench.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GooglePayloadWeight.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GooglePayloadWeight.java
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.grpc.google;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+import pbj.integration.tests.HelloReply;
+import pbj.integration.tests.HelloRequest;
+
+/**
+ * Specifies how "heavy" a benchmark should be in terms of the message payload size.
+ */
+public enum GooglePayloadWeight {
+    LIGHT(() -> GoogleGreeterService.EMPTY_REQUEST, request -> GoogleGreeterService.EMPTY_REPLY),
+    NORMAL(
+            () -> HelloRequest.newBuilder().setName("a".repeat(256)).build(),
+            request -> HelloReply.newBuilder().setMessage(request.getName()).build()),
+    HEAVY(
+            () -> HelloRequest.newBuilder().setName("a".repeat(8192)).build(),
+            request -> HelloReply.newBuilder().setMessage(request.getName()).build());
+
+    public final Supplier<HelloRequest> requestSupplier;
+    public final Function<HelloRequest, HelloReply> replyProvider;
+
+    GooglePayloadWeight(
+            final Supplier<HelloRequest> requestSupplier, final Function<HelloRequest, HelloReply> replyProvider) {
+        this.requestSupplier = requestSupplier;
+        this.replyProvider = replyProvider;
+    }
+}


### PR DESCRIPTION
**Description**:
Introducing a `GoogleGrpcBench` that is a replica of the recently added `GrpcBench`, but is implemented using the Google GRPC server/client. Here's the results for Google:

```
Benchmark                             (streamCount)  (weight)   Mode  Cnt      Score      Error  Units
GoogleGrpcBench.benchBidiStreaming                1     LIGHT  thrpt    5  11363.449 ± 1201.192  ops/s
GoogleGrpcBench.benchBidiStreaming                1    NORMAL  thrpt    5  10717.476 ±  118.145  ops/s
GoogleGrpcBench.benchBidiStreaming                1     HEAVY  thrpt    5   8406.644 ±  340.795  ops/s
GoogleGrpcBench.benchBidiStreaming               10     LIGHT  thrpt    5   1038.493 ±   19.796  ops/s
GoogleGrpcBench.benchBidiStreaming               10    NORMAL  thrpt    5    960.534 ±    2.459  ops/s
GoogleGrpcBench.benchBidiStreaming               10     HEAVY  thrpt    5    436.283 ±   19.743  ops/s
GoogleGrpcBench.benchClientStreaming              1     LIGHT  thrpt    5  11960.567 ±  374.498  ops/s
GoogleGrpcBench.benchClientStreaming              1    NORMAL  thrpt    5  11308.175 ±  292.324  ops/s
GoogleGrpcBench.benchClientStreaming              1     HEAVY  thrpt    5   8573.260 ±  193.666  ops/s
GoogleGrpcBench.benchClientStreaming             10     LIGHT  thrpt    5   6640.321 ±  183.404  ops/s
GoogleGrpcBench.benchClientStreaming             10    NORMAL  thrpt    5   5975.718 ±  124.562  ops/s
GoogleGrpcBench.benchClientStreaming             10     HEAVY  thrpt    5   1945.127 ±   51.694  ops/s
GoogleGrpcBench.benchServerStreaming              1     LIGHT  thrpt    5  11762.502 ± 2024.303  ops/s
GoogleGrpcBench.benchServerStreaming              1    NORMAL  thrpt    5  11921.816 ± 1686.829  ops/s
GoogleGrpcBench.benchServerStreaming              1     HEAVY  thrpt    5   8639.361 ±  245.211  ops/s
GoogleGrpcBench.benchServerStreaming             10     LIGHT  thrpt    5   6862.958 ±  167.346  ops/s
GoogleGrpcBench.benchServerStreaming             10    NORMAL  thrpt    5   6237.961 ±  580.701  ops/s
GoogleGrpcBench.benchServerStreaming             10     HEAVY  thrpt    5   3048.970 ±  178.323  ops/s
GoogleGrpcBench.benchUnary                      N/A     LIGHT  thrpt    5  13490.584 ±  549.904  ops/s
GoogleGrpcBench.benchUnary                      N/A    NORMAL  thrpt    5  12910.813 ±  403.167  ops/s
GoogleGrpcBench.benchUnary                      N/A     HEAVY  thrpt    5   8870.999 ±  161.864  ops/s
```

PBJ results can be found at:
1. https://github.com/hashgraph/pbj/pull/594
2. https://github.com/hashgraph/pbj/pull/602 (update for `benchServerStreaming` only)

The numbers look more or less comparable. There are instances where PBJ beats Google, e.g. for most of the `benchBidiStreaming`. However, Google clearly wins when it comes to the `HEAVY` payload size (which in our case is 8KB). I suspect that the latter could be attributed to the protocol compression that PBJ doesn't support currently. Other than that I don't see any too very major differences between Google and PBJ performance.

**Related issue(s)**:

Fixes #600 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
