### PR TITLE
596 varint perf

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -667,8 +667,23 @@ public final class Common {
                             }
                             """
                                     .replace("$fieldName", f.nameCamelFirstLower());
-                } else if (f.type() == Field.FieldType.STRING
-                        || f.type() == Field.FieldType.BYTES
+                } else if (f.type() == Field.FieldType.STRING) {
+                    generatedCodeSoFar += """
+                              if ($fieldName == null && thatObj.$fieldName != null) {
+                                  return -1;
+                              }
+                              if ($fieldName != null && thatObj.$fieldName == null) {
+                                  return 1;
+                              }
+                              if ($fieldName != null) {
+                                  result = Arrays.compare($fieldName, thatObj.$fieldName);
+                              }
+                              if (result != 0) {
+                                  return result;
+                              }
+                              """
+                            .replace("$fieldName", f.nameCamelFirstLower());
+                } else if (f.type() == Field.FieldType.BYTES
                         || f.type() == Field.FieldType.ENUM) {
                     generatedCodeSoFar += generateCompareToForObject(f);
                 } else if (f.type() == Field.FieldType.MESSAGE || f.type() == Field.FieldType.ONE_OF) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
@@ -58,7 +58,8 @@ public record MapField(
                         "An internal, private map entry key for %s"
                                 .formatted(mapContext.mapName().getText()),
                         false,
-                        null),
+                        null,
+                        true),
                 new SingleField(
                         false,
                         FieldType.of(mapContext.type_(), lookupHelper),
@@ -73,7 +74,8 @@ public record MapField(
                         "An internal, private map entry value for %s"
                                 .formatted(mapContext.mapName().getText()),
                         false,
-                        null),
+                        null,
+                        true),
                 false, // maps cannot be repeated
                 Integer.parseInt(mapContext.fieldNumber().getText()),
                 mapContext.mapName().getText(),

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -70,6 +70,7 @@ public final class JsonCodecGenerator implements Generator {
         writer.addImport("com.hedera.pbj.runtime.jsonparser.*");
         writer.addImport("static " + lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef) + ".*");
         writer.addImport("static com.hedera.pbj.runtime.JsonTools.*");
+        writer.addImport("static com.hedera.pbj.runtime.Utf8Tools.*");
 
         // spotless:off
         writer.append("""

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -8,6 +8,7 @@ import com.hedera.pbj.compiler.impl.Common;
 import com.hedera.pbj.compiler.impl.Field;
 import com.hedera.pbj.compiler.impl.MapField;
 import com.hedera.pbj.compiler.impl.OneOfField;
+import com.hedera.pbj.compiler.impl.SingleField;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -78,18 +79,19 @@ class JsonCodecParseMethodGenerator {
                             }
                         }
 
-                        return new $modelClassName($fieldsList);
+                        return new $modelClassName($fieldsList$unknownFields);
                     } catch (Exception ex) {
                         throw new ParseException(ex);
                     }
                 }
                 """
                 .replace("$modelClassName", modelClassName)
+                .replace("$unknownFields", fields.isEmpty() ? "Collections.emptyList()" : ", Collections.emptyList()")
                 .replace(
                         "$fieldDefs",
                         fields.stream()
                                 .map(field -> "    %s temp_%s = %s;"
-                                        .formatted(field.javaFieldType(), field.name(), field.javaDefault()))
+                                        .formatted(field.javaFieldStorageType(), field.name(), field.javaDefault()))
                                 .collect(Collectors.joining("\n")))
                 .replace(
                         "$fieldsList",
@@ -149,7 +151,7 @@ class JsonCodecParseMethodGenerator {
                     case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> sb.append("parseLong(v)");
                     case FLOAT -> sb.append("parseFloat(v)");
                     case DOUBLE -> sb.append("parseDouble(v)");
-                    case STRING -> sb.append("unescape(v.STRING().getText())");
+                    case STRING -> sb.append("toUtf8Bytes(unescape(v.STRING().getText()))");
                     case BOOL -> sb.append("parseBoolean(v)");
                     case BYTES -> sb.append("Bytes.fromBase64(v.STRING().getText())");
                     default -> throw new RuntimeException("Unknown field type [" + field.type() + "]");
@@ -186,6 +188,7 @@ class JsonCodecParseMethodGenerator {
                             .replace("$mapEntryKey", keySB.toString())
                             .replace("$mapEntryValue", valueSB.toString()));
         } else {
+            boolean isMapField = field instanceof SingleField && ((SingleField) field).isMapField();
             switch (field.type()) {
                 case MESSAGE -> sb.append(field.javaFieldType()
                         + ".JSON.parse($valueGetter.getChild(JSONParser.ObjContext.class, 0), false, maxDepth - 1)");
@@ -194,7 +197,10 @@ class JsonCodecParseMethodGenerator {
                 case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> sb.append("parseLong($valueGetter)");
                 case FLOAT -> sb.append("parseFloat($valueGetter)");
                 case DOUBLE -> sb.append("parseDouble($valueGetter)");
-                case STRING -> sb.append("unescape($valueGetter.STRING().getText())");
+                case STRING -> sb.append(isMapField || field.parent() != null ?
+                        "unescape($valueGetter.STRING().getText())" :
+                        "toUtf8Bytes(unescape($valueGetter.STRING().getText()))"
+                        );
                 case BOOL -> sb.append("parseBoolean($valueGetter)");
                 case BYTES -> sb.append("Bytes.fromBase64($valueGetter.STRING().getText())");
                 default -> throw new RuntimeException("Unknown field type [" + field.type() + "]");

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
@@ -102,7 +102,9 @@ final class JsonCodecWriteMethodGenerator {
                         + " && !data." + field.nameCamelFirstLower() + "().isEmpty()) fieldLines.add(" + basicFieldCode
                         + ");";
             } else {
-                return prefix + "if (data." + field.nameCamelFirstLower() + "() != " + field.javaDefault()
+                String getMethodName = field.hasDifferentStorageType() ? field.nameCamelFirstLower()+"Raw" :
+                        field.nameCamelFirstLower();
+                return prefix + "if (data." + getMethodName + "() != " + field.javaDefault()
                         + ") fieldLines.add(" + basicFieldCode + ");";
             }
         }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -82,6 +82,7 @@ public final class CodecGenerator implements Generator {
         writer.addImport("static com.hedera.pbj.runtime.ProtoWriterTools.*");
         writer.addImport("static com.hedera.pbj.runtime.ProtoParserTools.*");
         writer.addImport("static com.hedera.pbj.runtime.ProtoConstants.*");
+        writer.addImport("static com.hedera.pbj.runtime.Utf8Tools.*");
 
         // spotless:off
         writer.append("""

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -59,6 +59,8 @@ public final class CodecGenerator implements Generator {
         }
         final String writeMethod =
                 CodecWriteMethodGenerator.generateWriteMethod(modelClassName, schemaClassName, fields);
+        final String writeByteArrayMethod =
+                CodecWriteByteArrayMethodGenerator.generateWriteMethod(modelClassName, schemaClassName, fields);
 
         final String staticModifier = Generator.isInner(msgDef) ? " static" : "";
 
@@ -66,6 +68,8 @@ public final class CodecGenerator implements Generator {
         writer.addImport("com.hedera.pbj.runtime.io.*");
         writer.addImport("com.hedera.pbj.runtime.io.buffer.*");
         writer.addImport("com.hedera.pbj.runtime.io.stream.EOFException");
+        writer.addImport("com.hedera.pbj.runtime.io.stream.WritableStreamingData");
+        writer.addImport("com.hedera.pbj.runtime.ProtoArrayWriterTools");
         writer.addImport("java.io.IOException");
         writer.addImport("java.nio.*");
         writer.addImport("java.nio.charset.*");
@@ -104,6 +108,7 @@ public final class CodecGenerator implements Generator {
                 $unsetOneOfConstants
                 $parseMethod
                 $writeMethod
+                $writeByteArrayMethod
                 $measureDataMethod
                 $measureRecordMethod
                 $fastEqualsMethod
@@ -116,6 +121,7 @@ public final class CodecGenerator implements Generator {
                 .replace("$unsetOneOfConstants", CodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
                 .replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(modelClassName, schemaClassName, fields))
                 .replace("$writeMethod", writeMethod)
+                .replace("$writeByteArrayMethod", writeByteArrayMethod)
                 .replace("$measureDataMethod", CodecMeasureDataMethodGenerator.generateMeasureMethod(modelClassName, fields))
                 .replace("$measureRecordMethod", CodecMeasureRecordMethodGenerator.generateMeasureMethod(modelClassName, fields))
                 .replace("$fastEqualsMethod", CodecFastEqualsMethodGenerator.generateFastEqualsMethod(modelClassName, fields))

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -2,6 +2,8 @@
 package com.hedera.pbj.compiler.impl.generators.protobuf;
 
 import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
+import static com.hedera.pbj.compiler.impl.Field.FieldType.MAP;
+import static com.hedera.pbj.compiler.impl.Field.FieldType.STRING;
 
 import com.hedera.pbj.compiler.impl.Common;
 import com.hedera.pbj.compiler.impl.Field;
@@ -91,13 +93,14 @@ class CodecParseMethodGenerator {
                 }
                 """
         .replace("$modelClassName",modelClassName)
-        .replace("$fieldDefs",fields.stream().map(field -> "    %s temp_%s = %s;".formatted(field.javaFieldType(),
+        .replace("$fieldDefs",fields.stream().map(field -> "    %s temp_%s = %s;"
+                .formatted(field.javaFieldStorageType(),
                 field.name(), field.javaDefault())).collect(Collectors.joining("\n")))
         .replace("$fieldsList",
                 fields.stream().map(field -> "temp_"+field.name()).collect(Collectors.joining(", "))
                 + (fields.isEmpty() ? "" : ", ") + "$unknownFields"
         )
-        .replace("$parseLoop", generateParseLoop(generateCaseStatements(fields, schemaClassName), "", schemaClassName))
+        .replace("$parseLoop", generateParseLoop(generateCaseStatements(fields, schemaClassName, false), "", schemaClassName))
         .replace("$skipMaxSize", String.valueOf(Field.DEFAULT_MAX_SIZE))
         .indent(DEFAULT_INDENT);
         // spotless:on
@@ -192,20 +195,20 @@ class CodecParseMethodGenerator {
      * @param fields list of all fields in record
      * @return string of case statement code
      */
-    private static String generateCaseStatements(final List<Field> fields, final String schemaClassName) {
+    private static String generateCaseStatements(final List<Field> fields, final String schemaClassName, final boolean isMapField) {
         StringBuilder sb = new StringBuilder();
         for (Field field : fields) {
             if (field instanceof final OneOfField oneOfField) {
                 for (final Field subField : oneOfField.fields()) {
-                    generateFieldCaseStatement(sb, subField, schemaClassName);
+                    generateFieldCaseStatement(sb, subField, schemaClassName, isMapField);
                 }
             } else if (field.repeated() && field.type().wireType() != Common.TYPE_LENGTH_DELIMITED) {
                 // for repeated fields that are not length encoded there are 2 forms they can be stored in file.
                 // "packed" and repeated primitive fields
-                generateFieldCaseStatement(sb, field, schemaClassName);
-                generateFieldCaseStatementPacked(sb, field);
+                generateFieldCaseStatement(sb, field, schemaClassName, isMapField);
+                generateFieldCaseStatementPacked(sb, field, isMapField);
             } else {
-                generateFieldCaseStatement(sb, field, schemaClassName);
+                generateFieldCaseStatement(sb, field, schemaClassName, isMapField);
             }
         }
         return sb.toString().indent(DEFAULT_INDENT * 4);
@@ -218,7 +221,7 @@ class CodecParseMethodGenerator {
      * @param sb StringBuilder to append code to
      */
     @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-    private static void generateFieldCaseStatementPacked(final StringBuilder sb, final Field field) {
+    private static void generateFieldCaseStatementPacked(final StringBuilder sb, final Field field, final boolean isMapField) {
         final int wireType = Common.TYPE_LENGTH_DELIMITED;
         final int fieldNum = field.fieldNumber();
         final int tag = Common.getTag(wireType, fieldNum);
@@ -261,7 +264,7 @@ class CodecParseMethodGenerator {
      * @param sb StringBuilder to append code to
      */
     private static void generateFieldCaseStatement(
-            final StringBuilder sb, final Field field, final String schemaClassName) {
+            final StringBuilder sb, final Field field, final String schemaClassName, final boolean isMapField) {
         final int wireType = field.optionalValueType()
                 ? Common.TYPE_LENGTH_DELIMITED
                 : field.type().wireType();
@@ -290,7 +293,7 @@ class CodecParseMethodGenerator {
                                 // means optional is default value
                                 value = $defaultValue;
                             }"""
-                    .replace("$fieldType", field.javaFieldType())
+                    .replace("$fieldType", field.javaFieldStorageType())
                     .replace("$readMethod", readMethod(field))
                     .replace("$defaultValue",
                             switch (field.messageType()) {
@@ -392,8 +395,10 @@ class CodecParseMethodGenerator {
                     .replace("$fieldName", field.name())
                     .replace("$fieldDefs",mapEntryFields.stream().map(mapEntryField ->
                             "%s temp_%s = %s;".formatted(mapEntryField.javaFieldType(),
-                            mapEntryField.name(), mapEntryField.javaDefault())).collect(Collectors.joining("\n")))
-                    .replace("$mapParseLoop", generateParseLoop(generateCaseStatements(mapEntryFields, schemaClassName), "map_entry_", schemaClassName)
+                                    mapEntryField.name(),
+                                    mapEntryField.type() == STRING ? "\"\"" : mapEntryField.javaDefault()
+                            )).collect(Collectors.joining("\n")))
+                    .replace("$mapParseLoop", generateParseLoop(generateCaseStatements(mapEntryFields, schemaClassName, true), "map_entry_", schemaClassName)
                             .indent(-DEFAULT_INDENT))
                     .replace("$maxSize", String.valueOf(field.maxSize()))
             );
@@ -408,9 +413,10 @@ class CodecParseMethodGenerator {
             throw new PbjCompilerException("Fields can not be oneof and repeated ["+field+"]");
         } else if (field.parent() != null) {
             final var oneOfField = field.parent();
-            sb.append("temp_%s =  new %s<>(%s.%s, value);%n"
+            sb.append("temp_%s =  new %s<>(%s.%s, %s);%n"
                     .formatted(oneOfField.name(), oneOfField.className(), oneOfField.getEnumClassRef(),
-                            Common.camelToUpperSnake(field.name())));
+                            Common.camelToUpperSnake(field.name()),
+                            field.type() == STRING ? "toUtf8String(value)" : "value"));
         } else if (field.repeated()) {
             sb.append(
                 """
@@ -431,6 +437,8 @@ class CodecParseMethodGenerator {
                 }
                 """.formatted(field.name(), field.maxSize(),
                         mapField.keyField().name(), mapField.valueField().name()));
+        } else if(field.type() == STRING && isMapField){
+            sb.append("temp_%s = toUtf8String(value);\n".formatted(field.name()));
         } else {
             sb.append("temp_%s = value;\n".formatted(field.name()));
         }
@@ -470,7 +478,7 @@ class CodecParseMethodGenerator {
             case DOUBLE -> "readDouble(input)";
             case FIXED64 -> "readFixed64(input)";
             case SFIXED64 -> "readSignedFixed64(input)";
-            case STRING -> "readString(input, %d)".formatted(field.maxSize());
+            case STRING -> "readString%s(input, %d)".formatted(field.hasDifferentStorageType()?"Raw":"",field.maxSize());
             case BOOL -> "readBool(input)";
             case BYTES -> "readBytes(input, %d)".formatted(field.maxSize());
             case MESSAGE -> field.parseCode();

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
@@ -25,7 +25,8 @@ final class CodecWriteByteArrayMethodGenerator {
                 modelClassName,
                 schemaClassName,
                 fields,
-                field -> "data.%s()".formatted(field.nameCamelFirstLower()),
+                field -> " data.%s%s()".formatted(field.nameCamelFirstLower(),
+                        field.hasDifferentStorageType() ? "Raw" : ""),
                 true);
         // spotless:off
         return
@@ -98,7 +99,7 @@ final class CodecWriteByteArrayMethodGenerator {
         if (field.parent() != null) {
             final OneOfField oneOfField = field.parent();
             final String oneOfType = "%s.%sOneOfType".formatted(modelClassName, oneOfField.nameCamelFirstUpper());
-            getValueCode = "data.%s().as()".formatted(oneOfField.nameCamelFirstLower());
+            getValueCode = "(%s)data.%s().as()".formatted(field.javaFieldType(), oneOfField.nameCamelFirstLower());
             prefix += "if (data.%s().kind() == %s.%s)%n"
                     .formatted(oneOfField.nameCamelFirstLower(), oneOfType, Common.camelToUpperSnake(field.name()));
         }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.compiler.impl.generators.protobuf;
+
+import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
+
+import com.hedera.pbj.compiler.impl.Common;
+import com.hedera.pbj.compiler.impl.Field;
+import com.hedera.pbj.compiler.impl.MapField;
+import com.hedera.pbj.compiler.impl.OneOfField;
+import com.hedera.pbj.compiler.impl.SingleField;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Code to generate the write method for Codec classes.
+ */
+final class CodecWriteByteArrayMethodGenerator {
+
+    static String generateWriteMethod(
+            final String modelClassName, final String schemaClassName, final List<Field> fields) {
+        final String fieldWriteLines = buildFieldWriteLines(
+                modelClassName,
+                schemaClassName,
+                fields,
+                field -> "data.%s()".formatted(field.nameCamelFirstLower()),
+                true);
+        // spotless:off
+        return
+            """
+            /**
+             * Writes an item to the given byte array, this is a performance focused method. In non-performance centric use
+             * cases there are simpler methods such as toBytes() or writing to a {@link WritableStreamingData}.
+             *
+             * @param data The item to write. Must not be null.
+             * @param output The byte array to write to, this must be large enough to hold the entire item. The message is
+             *               always written at array offset 0.
+             * @param startOffset The offset in the output array to start writing at.
+             * @return The number of bytes written to the output array.
+             * @throws IOException If the {@link WritableSequentialData} cannot be written to.
+             * @throws IllegalArgumentException If the output array is not large enough to hold the entire item.
+             */
+            public int write(@NonNull $modelClass data, @NonNull byte[] output, final int startOffset) throws IOException {
+                int offset = startOffset;
+            $fieldWriteLines
+                // Write unknown fields if there are any
+                for(final UnknownField uf : data.getUnknownFields()) {
+                    final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
+                    offset += ProtoArrayWriterTools.writeUnsignedVarInt(output, offset, tag);
+                    offset += uf.bytes().writeTo(output, offset);
+                }
+                return offset - startOffset;
+            }
+            """
+            .replace("$modelClass", modelClassName)
+            .replace("$fieldWriteLines", fieldWriteLines)
+            .indent(DEFAULT_INDENT);
+        // spotless:on
+    }
+
+    private static String buildFieldWriteLines(
+            final String modelClassName,
+            final String schemaClassName,
+            final List<Field> fields,
+            final Function<Field, String> getValueBuilder,
+            final boolean skipDefault) {
+        return fields.stream()
+                .flatMap(field -> field.type() == Field.FieldType.ONE_OF
+                        ? ((OneOfField) field).fields().stream()
+                        : Stream.of(field))
+                .sorted(Comparator.comparingInt(Field::fieldNumber))
+                .map(field -> generateFieldWriteLines(
+                        field, modelClassName, schemaClassName, getValueBuilder.apply(field), skipDefault))
+                .collect(Collectors.joining("\n"))
+                .indent(DEFAULT_INDENT);
+    }
+
+    /**
+     * Generate lines of code for writing field
+     *
+     * @param field The field to generate writing line of code for
+     * @param modelClassName The model class name for model class for message type we are generating writer for
+     * @param getValueCode java code to get the value of field
+     * @param skipDefault skip writing the field if it has default value (for non-oneOf only)
+     * @return java code to write field to output
+     */
+    private static String generateFieldWriteLines(
+            final Field field,
+            final String modelClassName,
+            final String schemaClassName,
+            String getValueCode,
+            boolean skipDefault) {
+        final String fieldDef = schemaClassName + "." + Common.camelToUpperSnake(field.name());
+        String prefix = "// [%d] - %s%n".formatted(field.fieldNumber(), field.name());
+
+        if (field.parent() != null) {
+            final OneOfField oneOfField = field.parent();
+            final String oneOfType = "%s.%sOneOfType".formatted(modelClassName, oneOfField.nameCamelFirstUpper());
+            getValueCode = "data.%s().as()".formatted(oneOfField.nameCamelFirstLower());
+            prefix += "if (data.%s().kind() == %s.%s)%n"
+                    .formatted(oneOfField.nameCamelFirstLower(), oneOfType, Common.camelToUpperSnake(field.name()));
+        }
+        // spotless:off
+        final String writeMethodName = field.methodNameType();
+        if (field.optionalValueType()) {
+            return prefix + switch (field.messageType()) {
+                case "StringValue" -> "offset += ProtoArrayWriterTools.writeOptionalString(output, offset, %s, %s);"
+                        .formatted(fieldDef,getValueCode);
+                case "BoolValue" -> "offset += ProtoArrayWriterTools.writeOptionalBoolean(output, offset, %s, %s);"
+                        .formatted(fieldDef, getValueCode);
+                case "Int32Value" -> "offset += ProtoArrayWriterTools.writeOptionalInt32Value(output, offset, %s, %s);"
+                        .formatted(fieldDef, getValueCode);
+                case "UInt32Value" -> "offset += ProtoArrayWriterTools.writeOptionalUInt32Value(output, offset, %s, %s);"
+                        .formatted(fieldDef, getValueCode);
+                case "Int64Value","UInt64Value" -> "offset += ProtoArrayWriterTools.writeOptionalInt64Value(output, offset, %s, %s);"
+                        .formatted(fieldDef, getValueCode);
+                case "FloatValue" -> "offset += ProtoArrayWriterTools.writeOptionalFloat(output, offset, %s, %s);"
+                        .formatted(fieldDef, getValueCode);
+                case "DoubleValue" -> "offset += ProtoArrayWriterTools.writeOptionalDouble(output, offset, %s, %s);"
+                        .formatted(fieldDef, getValueCode);
+                case "BytesValue" -> "offset += ProtoArrayWriterTools.writeOptionalBytes(output, offset, %s, %s);"
+                        .formatted(fieldDef, getValueCode);
+                default -> throw new UnsupportedOperationException(
+                        "Unhandled optional message type:%s".formatted(field.messageType()));
+            };
+        } else {
+            String codecReference = "";
+            if (Field.FieldType.MESSAGE.equals(field.type())) {
+                codecReference = "%s.%s.PROTOBUF".formatted(((SingleField) field).messageTypeModelPackage(),
+                        ((SingleField) field).completeClassName());
+            }
+            if (field.repeated()) {
+                return prefix + switch(field.type()) {
+                    case ENUM -> "offset += ProtoArrayWriterTools.writeEnumList(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case MESSAGE -> "offset += ProtoArrayWriterTools.writeMessageList(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, codecReference);
+                    case INT32 -> "offset += ProtoArrayWriterTools.writeInt32List(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case UINT32 -> "offset += ProtoArrayWriterTools.writeUInt32List(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case SINT32 -> "offset += ProtoArrayWriterTools.writeSInt32List(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case FIXED32, SFIXED32 -> "offset += ProtoArrayWriterTools.writeFixed32List(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case INT64, UINT64 -> "offset += ProtoArrayWriterTools.writeInt64List(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case SINT64 -> "offset += ProtoArrayWriterTools.writeSInt64List(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case FIXED64, SFIXED64 -> "offset += ProtoArrayWriterTools.writeFixed64List(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+
+                    default -> "offset += ProtoArrayWriterTools.write%sList(output, offset, %s, %s);"
+                            .formatted(writeMethodName, fieldDef, getValueCode);
+                };
+            } else if (field.type() == Field.FieldType.MAP) {
+                // https://protobuf.dev/programming-guides/proto3/#maps
+                // On the wire, a map is equivalent to:
+                //    message MapFieldEntry {
+                //      key_type key = 1;
+                //      value_type value = 2;
+                //    }
+                //    repeated MapFieldEntry map_field = N;
+                // NOTE: we serialize the map in the natural order of keys by design,
+                //       so that the binary representation of the map is deterministic.
+                // NOTE: protoc serializes default values (e.g. "") in maps, so we should too.
+                final MapField mapField = (MapField) field;
+                final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
+                final Function<Field, String> getValueBuilder = mapEntryField ->
+                        mapEntryField == mapField.keyField() ? "k" : (mapEntryField == mapField.valueField() ? "v" : null);
+                final String fieldWriteLines = buildFieldWriteLines(
+                        field.name(),
+                        schemaClassName,
+                        mapEntryFields,
+                        getValueBuilder,
+                        false);
+                final String fieldSizeOfLines = CodecMeasureRecordMethodGenerator.buildFieldSizeOfLines(
+                        field.name(),
+                        mapEntryFields,
+                        getValueBuilder,
+                        false);
+                return prefix + """
+                            if (!$map.isEmpty()) {
+                                final Pbj$javaFieldType pbjMap = (Pbj$javaFieldType) $map;
+                                final int mapSize = pbjMap.size();
+                                for (int i = 0; i < mapSize; i++) {
+                                    offset += ProtoArrayWriterTools.writeTag(output, offset, $fieldDef, WIRE_TYPE_DELIMITED);
+                                    $K k = pbjMap.getSortedKeys().get(i);
+                                    $V v = pbjMap.get(k);
+                                    int size = 0;
+                                    $fieldSizeOfLines
+                                    offset += ProtoArrayWriterTools.writeUnsignedVarInt(output, offset, size);
+                                    $fieldWriteLines
+                                }
+                            }
+                            """
+                        .replace("$fieldDef", fieldDef)
+                        .replace("$map", getValueCode)
+                        .replace("$javaFieldType", mapField.javaFieldType())
+                        .replace("$K", mapField.keyField().type().boxedType)
+                        .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? ((SingleField)mapField.valueField()).messageType() : mapField.valueField().type().boxedType)
+                        .replace("$fieldWriteLines", fieldWriteLines.indent(DEFAULT_INDENT))
+                        .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT));
+            } else {
+                return prefix + switch(field.type()) {
+                    case ENUM -> "offset += ProtoArrayWriterTools.writeEnum(output, offset, %s, %s);"
+                            .formatted(fieldDef, getValueCode);
+                    case STRING -> "offset += ProtoArrayWriterTools.writeString(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case MESSAGE -> "offset += ProtoArrayWriterTools.writeMessage(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, codecReference);
+                    case BOOL -> "offset += ProtoArrayWriterTools.writeBoolean(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case INT32 -> "offset += ProtoArrayWriterTools.writeInt32(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case UINT32 -> "offset += ProtoArrayWriterTools.writeUInt32(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case SINT32 -> "offset += ProtoArrayWriterTools.writSInt32(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case FIXED32, SFIXED32 -> "offset += ProtoArrayWriterTools.writeFixed32(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case INT64, UINT64 -> "offset += ProtoArrayWriterTools.writeInt64(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case SINT64 -> "offset += ProtoArrayWriterTools.writeSInt64(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case FIXED64, SFIXED64 -> "offset += ProtoArrayWriterTools.writeFixed64(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    case BYTES -> "offset += ProtoArrayWriterTools.writeBytes(output, offset, %s, %s, %s);"
+                            .formatted(fieldDef, getValueCode, skipDefault);
+                    default -> "offset += ProtoArrayWriterTools.write%s(output, offset, %s, %s);"
+                            .formatted(writeMethodName, fieldDef, getValueCode);
+                };
+            }
+        }
+        // spotless:on
+    }
+}

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -25,7 +25,8 @@ final class CodecWriteMethodGenerator {
                 modelClassName,
                 schemaClassName,
                 fields,
-                field -> "data.%s()".formatted(field.nameCamelFirstLower()),
+                field -> " data.%s%s()".formatted(field.nameCamelFirstLower(),
+                        field.hasDifferentStorageType() ? "Raw" : ""),
                 true);
         // spotless:off
         return
@@ -93,7 +94,7 @@ final class CodecWriteMethodGenerator {
         if (field.parent() != null) {
             final OneOfField oneOfField = field.parent();
             final String oneOfType = "%s.%sOneOfType".formatted(modelClassName, oneOfField.nameCamelFirstUpper());
-            getValueCode = "data.%s().as()".formatted(oneOfField.nameCamelFirstLower());
+            getValueCode = "(%s)data.%s().as()".formatted(field.javaFieldType(), oneOfField.nameCamelFirstLower());
             prefix += "if (data.%s().kind() == %s.%s)%n"
                     .formatted(oneOfField.nameCamelFirstLower(), oneOfType, Common.camelToUpperSnake(field.name()));
         }
@@ -185,7 +186,7 @@ final class CodecWriteMethodGenerator {
                 return prefix + switch(field.type()) {
                     case ENUM -> "writeEnum(out, %s, %s);"
                             .formatted(fieldDef, getValueCode);
-                    case STRING -> "writeString(out, %s, %s, %s);"
+                    case STRING -> "/* FOO */ writeString(out, %s, %s, %s);"
                             .formatted(fieldDef, getValueCode, skipDefault);
                     case MESSAGE -> "writeMessage(out, %s, %s, %s);"
                             .formatted(fieldDef, getValueCode, codecReference);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
@@ -106,7 +106,7 @@ public class LazyGetProtobufSizeMethodGenerator {
             final String oneOfType = modelClassName == null
                     ? oneOfField.nameCamelFirstUpper() + "OneOfType"
                     : modelClassName + "." + oneOfField.nameCamelFirstUpper() + "OneOfType";
-            getValueCode = oneOfField.nameCamelFirstLower() + ".as()";
+            getValueCode = "("+field.javaFieldType()+")"+oneOfField.nameCamelFirstLower() + ".as()";
             prefix += "if (" + oneOfField.nameCamelFirstLower() + ".kind() == " + oneOfType + "."
                     + Common.camelToUpperSnake(field.name()) + ")";
             prefix += "\n";
@@ -117,7 +117,7 @@ public class LazyGetProtobufSizeMethodGenerator {
             return prefix
                     + switch (field.messageType()) {
                         case "StringValue" ->
-                            "_size += sizeOfOptionalString(%s, %s);".formatted(fieldDef, getValueCode);
+                            "_size += sizeOfOptionalString(%s, (String)%s);".formatted(fieldDef, getValueCode);
                         case "BoolValue" -> "_size += sizeOfOptionalBoolean(%s, %s);".formatted(fieldDef, getValueCode);
                         case "Int32Value", "UInt32Value" ->
                             "_size += sizeOfOptionalInteger(%s, %s);".formatted(fieldDef, getValueCode);
@@ -182,7 +182,8 @@ public class LazyGetProtobufSizeMethodGenerator {
                     + switch (field.type()) {
                         case ENUM -> "_size += sizeOfEnum(%s, %s);".formatted(fieldDef, getValueCode);
                         case STRING ->
-                            "_size += sizeOfString(%s, %s, %s);".formatted(fieldDef, getValueCode, skipDefault);
+                            "_size += sizeOfString(%s, %s, %s);".formatted(
+                                    fieldDef, getValueCode, skipDefault);
                         case MESSAGE ->
                             "_size += sizeOfMessage($fieldDef, $valueCode, $codec);"
                                     .replace("$fieldDef", fieldDef)

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -15,11 +15,7 @@ import java.io.UncheckedIOException;
  *
  * @param <T> The type of object to serialize and deserialize
  */
-public interface Codec<T /*extends Record*/> {
-
-    // NOTE: When services has finished migrating to protobuf based objects in state,
-    // then we should strongly enforce Codec works with Records. This will reduce bugs
-    // where people try to use a mutable object.
+public interface Codec<T> {
 
     /**
      * Parses an object from the {@link ReadableSequentialData} and returns it.
@@ -156,6 +152,27 @@ public interface Codec<T /*extends Record*/> {
      * @throws IOException If the {@link WritableSequentialData} cannot be written to.
      */
     void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException;
+
+    /**
+     * Writes an item to the given byte array, this is a performance focused method. In non-performance centric use
+     * cases there are simpler methods such as {@link #toBytes(T)} or writing to a {@link WritableStreamingData}.
+     *
+     * @param item The item to write. Must not be null.
+     * @param output The byte array to write to, this must be large enough to hold the entire item.
+     * @param startOffset The offset in the output array to start writing at.
+     * @return The number of bytes written to the output array.
+     * @throws IOException If the there is a problem writing to the output array.
+     * @throws IndexOutOfBoundsException If the output array is not large enough to hold the entire item.
+     */
+    default int write(@NonNull T item, @NonNull byte[] output, final int startOffset) throws IOException {
+        final BufferedData bufferedData = BufferedData.wrap(output, startOffset, output.length - startOffset);
+        try {
+            write(item, bufferedData);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return (int)bufferedData.position();
+    }
 
     /**
      * Reads from this data input the length of the data within the input. The implementation may

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjConstants.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjConstants.java
@@ -1,0 +1,9 @@
+package com.hedera.pbj.runtime;
+
+/**
+ * Constants used in the PBJ runtime.
+ */
+public final class PbjConstants {
+    /** An empty byte array constant to avoid creating multiple empty arrays */
+    public static final byte[] EMPTY_BYTES = new byte[0];
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoArrayWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoArrayWriterTools.java
@@ -1,0 +1,1093 @@
+package com.hedera.pbj.runtime;
+
+import static com.hedera.pbj.runtime.FieldType.FIXED32;
+import static com.hedera.pbj.runtime.FieldType.FIXED64;
+import static com.hedera.pbj.runtime.FieldType.INT32;
+import static com.hedera.pbj.runtime.FieldType.INT64;
+import static com.hedera.pbj.runtime.FieldType.SFIXED32;
+import static com.hedera.pbj.runtime.FieldType.SFIXED64;
+import static com.hedera.pbj.runtime.FieldType.SINT32;
+import static com.hedera.pbj.runtime.FieldType.SINT64;
+import static com.hedera.pbj.runtime.FieldType.UINT32;
+import static com.hedera.pbj.runtime.FieldType.UINT64;
+import static com.hedera.pbj.runtime.ProtoConstants.WIRE_TYPE_DELIMITED;
+import static com.hedera.pbj.runtime.ProtoConstants.WIRE_TYPE_FIXED_32_BIT;
+import static com.hedera.pbj.runtime.ProtoConstants.WIRE_TYPE_FIXED_64_BIT;
+import static com.hedera.pbj.runtime.ProtoConstants.WIRE_TYPE_VARINT_OR_ZIGZAG;
+import static com.hedera.pbj.runtime.ProtoWriterTools.FIXED32_SIZE;
+import static com.hedera.pbj.runtime.ProtoWriterTools.FIXED64_SIZE;
+import static com.hedera.pbj.runtime.ProtoWriterTools.TAG_TYPE_BITS;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfBoolean;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfBytes;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfDouble;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfFloat;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfString;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfStringNoTag;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfTag;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfUnsignedVarInt32;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfUnsignedVarInt64;
+import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfVarInt32;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.List;
+
+/**
+ * Suite of static utility methods to assist in writing protobuf messages into Java byte arrays. Its number one focus
+ * is performance.
+ */
+@SuppressWarnings({"DuplicatedCode", "ForLoopReplaceableByForEach"})
+public final class ProtoArrayWriterTools {
+    /** Table to determine the length of a varint based on the number of leading zeros */
+    private static final int[] VAR_INT_LENGTHS = new int[65];
+    static {
+        for (int i = 0; i <= 64; ++i) VAR_INT_LENGTHS[i] = ((63 - i) / 7);
+    }
+    /** VarHandle to write little-endian integers to byte arrays */
+    private static final VarHandle INTEGER_LITTLE_ENDIAN = MethodHandles.byteArrayViewVarHandle(int[].class,
+            ByteOrder.LITTLE_ENDIAN);
+    /** VarHandle to write little-endian longs to byte arrays */
+    private static final VarHandle LONG_LITTLE_ENDIAN = MethodHandles.byteArrayViewVarHandle(long[].class,
+            ByteOrder.LITTLE_ENDIAN);
+
+    /**
+     * Write an unsigned varint to the output.
+     *
+     * @param output The byte array to write to
+     * @param offset The offset to start writing at
+     * @param value The value to write
+     * @return The number of bytes written
+     */
+    @SuppressWarnings("fallthrough")
+    public static int writeUnsignedVarInt(@NonNull byte[] output, final int offset, final long value) {
+        int length = VAR_INT_LENGTHS[Long.numberOfLeadingZeros(value)];
+        output[offset+length] = (byte)(value >>> (length * 7));
+        switch (length - 1) {
+            case 8:
+                output[offset+8] = (byte)((value >>> 56) | 0x80);
+                // Deliberate fallthrough
+            case 7:
+                output[offset+7] = (byte)((value >>> 49) | 0x80);
+                // Deliberate fallthrough
+            case 6:
+                output[offset+6] = (byte)((value >>> 42) | 0x80);
+                // Deliberate fallthrough
+            case 5:
+                output[offset+5] = (byte)((value >>> 35) | 0x80);
+                // Deliberate fallthrough
+            case 4:
+                output[offset+4] = (byte)((value >>> 28) | 0x80);
+                // Deliberate fallthrough
+            case 3:
+                output[offset+3] = (byte)((value >>> 21) | 0x80);
+                // Deliberate fallthrough
+            case 2:
+                output[offset+2] = (byte)((value >>> 14) | 0x80);
+                // Deliberate fallthrough
+            case 1:
+                output[offset+1] = (byte)((value >>> 7) | 0x80);
+                // Deliberate fallthrough
+            case 0:
+                output[offset] = (byte)(value | 0x80);
+        }
+        return length;
+    }
+
+    /**
+     * Write a signed zigzag encoded varint to the output.
+     *
+     * @param output The byte array to write to
+     * @param offset The offset to start writing at
+     * @param value The value to write
+     * @return The number of bytes written
+     */
+    public static int writeSignedVarInt(@NonNull byte[] output, final int offset, final long value) {
+        final long zigZag = (value << 1) ^ (value >> 63);
+        return writeUnsignedVarInt(output, offset, zigZag);
+    }
+
+    /**
+     * Write a protobuf tag to the output.
+     *
+     * @param offset The offset to start writing at
+     * @param field The field to include in tag
+     * @param wireType The field wire type to include in tag
+     * @return The number of bytes written
+     */
+    public static int writeTag(@NonNull byte[] output, final int offset, @NonNull final FieldDefinition field,
+            @NonNull final ProtoConstants wireType) {
+        return writeUnsignedVarInt(output, offset, ((long)field.number() << TAG_TYPE_BITS) | wireType.ordinal());
+    }
+
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    public static int writeString(@NonNull byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final String value, final boolean skipDefault) throws IOException {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert !field.repeated() : "Use writeStringList with repeated types";
+        return writeStringNoChecks(output, offset, field, value, skipDefault);
+    }
+
+    /**
+     * Write an integer to data output - no validation checks.
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    private static int writeStringNoChecks(@NonNull byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final String value, final boolean skipDefault) throws IOException {
+        int bytesWritten = 0;
+        // When not a oneOf don't write default value
+        if (skipDefault && !field.oneOf() && (value == null || value.isEmpty())) {
+            return 0;
+        }
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, sizeOfStringNoTag(value));
+        bytesWritten += Utf8Tools.encodeUtf8(output, offset + bytesWritten, value);
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional string to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the field definition for the string field
+     * @param value the optional string value to write
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    public static int writeOptionalString(@NonNull byte[] output, final int offset, @NonNull final FieldDefinition field,
+            @Nullable final String value) throws IOException {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, sizeOfString(newField, value));
+            bytesWritten += writeStringNoChecks(output, offset + bytesWritten, newField, value, true);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a boolean to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writeBoolean(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final boolean value, final boolean skipDefault) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert !field.repeated() : "Use writeBooleanList with repeated types";
+        int bytesWritten = 0;
+        // In the case of oneOf we write the value even if it is default value of false
+        if (value || field.oneOf() || !skipDefault) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+            output[offset + bytesWritten] = value ? (byte) 1 : 0;
+            bytesWritten ++;
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional boolean to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the optional boolean value to write
+     * @return the number of bytes written
+     */
+    public static int writeOptionalBoolean(@NonNull final byte[] output, final int offset, @NonNull FieldDefinition field, @Nullable Boolean value) {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, sizeOfBoolean(newField, value));
+            bytesWritten += writeBoolean(output, offset + bytesWritten, newField, value, true);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write an Int32 to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writeInt32(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final int value, boolean skipDefault) {
+        assert field.type() == INT32 : "Not an Int32 type " + field;
+        assert !field.repeated() : "Use writeIntegerList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0) return 0;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, value);
+        return bytesWritten;
+    }
+
+    /**
+     * Write an UInt32 to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writeUInt32(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final int value, boolean skipDefault) {
+        assert field.type() == UINT32 : "Not a UInt32 type " + field;
+        assert !field.repeated() : "Use writeIntegerList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0) return 0;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, Integer.toUnsignedLong(value));
+        return bytesWritten;
+    }
+
+
+    /**
+     * Write an SInt32 to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writSInt32(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final int value, boolean skipDefault) {
+        assert field.type() == SINT32 : "Not a SInt32 type " + field;
+        assert !field.repeated() : "Use writeIntegerList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0) return 0;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        bytesWritten += writeSignedVarInt(output, offset + bytesWritten, value);
+        return bytesWritten;
+    }
+
+    /**
+     * Write a SFixed32 or Fixed32 to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writeFixed32(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final int value, boolean skipDefault) {
+        assert field.type() == FieldType.FIXED32 || field.type() == FieldType.SFIXED32
+                : "Not a Fixed32 or SFixed32 type " + field;
+        assert !field.repeated() : "Use writeIntegerList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0) return 0;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_FIXED_32_BIT);
+        INTEGER_LITTLE_ENDIAN.set(output, offset + bytesWritten, value);
+        bytesWritten += Integer.BYTES;
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional signed integer to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the optional integer value to write
+     * @return the number of bytes written
+     */
+    public static int writeOptionalInt32Value(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, @Nullable Integer value) {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten,
+                    sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfVarInt32(value));
+            bytesWritten += writeInt32(output, offset + bytesWritten, newField, value, true);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional unsigned integer to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the optional integer value to write
+     * @return the number of bytes written
+     */
+    public static int writeOptionalUInt32Value(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, @Nullable Integer value) {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten,
+                    sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfVarInt32(value));
+            bytesWritten += writeUInt32(output, offset + bytesWritten, newField, value, true);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write an Int64 or UInt64 to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writeInt64(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final long value, boolean skipDefault) {
+        assert field.type() == INT64 || field.type() == UINT64
+                : "Not an Int64 or UInt64 type " + field;
+        assert !field.repeated() : "Use writeLongList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0L) return 0;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, value);
+        return bytesWritten;
+    }
+
+    /**
+     * Write an SInt64 to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writeSInt64(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final long value, boolean skipDefault) {
+        assert field.type() == SINT64 : "Not a SInt64 type " + field;
+        assert !field.repeated() : "Use writeLongList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0L) return 0;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        bytesWritten += writeSignedVarInt(output, offset + bytesWritten, value);
+        return bytesWritten;
+    }
+
+    /**
+     * Write a SFixed64 or Fixed64 to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     */
+    public static int writeFixed64(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            final long value, boolean skipDefault) {
+        assert field.type() == FIXED64 || field.type() == SFIXED64
+                : "Not a Fixed64 or SFixed64 type " + field;
+        assert !field.repeated() : "Use writeLongList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0L) return 0;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_FIXED_32_BIT);
+        LONG_LITTLE_ENDIAN.set(output, offset + bytesWritten, value);
+        bytesWritten += Long.BYTES;
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional signed or unsinged long to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the optional long value to write
+     * @return the number of bytes written
+     */
+    public static int writeOptionalInt64Value(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, @Nullable Long value) {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten,
+                    sizeOfTag(field, WIRE_TYPE_VARINT_OR_ZIGZAG) + sizeOfUnsignedVarInt64(value));
+            bytesWritten += writeInt64(output, offset + bytesWritten, newField, value, true);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a float to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the float value to write
+     * @return the number of bytes written
+     */
+    public static int writeFloat(@NonNull final byte[] output, final int offset, FieldDefinition field, float value) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert !field.repeated() : "Use writeFloatList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return 0;
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_FIXED_32_BIT);
+        INTEGER_LITTLE_ENDIAN.set(output, offset + bytesWritten, Float.floatToIntBits(value));
+        bytesWritten += Integer.BYTES;
+        return bytesWritten;
+    }
+
+    /**
+     * Write a double to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the double value to write
+     * @return the number of bytes written
+     */
+    public static int writeDouble(@NonNull final byte[] output, final int offset, FieldDefinition field, double value) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert !field.repeated() : "Use writeDoubleList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return 0;
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_FIXED_64_BIT);
+        LONG_LITTLE_ENDIAN.set(output, offset + bytesWritten, Double.doubleToLongBits(value));
+        bytesWritten += Long.BYTES;
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional float to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the optional long value to write
+     * @return the number of bytes written
+     */
+    public static int writeOptionalFloat(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, @Nullable Float value) {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, sizeOfFloat(newField, value));
+            bytesWritten += writeFixed32(output, offset + bytesWritten, newField, Float.floatToIntBits(value), true);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional double to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the optional long value to write
+     * @return the number of bytes written
+     */
+    public static int writeOptionalDouble(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, @Nullable Double value) {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, sizeOfDouble(newField, value));
+            bytesWritten += writeFixed64(output, offset + bytesWritten, newField, Double.doubleToLongBits(value), true);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write an optional bytes to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the optional long value to write
+     * @return the number of bytes written
+     */
+    public static int writeOptionalBytes(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, @Nullable Bytes value) {
+        int bytesWritten = 0;
+        if (value != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            final int size = sizeOfBytes(newField, value);
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten,size);
+            if (size > 0) {
+                bytesWritten += writeTag(output, offset+ bytesWritten, field, WIRE_TYPE_DELIMITED);
+                bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten,size);
+                bytesWritten += value.writeTo(output, offset + bytesWritten);
+            }
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write an enum to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param enumValue the enum value to write
+     * @return the number of bytes written
+     */
+    public static int writeEnum(@NonNull final byte[] output, final int offset, @NonNull final FieldDefinition field,
+            @Nullable final EnumWithProtoMetadata enumValue) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert !field.repeated() : "Use writeEnumList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (enumValue == null || enumValue.protoOrdinal() == 0)) {
+            return 0;
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        bytesWritten += writeUnsignedVarInt(output, offset, enumValue == null ? 0 : enumValue.protoOrdinal());
+        return bytesWritten;
+    }
+
+
+    /**
+     * Write a message to data output, assuming the corresponding field is non-repeated.
+     *
+     * @param <T> type of message
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    public static <T> int writeMessage(@NonNull final byte[] output, final int offset,
+            @NonNull final FieldDefinition field, final T message, final Codec<T> codec)
+            throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert !field.repeated() : "Use writeMessageList with repeated types";
+        return writeMessageNoChecks(output, offset, field, message, codec);
+    }
+
+
+    /**
+     * Write a message to data output - no validation checks.
+     *
+     * @param <T> type of message
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    private static <T> int writeMessageNoChecks(@NonNull final byte[] output, final int offset,
+            @NonNull final FieldDefinition field, final T message, final Codec<T> codec)
+            throws IOException {
+        // When not a oneOf don't write default value
+        int bytesWritten = 0;
+        if (field.oneOf() && message == null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            bytesWritten += writeUnsignedVarInt(output,offset + bytesWritten,0);
+        } else if (message != null) {
+            bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+            final int size = codec.measureRecord(message);
+            bytesWritten += writeUnsignedVarInt(output,offset + bytesWritten,size);
+            if (size > 0) {
+                bytesWritten += codec.write(message, output, offset + bytesWritten);
+            }
+        }
+        return bytesWritten;
+    }
+
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    public static int writeBytes(@NonNull final byte[] output, final int offset,
+            @NonNull final FieldDefinition field,
+            final Bytes value,
+            boolean skipDefault)
+            throws IOException {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert !field.repeated() : "Use writeBytesList with repeated types";
+        return writeBytesNoChecks(output, offset, field, value, skipDefault);
+    }
+
+    /**
+     * Write a bytes to data output - no validation checks.
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param value the bytes value to write
+     * @param skipZeroLength this is true for normal single bytes and false for repeated lists
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    private static int writeBytesNoChecks(@NonNull final byte[] output, final int offset,
+            @NonNull final FieldDefinition field,
+            final Bytes value,
+            final boolean skipZeroLength)
+            throws IOException {
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (skipZeroLength && (value.length() == 0))) {
+            return 0;
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, value.length());
+        bytesWritten += value.writeTo(output, offset + bytesWritten);
+        return bytesWritten;
+    }
+
+
+    // ================================================================================================================
+    // LIST VERSIONS OF WRITE METHODS
+
+    /**
+     * Write a list of integers to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of integers value to write
+     * @return the number of bytes written
+     */
+    public static int writeInt32List(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Integer> list) {
+        assert field.type() !=  INT32 : "Not a long type " + field;
+        assert field.repeated() : "Use writeInteger with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) return 0;
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            final int val = list.get(i);
+            size += sizeOfVarInt32(val);
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, list.get(i));
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of integers to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of integers value to write
+     * @return the number of bytes written
+     */
+    public static int writeUInt32List(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Integer> list) {
+        assert field.type() !=  UINT32 : "Not a long type " + field;
+        assert field.repeated() : "Use writeInteger with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) return 0;
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            final int val = list.get(i);
+            size += sizeOfUnsignedVarInt64(Integer.toUnsignedLong(val));
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, Integer.toUnsignedLong(list.get(i)));
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of integers to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of integers value to write
+     * @return the number of bytes written
+     */
+    public static int writeSInt32List(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Integer> list) {
+        assert field.type() !=  SINT32 : "Not a long type " + field;
+        assert field.repeated() : "Use writeInteger with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) return 0;
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            final int val = list.get(i);
+            size += sizeOfUnsignedVarInt64(((long) val << 1) ^ ((long) val >> 63));
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeSignedVarInt(output, offset + bytesWritten, Integer.toUnsignedLong(list.get(i)));
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of integers to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of integers value to write
+     * @return the number of bytes written
+     */
+    public static int writeFixed32List(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Integer> list) {
+        assert field.type() !=  FIXED32 && field.type() != SFIXED32 : "Not a long type " + field;
+        assert field.repeated() : "Use writeInteger with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) return 0;
+        final int listSize = list.size();
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, (long) list.size() * FIXED32_SIZE);
+        for (int i = 0; i < listSize; i++) {
+            INTEGER_LITTLE_ENDIAN.set(output, offset + bytesWritten, list.get(i));
+            bytesWritten += Integer.BYTES;
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of longs to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of longs value to write
+     * @return the number of bytes written
+     */
+    public static int writeInt64List(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Long> list) {
+        assert field.type() !=  INT64 && field.type() != UINT64 : "Not a long type " + field;
+        assert field.repeated() : "Use writeLong with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) return 0;
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            final long val = list.get(i);
+            size += sizeOfUnsignedVarInt64(val);
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, list.get(i));
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of longs to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of longs value to write
+     * @return the number of bytes written
+     */
+    public static int writeSInt64List(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Long> list) {
+        assert field.type() !=  SINT64 : "Not a SINT64 type " + field;
+        assert field.repeated() : "Use writeLong with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) return 0;
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            final long val = list.get(i);
+            size += sizeOfUnsignedVarInt64(val);
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeSignedVarInt(output, offset + bytesWritten, list.get(i));
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of longs to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of longs value to write
+     * @return the number of bytes written
+     */
+    public static int writeFixed64List(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Long> list) {
+        assert field.type() !=  FIXED64 && field.type() != SFIXED64 : "Not a fixed long type " + field;
+        assert field.repeated() : "Use writeLong with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) return 0;
+        final int listSize = list.size();
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, (long) list.size() * FIXED64_SIZE);
+        for (int i = 0; i < listSize; i++) {
+            LONG_LITTLE_ENDIAN.set(output, offset + bytesWritten, list.get(i));
+            bytesWritten += Long.BYTES;
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of floats to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of floats value to write
+     * @return the number of bytes written
+     */
+    public static int writeFloatList(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Float> list) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert field.repeated() : "Use writeFloat with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return 0;
+        }
+        final int size = list.size() * FIXED32_SIZE;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset + bytesWritten, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            INTEGER_LITTLE_ENDIAN.set(output, offset + bytesWritten, Float.floatToRawIntBits(list.get(i)));
+            bytesWritten += Integer.BYTES;
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of doubles to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of doubles value to write
+     * @return the number of bytes written
+     */
+    public static int writeDoubleList(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Double> list) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert field.repeated() : "Use writeDouble with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return 0;
+        }
+        final int size = list.size() * FIXED64_SIZE;
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset + bytesWritten, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            LONG_LITTLE_ENDIAN.set(output, offset + bytesWritten, Double.doubleToLongBits(list.get(i)));
+            bytesWritten += Long.BYTES;
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of booleans to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of booleans value to write
+     * @return the number of bytes written
+     */
+    public static int writeBooleanList(@NonNull final byte[] output, final int offset, FieldDefinition field, List<Boolean> list) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert field.repeated() : "Use writeBoolean with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return 0;
+        }
+        // write
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset + bytesWritten, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, list.size());
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            final boolean b = list.get(i);
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, b ? 1 : 0);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of enums to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of enums value to write
+     * @return the number of bytes written
+     */
+    public static int writeEnumList(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, List<? extends EnumWithProtoMetadata> list) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert field.repeated() : "Use writeEnum with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return 0;
+        }
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            size += sizeOfUnsignedVarInt32(list.get(i).protoOrdinal());
+        }
+        int bytesWritten = 0;
+        bytesWritten += writeTag(output, offset + bytesWritten, field, WIRE_TYPE_DELIMITED);
+        bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, size);
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, list.get(i).protoOrdinal());
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of strings to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of strings value to write
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    public static int writeStringList(@NonNull final byte[] output, final int offset, FieldDefinition field, List<String> list)
+            throws IOException {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "Use writeString with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return 0;
+        }
+        final int listSize = list.size();
+        int bytesWritten = 0;
+        for (int i = 0; i < listSize; i++) {
+            final String value = list.get(i);
+            bytesWritten += writeTag(output, offset + bytesWritten, field, WIRE_TYPE_DELIMITED);
+            bytesWritten += writeUnsignedVarInt(output, offset + bytesWritten, sizeOfStringNoTag(value));
+            bytesWritten += Utf8Tools.encodeUtf8(output, offset + bytesWritten, value);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of messages to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of messages value to write
+     * @param codec the codec for the message type
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     * @param <T> type of message
+     */
+    public static <T> int writeMessageList(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, List<T> list, Codec<T> codec) throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "Use writeMessage with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return 0;
+        }
+        final int listSize = list.size();
+        int bytesWritten = 0;
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeMessageNoChecks(output, offset + bytesWritten, field, list.get(i), codec);
+        }
+        return bytesWritten;
+    }
+
+    /**
+     * Write a list of bytes objects to data output
+     *
+     * @param output the byte array to write to
+     * @param offset the offset to start writing at
+     * @param field the descriptor for the field we are writing
+     * @param list the list of bytes objects value to write
+     * @return the number of bytes written
+     * @throws IOException If a I/O error occurs
+     */
+    public static int writeBytesList(
+            @NonNull final byte[] output, final int offset, FieldDefinition field, List<? extends Bytes> list)
+            throws IOException {
+        assert field.type() == FieldType.BYTES : "Not a message type " + field;
+        assert field.repeated() : "Use writeBytes with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return 0;
+        }
+        final int listSize = list.size();
+        int bytesWritten = 0;
+        for (int i = 0; i < listSize; i++) {
+            bytesWritten += writeBytesNoChecks(output, offset + bytesWritten, field, list.get(i), false);
+        }
+        return bytesWritten;
+    }
+
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -269,6 +269,31 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a String field from data input
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return Read string
+     * @throws ParseException if the length is greater than maxSize
+     */
+    public static byte[] readStringRaw(final ReadableSequentialData input, final long maxSize)
+            throws IOException, ParseException {
+        final int length = input.readVarInt(false);
+        if (length > maxSize) {
+            throw new ParseException("size " + length + " is greater than max " + maxSize);
+        }
+        if (input.remaining() < length) {
+            throw new BufferUnderflowException();
+        }
+        byte[] result = new byte[length];
+        final long bytesRead = input.readBytes(result);
+        if (bytesRead != length) {
+            throw new BufferUnderflowException();
+        }
+        return result;
+    }
+
+    /**
      * Read a Bytes field from data input
      *
      * @param input the input to read from

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -272,7 +272,7 @@ public final class ProtoWriterTools {
      * @param value the string value to write
      * @throws IOException If a I/O error occurs
      */
-    public static void writeString(final WritableSequentialData out, final FieldDefinition field, final String value)
+    public static void writeString(final WritableSequentialData out, final FieldDefinition field, final byte[] value)
             throws IOException {
         writeString(out, field, value, true);
     }
@@ -295,6 +295,23 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @throws IOException If a I/O error occurs
+     */
+    public static void writeString(
+            final WritableSequentialData out, final FieldDefinition field, final byte[] value, boolean skipDefault)
+            throws IOException {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert !field.repeated() : "Use writeStringList with repeated types";
+        writeStringNoChecks(out, field, value, skipDefault);
+    }
+
+    /**
      * Write a string to data output, assuming the field is repeated. Usually this method is called multiple
      * times, one for every repeated value. If all values are available immediately, {@link #writeStringList(
      * WritableSequentialData, FieldDefinition, List)} should be used instead.
@@ -305,7 +322,7 @@ public final class ProtoWriterTools {
      * @throws IOException If a I/O error occurs
      */
     public static void writeOneRepeatedString(
-            final WritableSequentialData out, final FieldDefinition field, final String value) throws IOException {
+            final WritableSequentialData out, final FieldDefinition field, final byte[] value) throws IOException {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert field.repeated() : "writeOneRepeatedString can only be used with repeated fields";
         writeStringNoChecks(out, field, value);
@@ -320,7 +337,7 @@ public final class ProtoWriterTools {
      * @throws IOException If a I/O error occurs
      */
     private static void writeStringNoChecks(
-            final WritableSequentialData out, final FieldDefinition field, final String value) throws IOException {
+            final WritableSequentialData out, final FieldDefinition field, final byte[] value) throws IOException {
         writeStringNoChecks(out, field, value, true);
     }
 
@@ -343,6 +360,27 @@ public final class ProtoWriterTools {
         writeTag(out, field, WIRE_TYPE_DELIMITED);
         out.writeVarInt(sizeOfStringNoTag(value), false);
         Utf8Tools.encodeUtf8(value, out);
+    }
+
+    /**
+     * Write a integer to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     * @throws IOException If a I/O error occurs
+     */
+    private static void writeStringNoChecks(
+            final WritableSequentialData out, final FieldDefinition field, final byte[] value, boolean skipDefault)
+            throws IOException {
+        // When not a oneOf don't write default value
+        if (skipDefault && !field.oneOf() && (value == null || value.length == 0)) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(value.length, false);
+        out.writeBytes(value);
     }
 
     /**
@@ -626,7 +664,15 @@ public final class ProtoWriterTools {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
             out.writeVarInt(sizeOfString(newField, value), false);
-            writeString(out, newField, value);
+//            writeString(out, newField, value);
+
+            // When not a oneOf don't write default value
+            if (!field.oneOf() && value.isEmpty()) {
+                return;
+            }
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            out.writeVarInt(sizeOfStringNoTag(value), false);
+            Utf8Tools.encodeUtf8(value, out);
         }
     }
 
@@ -896,7 +942,7 @@ public final class ProtoWriterTools {
      * @param list the list of strings value to write
      * @throws IOException If a I/O error occurs
      */
-    public static void writeStringList(WritableSequentialData out, FieldDefinition field, List<String> list)
+    public static void writeStringList(WritableSequentialData out, FieldDefinition field, List<byte[]> list)
             throws IOException {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert field.repeated() : "Use writeString with non-repeated types";
@@ -906,10 +952,14 @@ public final class ProtoWriterTools {
         }
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
-            final String value = list.get(i);
+            final byte[] value = list.get(i);
             writeTag(out, field, WIRE_TYPE_DELIMITED);
-            out.writeVarInt(sizeOfStringNoTag(value), false);
-            Utf8Tools.encodeUtf8(value, out);
+            if (value == null) {
+                out.writeVarInt(0, false);
+            } else {
+                out.writeVarInt(value.length, false);
+                out.writeBytes(value);
+            }
         }
     }
 
@@ -1303,6 +1353,17 @@ public final class ProtoWriterTools {
      *
      * @param field descriptor of field
      * @param value string value to get encoded size for
+     * @return the number of bytes for encoded value
+     */
+    public static int sizeOfString(FieldDefinition field, byte[] value) {
+        return value == null ? 0 : value.length;
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode a string field
+     *
+     * @param field descriptor of field
+     * @param value string value to get encoded size for
      * @param skipDefault default value results in zero size
      * @return the number of bytes for encoded value
      */
@@ -1312,6 +1373,18 @@ public final class ProtoWriterTools {
             return 0;
         }
         return sizeOfDelimited(field, sizeOfStringNoTag(value));
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode a string field
+     *
+     * @param field descriptor of field
+     * @param value string value to get encoded size for
+     * @param skipDefault default value results in zero size
+     * @return the number of bytes for encoded value
+     */
+    public static int sizeOfString(FieldDefinition field, byte[] value, boolean skipDefault) {
+        return value == null ? 0 : value.length;
     }
 
     /**
@@ -1330,6 +1403,16 @@ public final class ProtoWriterTools {
         } catch (IOException e) { // fall back to JDK
             return value.getBytes(StandardCharsets.UTF_8).length;
         }
+    }
+
+    /**
+     * Get number of bytes that would be needed to encode a string, without field tag
+     *
+     * @param value string value to get encoded size for
+     * @return the number of bytes for encoded value
+     */
+    static int sizeOfStringNoTag(byte[] value) {
+        return value == null ? 0 : value.length;
     }
 
     /**
@@ -1524,11 +1607,11 @@ public final class ProtoWriterTools {
      * @param list string list value to get encoded size for
      * @return the number of bytes for encoded value
      */
-    public static int sizeOfStringList(FieldDefinition field, List<String> list) {
+    public static int sizeOfStringList(FieldDefinition field, List<byte[]> list) {
         int size = 0;
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
-            size += sizeOfDelimited(field, sizeOfStringNoTag(list.get(i)));
+            size += list.get(i).length;
         }
         return size;
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Utf8Tools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Utf8Tools.java
@@ -6,11 +6,39 @@ import static java.lang.Character.*;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * UTF8 tools based on protobuf standard library, so we are byte for byte identical
  */
 public final class Utf8Tools {
+
+    public static byte[] toUtf8Bytes(final String string) {
+        return string.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public static List<byte[]> toUtf8Bytes(final List<String> strings) {
+        return strings.stream().map(s -> {
+            return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        }).toList();
+    }
+
+    public static List<byte[]> toUtf8Bytes(final String... strings) {
+        return Arrays.stream(strings).map(s -> {
+            return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        }).toList();
+    }
+
+    public static String toUtf8String(final byte[] bytes) {
+        return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public static List<String> toUtf8String(final List<byte[]> bytesList) {
+        return bytesList.stream()
+                .map(bytes -> new String(bytes, java.nio.charset.StandardCharsets.UTF_8))
+                .toList();
+    }
 
     /**
      * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -310,6 +310,18 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     }
 
     /**
+     * A helper method for efficient copy of our data into a byte array.
+     *
+     * @param dst the byte array to copy into
+     * @param dstOffset the offset into the destination array to start copying into
+     * @return the number of bytes copied
+     */
+    public int writeTo(@NonNull final byte[] dst, final int dstOffset) {
+        System.arraycopy(buffer, start, dst, dstOffset, length);
+        return length;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/ProtobufObjectBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/ProtobufObjectBench.java
@@ -67,6 +67,7 @@ public abstract class ProtobufObjectBench<P, G extends GeneratedMessage> {
         private BufferedData outDataBufferDirect;
         private ByteBuffer bbout;
         private ByteBuffer bboutDirect;
+        private byte[] outArray;
 
         public void configure(
                 P pbjModelObject,
@@ -100,6 +101,7 @@ public abstract class ProtobufObjectBench<P, G extends GeneratedMessage> {
                 // output buffers
                 this.bout = new NonSynchronizedByteArrayOutputStream();
                 WritableStreamingData dout = new WritableStreamingData(this.bout);
+                this.outArray = new byte[this.protobuf.length*2]; // make sure big enough
                 this.outDataBuffer = BufferedData.allocate(this.protobuf.length);
                 this.outDataBufferDirect = BufferedData.allocateOffHeap(this.protobuf.length);
                 this.bbout = ByteBuffer.allocate(this.protobuf.length);
@@ -191,9 +193,8 @@ public abstract class ProtobufObjectBench<P, G extends GeneratedMessage> {
     @OperationsPerInvocation(OPERATION_COUNT)
     public void writePbjByteArray(BenchmarkState<P, G> benchmarkState, Blackhole blackhole) throws IOException {
         for (int i = 0; i < OPERATION_COUNT; i++) {
-            benchmarkState.outDataBuffer.reset();
-            benchmarkState.pbjCodec.write(benchmarkState.pbjModelObject, benchmarkState.outDataBuffer);
-            blackhole.consume(benchmarkState.outDataBuffer);
+            benchmarkState.pbjCodec.write(benchmarkState.pbjModelObject, benchmarkState.outArray, 0);
+            blackhole.consume(benchmarkState.outArray);
         }
     }
 
@@ -317,6 +318,13 @@ public abstract class ProtobufObjectBench<P, G extends GeneratedMessage> {
                     GetAccountDetailsResponse.AccountDetails::parseFrom,
                     GetAccountDetailsResponse.AccountDetails::parseFrom,
                     GetAccountDetailsResponse.AccountDetails::parseFrom);
+        }
+
+        public static void main(String[] args) throws Exception{
+            for (long i = 0; i < 10_000_000_000L; i++) {
+                AccountDetails.PROTOBUF.write(
+                        AccountDetailsPbj.ACCOUNT_DETAILS, new byte[5000], 0);
+            }
         }
     }
 }

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8Bench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8Bench.java
@@ -1,0 +1,311 @@
+package com.hedera.pbj.integration.jmh.utf8;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks three implementations: Utf8ToolsV1, Utf8ToolsV2, Utf8ToolsV3.
+ *
+ * <p>Each implementation must provide:</p>
+ * <pre>
+ *   public final class Utf8ToolsV* {
+ *       // private static int encodedLength(String) throws IOException {...} // (not used here)
+ *       public static String decodeUtf8(byte[] in, int offset, int length) throws java.io.IOException;
+ *       public static void encodeUtf8(String in, byte[] out, int offset) throws java.io.IOException;
+ *   }
+ * </pre>
+ * <p>We precompute input strings and their UTF-8 byte[] using the JDK encoder in @Setup,
+ * and we preallocate output buffers sized to the exact UTF-8 length so the measured
+ * methods do not allocate (other than what the implementation itself does).</p>
+ *
+ * <p>Make sure you run with JVM arg <code>--add-opens java.base/java.lang=ALL-UNNAMED</code></p>
+ */
+@SuppressWarnings("SameParameterValue")
+@BenchmarkMode({Mode.AverageTime})     // ops/sec; switch to SampleTime if you want latency histograms
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 3)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class Utf8Bench {
+    // -------------------- Parameters --------------------
+
+    /** Which implementation to run (maps to class switch below). */
+    @Param({"V0", "V1", "V2", "V3", "V4"})
+//    @Param({"V4"})
+    public String impl;
+
+    /** Dataset shape: ASCII-heavy, Latin-1, Mixed BMP, Emoji (surrogates). */
+    @Param({"ascii", "latin1", "mixed", "emoji"})
+//    @Param({"ascii"})
+    public String dataset;
+
+    /** Mean string length to generate. Actual strings vary around this length. */
+    @Param({"8", "32", "100"})
+    public int meanLen;
+
+    /** Number of distinct strings in the corpus (cycled during the run). */
+    @Param({"1024"})
+    public int corpusSize;
+
+    // -------------------- Corpus --------------------
+
+    private String[] strings;         // inputs for encode & round-trip
+    private byte[][] utf8Bytes;       // pre-encoded with JDK for decode benchmark
+    private byte[][] encodeBuffers;   // sized exactly to utf8 length
+    private int[] utf8Lens;           // lengths of utf8Bytes[i]
+    private int[] utf8LensJdk;        // for correctness check of encodedLength
+    private int idxMask;              // for cheap modulo (power-of-two corpus)
+
+    private final Random rnd = new Random(4141684161512124L);
+
+    // -------------------- Lifecycle --------------------
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        // Ensure corpusSize is a power of two for cheap cycling
+        int pow2 = 1;
+        while (pow2 < corpusSize) pow2 <<= 1;
+        if (pow2 != corpusSize) {
+            corpusSize = pow2; // silently round up
+        }
+        idxMask = corpusSize - 1;
+
+        strings = new String[corpusSize];
+        utf8Bytes = new byte[corpusSize][];
+        utf8Lens = new int[corpusSize];
+        utf8LensJdk = new int[corpusSize];
+        encodeBuffers = new byte[corpusSize][];
+
+        // Generate corpus
+        for (int i = 0; i < corpusSize; i++) {
+            String s = switch (dataset) {
+                case "ascii"  -> genAsciiString(meanLen, 0.50);
+                case "latin1" -> genLatin1String(meanLen, 0.50);       // includes bytes 0x80..0xFF (→ 2-byte UTF-8)
+                case "mixed"  -> genMixedBmpString(meanLen, 0.30, 0.10); // some non-ASCII BMP
+                case "emoji"  -> genEmojiString(meanLen, 0.15);        // surrogate pairs sprinkled in
+                default -> throw new IllegalArgumentException("Unknown dataset: " + dataset);
+            };
+            strings[i] = s;
+
+            // Pre-encode with the JDK for decode() input and for sizing encode buffers.
+            byte[] u = s.getBytes(StandardCharsets.UTF_8);
+            utf8Bytes[i] = u;
+            utf8Lens[i] = u.length;
+            utf8LensJdk[i] = u.length;
+            encodeBuffers[i] = new byte[u.length]; // exact size; offset=0 in benchmarks
+        }
+
+        // Quick sanity: round-trip each impl once to catch broken code before timing
+        for (String version : new String[]{"V1", "V2", "V3"}) {
+            for (int i = 0; i < Math.min(corpusSize, 128); i++) {
+                String s = strings[i];
+                byte[] buf = new byte[utf8Lens[i]];
+                encode(version, s, buf, 0);
+                String back = decode(version, buf, 0, buf.length);
+                if (!s.equals(back)) {
+                    throw new IllegalStateException(version + " failed round-trip on sample " + i);
+                }
+            }
+        }
+
+
+        // Sanity: encodedLength must match JDK UTF-8 byte length
+        for (String version : new String[]{"V1", "V2", "V3"}) {
+            for (int i = 0; i < Math.min(corpusSize, 1024); i++) {
+                int len = strings[i].getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+                if (len != utf8LensJdk[i]) {
+                    throw new IllegalStateException(version + " encodedLength mismatch at " + i
+                    + " expected=" + utf8LensJdk[i] + " got=" + len
+                    + " str=\"" + preview(strings[i]) + "\"");
+                }
+            }
+         }
+    }
+
+    // -------------------- Benchmarks --------------------
+
+    private int cursor = 0;
+
+    /** Encode String -> UTF-8 bytes into a pre-sized buffer. */
+    @Benchmark
+    public void encode(Blackhole bh) throws Exception {
+        final int i = (cursor++) & idxMask;
+        final String s = strings[i];
+        final byte[] out = encodeBuffers[i];
+        encode(impl, s, out, 0);
+        // Consume a couple of bytes to keep JIT honest (avoid DCE):
+        bh.consume(out[0]);
+        bh.consume(out[out.length - 1]);
+    }
+
+    /** Decode UTF-8 bytes -> String (input was pre-encoded by the JDK). */
+    @Benchmark
+    public void decode(Blackhole bh) throws Exception {
+        final int i = (cursor++) & idxMask;
+        final byte[] in = utf8Bytes[i];
+        final String s = decode(impl, in, 0, in.length);
+        // Consume length & first char (if present) to avoid DCE:
+        bh.consume(s.length());
+        if (!s.isEmpty()) bh.consume(s.charAt(0));
+    }
+
+    /** Round-trip using the impl for both encode and decode (avoids JDK encoder in timed region). */
+    @Benchmark
+    public void roundTrip(Blackhole bh) throws Exception {
+        final int i = (cursor++) & idxMask;
+        final String s = strings[i];
+        final byte[] buf = encodeBuffers[i];
+        encode(impl, s, buf, 0);
+        final String back = decode(impl, buf, 0, buf.length);
+        bh.consume(back.length());
+    }
+
+    /** Measure just the UTF-8 length computation (no encoding). */
+    @Benchmark
+    public void encodedLength(Blackhole bh) {
+        final int i = (cursor++) & idxMask;
+        final String s = strings[i];
+        final int len = encodedLength(impl, s);
+        // consume value and a char to discourage CSE / constant folding
+                bh.consume(len);
+        if (!s.isEmpty()) bh.consume(s.charAt(0));
+    }
+
+    // -------------------- Dispatch to implementations --------------------
+
+    // Replace these with your real classes (same static method signatures).
+    // Example: Utf8ToolsV1.encodeUtf8(in, out, off);
+    private static void encode(String version, String in, byte[] out, int off) throws Exception {
+        switch (version) {
+            case "V0" -> Utf8ToolsV0.encodeUtf8(in, out, off);
+            case "V1" -> Utf8ToolsV1.encodeUtf8(in, out, off);
+            case "V2" -> Utf8ToolsV2.encodeUtf8(in, out, off);
+            case "V3" -> Utf8ToolsV3.encodeUtf8(in, out, off);
+            case "V4" -> Utf8ToolsV4.encodeUtf8(in, out, off);
+            default -> throw new IllegalArgumentException(version);
+        }
+    }
+
+    private static String decode(String version, byte[] in, int off, int len) throws Exception {
+        return switch (version) {
+            case "V0" -> Utf8ToolsV0.decodeUtf8(in, off, len);
+            case "V1" -> Utf8ToolsV1.decodeUtf8(in, off, len);
+            case "V2" -> Utf8ToolsV2.decodeUtf8(in, off, len);
+            case "V3" -> Utf8ToolsV3.decodeUtf8(in, off, len);
+            case "V4" -> Utf8ToolsV4.decodeUtf8(in, off, len);
+            default -> throw new IllegalArgumentException(version);
+        };
+    }
+
+
+    private static int encodedLength(String version, String s) {
+        try {
+                return switch (version) {
+                        case "V0" -> Utf8ToolsV0.encodedLength(s);
+                        case "V1" -> Utf8ToolsV1.encodedLength(s);
+                        case "V2" -> Utf8ToolsV2.encodedLength(s);
+                        case "V3" -> Utf8ToolsV3.encodedLength(s);
+                        case "V4" -> Utf8ToolsV4.encodedLength(s);
+                        default -> throw new IllegalArgumentException(version);
+                    };
+            } catch (java.io.IOException e) {
+                // Treat malformed handling as a failure in correctness check
+                        throw new RuntimeException(e);
+            }
+    }
+
+
+    // -------------------- Generators (fast & simple; deterministic-ish) --------------------
+
+    private String genAsciiString(int mean, double punctRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            if (rnd.nextDouble() < punctRatio) {
+                sb.append(" .,-_/+[]()".charAt(rnd.nextInt(11)));
+            } else {
+                char c = (char) ('a' + rnd.nextInt(26));
+                if (rnd.nextBoolean()) c = Character.toUpperCase(c);
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    private String genLatin1String(int mean, double highRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            if (rnd.nextDouble() < highRatio) {
+                // 0x80..0xFF (valid Latin-1; forces 2-byte UTF-8)
+                sb.append((char) (0x80 + rnd.nextInt(0x80)));
+            } else {
+                sb.append((char) (' ' + rnd.nextInt(95))); // ASCII printable
+            }
+        }
+        return sb.toString();
+    }
+
+    private String genMixedBmpString(int mean, double nonAsciiRatio, double threeByteRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            double r = rnd.nextDouble();
+            if (r < nonAsciiRatio) {
+                if (r < threeByteRatio) {
+                    // 3-byte UTF-8 BMP range excluding surrogates (e.g., Greek/Cyrillic)
+                    char c = (char) (0x0800 + rnd.nextInt(0xD7FF - 0x0800));
+                    sb.append(c);
+                } else {
+                    // Latin-1 high bytes (2-byte UTF-8)
+                    sb.append((char) (0x80 + rnd.nextInt(0x80)));
+                }
+            } else {
+                sb.append((char) (' ' + rnd.nextInt(95)));
+            }
+        }
+        return sb.toString();
+    }
+
+    private String genEmojiString(int mean, double emojiRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            if (rnd.nextDouble() < emojiRatio) {
+                // A few common emoji code points (U+1F3xx / U+1F60x / U+1F9xx)
+                int[] cps = {0x1F600, 0x1F602, 0x1F603, 0x1F60D, 0x1F680, 0x1F64C, 0x1F4AF, 0x1F3C3, 0x1F9E9};
+                int cp = cps[rnd.nextInt(cps.length)];
+                sb.appendCodePoint(cp);
+            } else {
+                sb.append((char) (' ' + rnd.nextInt(95)));
+            }
+        }
+        return sb.toString();
+    }
+
+    private int jitteredLen(int mean) {
+        // ±25% jitter around mean, min 1
+        int span = Math.max(1, mean / 4);
+        return Math.max(1, mean - span + rnd.nextInt(2 * span + 1));
+    }
+
+    private static String preview(String s) {
+        if (s.length() <= 24) return s;
+        return s.substring(0, 24) + "…(" + s.length() + ")";
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV0.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV0.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.isSurrogatePair;
+import static java.lang.Character.toCodePoint;
+
+import com.hedera.pbj.runtime.MalformedProtobufException;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * UTF8 Tools based on java standard library
+ */
+@SuppressWarnings("DuplicatedCode")
+public final class Utf8ToolsV0 {
+    public static int encodedLength(final String in) {
+        return in.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+    }
+
+    public static String decodeUtf8(byte[] in, int offset, int length) {
+        return new String(in, offset, length, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public static int encodeUtf8(String in, byte[] out, int offset) {
+        byte[] b = in.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        System.arraycopy(b, 0, out, offset, b.length);
+        return b.length;
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV2.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV2.java
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.pbj.runtime;
+package com.hedera.pbj.integration.jmh.utf8;
 
-import static java.lang.Character.*;
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.isSurrogatePair;
+import static java.lang.Character.toCodePoint;
 
+import com.hedera.pbj.runtime.MalformedProtobufException;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -10,7 +15,7 @@ import java.io.IOException;
 /**
  * UTF8 tools based on protobuf standard library, so we are byte for byte identical
  */
-public final class Utf8Tools {
+public final class Utf8ToolsV2 {
 
     /**
      * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this
@@ -20,36 +25,51 @@ public final class Utf8Tools {
      * @throws IllegalArgumentException if {@code sequence} contains ill-formed UTF-16 (unpaired
      *     surrogates)
      */
-    static int encodedLength(final CharSequence sequence) throws IOException {
-        if (sequence == null) {
-            return 0;
-        }
-        // Warning to maintainers: this implementation is highly optimized.
-        int utf16Length = sequence.length();
-        int utf8Length = utf16Length;
-        int i = 0;
-
-        // This loop optimizes for pure ASCII.
-        while (i < utf16Length && sequence.charAt(i) < 0x80) {
-            i++;
-        }
-
-        // This loop optimizes for chars less than 0x800.
-        for (; i < utf16Length; i++) {
-            char c = sequence.charAt(i);
-            if (c < 0x800) {
-                utf8Length += ((0x7f - c) >>> 31); // branch free!
+    public static int encodedLength(final String in) throws IOException {
+        int len = 0;
+        for (int i = 0; i < in.length(); ) {
+            int codePoint = in.codePointAt(i);
+            if (codePoint <= 0x7F) {
+                len += 1;
+            } else if (codePoint <= 0x7FF) {
+                len += 2;
+            } else if (codePoint <= 0xFFFF) {
+                len += 3;
             } else {
-                utf8Length += encodedLengthGeneral(sequence, i);
-                break;
+                len += 4;
             }
+            i += Character.charCount(codePoint);
         }
-
-        if (utf8Length < utf16Length) {
-            // Necessary and sufficient condition for overflow because of maximum 3x expansion
-            throw new IllegalArgumentException("UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
-        }
-        return utf8Length;
+        return len;
+//        if (in == null) {
+//            return 0;
+//        }
+//        // Warning to maintainers: this implementation is highly optimized.
+//        int utf16Length = in.length();
+//        int utf8Length = utf16Length;
+//        int i = 0;
+//
+//        // This loop optimizes for pure ASCII.
+//        while (i < utf16Length && in.charAt(i) < 0x80) {
+//            i++;
+//        }
+//
+//        // This loop optimizes for chars less than 0x800.
+//        for (; i < utf16Length; i++) {
+//            char c = in.charAt(i);
+//            if (c < 0x800) {
+//                utf8Length += ((0x7f - c) >>> 31); // branch free!
+//            } else {
+//                utf8Length += encodedLengthGeneral(in, i);
+//                break;
+//            }
+//        }
+//
+//        if (utf8Length < utf16Length) {
+//            // Necessary and sufficient condition for overflow because of maximum 3x expansion
+//            throw new IllegalArgumentException("UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
+//        }
+//        return utf8Length;
     }
 
     private static int encodedLengthGeneral(final CharSequence sequence, final int start) throws IOException {
@@ -75,44 +95,8 @@ public final class Utf8Tools {
         return utf8Length;
     }
 
-    /**
-     * Encodes the input character sequence to a {@link WritableSequentialData} using the same algorithm as protoc, so we are
-     * byte for byte the same.
-     */
-    static void encodeUtf8(final CharSequence in, final WritableSequentialData out) throws IOException {
-        final int inLength = in.length();
-        for (int inIx = 0; inIx < inLength; ++inIx) {
-            final char c = in.charAt(inIx);
-            if (c < 0x80) {
-                // One byte (0xxx xxxx)
-                out.writeByte((byte) c);
-            } else if (c < 0x800) {
-                // Two bytes (110x xxxx 10xx xxxx)
-
-                // Benchmarks show put performs better than putShort here (for HotSpot).
-                out.writeByte2((byte) (0xC0 | (c >>> 6)), (byte) (0x80 | (0x3F & c)));
-            } else if (c < MIN_SURROGATE || MAX_SURROGATE < c) {
-                // Three bytes (1110 xxxx 10xx xxxx 10xx xxxx)
-                // Maximum single-char code point is 0xFFFF, 16 bits.
-
-                // Benchmarks show put performs better than putShort here (for HotSpot).
-                out.writeByte3(
-                        (byte) (0xE0 | (c >>> 12)), (byte) (0x80 | (0x3F & (c >>> 6))), (byte) (0x80 | (0x3F & c)));
-            } else {
-                // Four bytes (1111 xxxx 10xx xxxx 10xx xxxx 10xx xxxx)
-                // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
-                final char low;
-                if (inIx + 1 == inLength || !isSurrogatePair(c, (low = in.charAt(++inIx)))) {
-                    throw new MalformedProtobufException("Unpaired surrogate at index " + inIx + " of " + inLength);
-                }
-                int codePoint = toCodePoint(c, low);
-                out.writeByte4(
-                        (byte) ((0xF << 4) | (codePoint >>> 18)),
-                        (byte) (0x80 | (0x3F & (codePoint >>> 12))),
-                        (byte) (0x80 | (0x3F & (codePoint >>> 6))),
-                        (byte) (0x80 | (0x3F & codePoint)));
-            }
-        }
+    public static String decodeUtf8(byte[] in, int offset, int length) {
+        return new String(in, offset, length, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     /**
@@ -125,7 +109,7 @@ public final class Utf8Tools {
      * @return The number of bytes written
      * @throws MalformedProtobufException if the input contains unpaired surrogates
      */
-    public static int encodeUtf8(@NonNull final byte[] out, final int offset, final String in) throws MalformedProtobufException{
+    public static int encodeUtf8(final String in, @NonNull final byte[] out, final int offset) throws MalformedProtobufException{
         int utf16Length = in.length();
         int i = 0;
         int j = offset;
@@ -166,4 +150,5 @@ public final class Utf8Tools {
         }
         return j - offset;
     }
+
 }

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV3.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV3.java
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import java.io.IOException;
+
+/**
+ * UTF8 tools based on protobuf standard library, so we are byte for byte identical
+ */
+public final class Utf8ToolsV3 {
+
+    // ----------------------------------------------------------------------
+    // Public API
+    // ----------------------------------------------------------------------
+
+    /** Strict UTF-8 decode. Throws IOException on malformed sequences. */
+    public static String decodeUtf8(final byte[] in, final int offset, final int length) throws IOException {
+        if ((offset | length) < 0 || offset + length > in.length) {
+            throw new IndexOutOfBoundsException("decodeUtf8: bad offset/length");
+        }
+        final int end = offset + length;
+
+        // Fast ASCII-only pass; if all ASCII, build String directly.
+        int i = offset;
+        while (i < end && (in[i] >= 0)) i++;
+        if (i == end) {
+            // All ASCII
+            char[] chars = new char[length];
+            for (int p = 0; p < length; p++) {
+                chars[p] = (char) (in[offset + p] & 0x7F);
+            }
+            return new String(chars);
+        }
+
+        // Two-pass: count UTF-16 code units, then decode into a single char[].
+        final int charCount = countUtf16UnitsStrict(in, offset, end);
+        final char[] out = new char[charCount];
+
+        // Decode pass
+        int outPos = 0;
+        i = offset;
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                out[outPos++] = (char) b0;
+                // try to chew a few ASCII in a tight loop
+                while (i < end && (in[i] >= 0)) {
+                    out[outPos++] = (char) (in[i++] & 0x7F);
+                }
+                continue;
+            }
+            if ((b0 & 0xE0) == 0xC0) {               // 2-byte
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                int cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+                // reject overlongs: must be >= 0x80; also b0 >= 0xC2
+                if (cp < 0x80 || b0 < 0xC2) throw bad();
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF0) == 0xE0) {               // 3-byte
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+
+                // E0: b1 >= 0xA0 to avoid overlong; ED: b1 <= 0x9F to avoid surrogates
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad();
+                if (b0 == 0xED && b1 >= 0xA0) throw bad();
+
+                int cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+                if (cp >= 0xD800 && cp <= 0xDFFF) throw bad(); // no UTF-8-encoded surrogates
+                if (cp < 0x800) throw bad(); // overlong (should have been 2-byte)
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF8) == 0xF0) {               // 4-byte
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                int b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+
+                // F0: b1 >= 0x90 (avoid overlong); F4: b1 <= 0x8F (max U+10FFFF); F5..FF invalid
+                if (b0 == 0xF0 && b1 < 0x90) throw bad();
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad();
+
+                int cp = ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+                if (cp < 0x10000 || cp > 0x10FFFF) throw bad();
+
+                // Encode as surrogate pair in UTF-16
+                int hi = ((cp - 0x10000) >>> 10) + 0xD800;
+                int lo = ((cp - 0x10000) & 0x3FF) + 0xDC00;
+                out[outPos++] = (char) hi;
+                out[outPos++] = (char) lo;
+                continue;
+            }
+            throw bad();
+        }
+
+        return new String(out);
+    }
+
+    /**
+     * Encodes {@code in} to UTF-8 into {@code out} starting at {@code offset}.
+     * Returns the number of bytes written. Throws IOException if {@code out}
+     * does not have enough space or on invalid surrogate usage.
+     */
+    public static int encodeUtf8(final String in, final byte[] out, final int offset) throws IOException {
+        if (in == null) throw new NullPointerException("in");
+        if (offset < 0 || offset > out.length) throw new IndexOutOfBoundsException("encodeUtf8: bad offset");
+
+        final int need = encodedLength(in); // also validates surrogate pairs
+        if (out.length - offset < need) {
+            throw new IOException("encodeUtf8: insufficient space: need=" + need + " have=" + (out.length - offset));
+        }
+
+        int pos = offset;
+        final int n = in.length();
+        int i = 0;
+
+        // ASCII fast path (eat a run)
+        while (i < n) {
+            char c = in.charAt(i);
+            if (c <= 0x7F) {
+                out[pos++] = (byte) c;
+                i++;
+                while (i < n) {
+                    char d = in.charAt(i);
+                    if (d > 0x7F) break;
+                    out[pos++] = (byte) d;
+                    i++;
+                }
+                continue;
+            }
+
+            if (c <= 0x7FF) {
+                out[pos++] = (byte) (0xC0 | (c >>> 6));
+                out[pos++] = (byte) (0x80 | (c & 0x3F));
+                i++;
+                continue;
+            }
+
+            if (Character.isHighSurrogate(c)) {
+                if (i + 1 >= n) throw new IOException("encodeUtf8: unpaired high surrogate at end");
+                char d = in.charAt(i + 1);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodeUtf8: unpaired high surrogate");
+                int cp = Character.toCodePoint(c, d);
+                // 4-byte
+                out[pos++] = (byte) (0xF0 | (cp >>> 18));
+                out[pos++] = (byte) (0x80 | ((cp >>> 12) & 0x3F));
+                out[pos++] = (byte) (0x80 | ((cp >>> 6) & 0x3F));
+                out[pos++] = (byte) (0x80 | (cp & 0x3F));
+                i += 2;
+                continue;
+            }
+
+            if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodeUtf8: unpaired low surrogate");
+            }
+
+            // 3-byte (BMP non-surrogate)
+            out[pos++] = (byte) (0xE0 | (c >>> 12));
+            out[pos++] = (byte) (0x80 | ((c >>> 6) & 0x3F));
+            out[pos++] = (byte) (0x80 | (c & 0x3F));
+            i++;
+        }
+        return pos - offset;
+    }
+
+    // ----------------------------------------------------------------------
+    // Private helpers
+    // ----------------------------------------------------------------------
+
+    /** Computes the exact number of UTF-8 bytes required for {@code str}. Validates surrogate pairing. */
+    public static int encodedLength(final String str) throws IOException {
+        final int n = str.length();
+        int len = 0;
+        int i = 0;
+
+        // Fast ASCII prefix
+        while (i < n) {
+            char c = str.charAt(i);
+            if (c > 0x7F) break;
+            len++; i++;
+            // nibble a few ASCII in a burst
+            while (i < n) {
+                char d = str.charAt(i);
+                if (d > 0x7F) break;
+                len++; i++;
+            }
+        }
+
+        while (i < n) {
+            char c = str.charAt(i++);
+            if (c <= 0x7F) {
+                len += 1;
+            } else if (c <= 0x7FF) {
+                len += 2;
+            } else if (Character.isHighSurrogate(c)) {
+                if (i >= n) throw new IOException("encodedLength: unpaired high surrogate at end");
+                char d = str.charAt(i);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodedLength: unpaired high surrogate");
+                i++; // consume pair
+                len += 4;
+            } else if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodedLength: unpaired low surrogate");
+            } else {
+                len += 3;
+            }
+        }
+        return len;
+    }
+
+    /** Counts UTF-16 code units produced by decoding strict UTF-8 in in[offset..end). */
+    private static int countUtf16UnitsStrict(final byte[] in, final int offset, final int end) throws IOException {
+        int i = offset;
+        int count = 0;
+
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                count += 1;
+                // run of ASCII
+                while (i < end && (in[i] >= 0)) { i++; count++; }
+                continue;
+            }
+
+            if ((b0 & 0xE0) == 0xC0) {                 // 2-byte
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                int cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+                if (cp < 0x80 || b0 < 0xC2) throw bad(); // overlong / invalid
+                count += 1;
+                continue;
+            }
+
+            if ((b0 & 0xF0) == 0xE0) {                 // 3-byte
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad();     // overlong
+                if (b0 == 0xED && b1 >= 0xA0) throw bad();    // surrogate range
+                int cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+                if (cp < 0x800) throw bad();                  // overlong
+                if (cp >= 0xD800 && cp <= 0xDFFF) throw bad();// encoded surrogate
+                count += 1;
+                continue;
+            }
+
+            if ((b0 & 0xF8) == 0xF0) {                 // 4-byte
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                int b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xF0 && b1 < 0x90) throw bad();     // overlong
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad(); // > U+10FFFF
+                count += 2; // surrogate pair in UTF-16
+                continue;
+            }
+
+            throw bad();
+        }
+        return count;
+    }
+
+    private static IOException bad() {
+        return new IOException("Malformed UTF-8 input");
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV4.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV4.java
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+
+/**
+ * UTF8 tools based on protobuf standard library, so we are byte for byte identical
+ */
+public final class Utf8ToolsV4 {
+
+    // ---- Internal fast-path plumbing ---------------------------------------------------------
+
+    // Compact Strings: coder == 0 (LATIN1), 1 (UTF16)
+    private static final byte CODER_LATIN1 = 0;
+    private static final byte CODER_UTF16  = 1;
+
+    // Guard: if these are non-null, we can fast-path on String internals.
+    private static final VarHandle STRING_VALUE_VH;
+    private static final VarHandle STRING_CODER_VH;
+    private static final boolean   HAS_STRING_VH;
+
+    static {
+        VarHandle v = null, c = null;
+        boolean ok = false;
+        try {
+            MethodHandles.Lookup l = MethodHandles.privateLookupIn(String.class, MethodHandles.lookup());
+            v = l.findVarHandle(String.class, "value", byte[].class);
+            c = l.findVarHandle(String.class, "coder", byte.class);
+            ok = (v != null && c != null);
+        } catch (Throwable ignore) {
+            ignore.printStackTrace();
+            ok = false;
+        }
+        STRING_VALUE_VH = v;
+        STRING_CODER_VH = c;
+        HAS_STRING_VH   = ok;
+    }
+
+    // Helpers
+    private static byte[] stringValueBytes(String s) { return (byte[]) STRING_VALUE_VH.get(s); }
+    private static byte   stringCoder(String s)      { return (byte)   STRING_CODER_VH.get(s); }
+
+    // ---- Public API --------------------------------------------------------------------------
+
+    /** Strict UTF-8 decode. Throws IOException on malformed sequences. */
+    public static String decodeUtf8(final byte[] in, final int offset, final int length) throws IOException {
+        if ((offset | length) < 0 || offset + length > in.length) {
+            throw new IndexOutOfBoundsException("decodeUtf8: bad offset/length");
+        }
+        final int end = offset + length;
+
+        // ASCII run fast path
+        int i = offset;
+        while (i < end && in[i] >= 0) i++;
+        if (i == end) {
+            char[] chars = new char[length];
+            for (int p = 0; p < length; p++) chars[p] = (char) (in[offset + p] & 0x7F);
+            return new String(chars);
+        }
+
+        // Count UTF-16 units (strict validation)
+        final int charCount = countUtf16UnitsStrict(in, offset, end);
+        final char[] out = new char[charCount];
+
+        // Decode
+        int outPos = 0;
+        i = offset;
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                out[outPos++] = (char) b0;
+                while (i < end && in[i] >= 0) out[outPos++] = (char) (in[i++] & 0x7F);
+                continue;
+            }
+            if ((b0 & 0xE0) == 0xC0) {
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                int cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+                if (cp < 0x80 || b0 < 0xC2) throw bad(); // overlong
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF0) == 0xE0) {
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad();
+                if (b0 == 0xED && b1 >= 0xA0) throw bad();
+                int cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+                if (cp < 0x800 || (cp >= 0xD800 && cp <= 0xDFFF)) throw bad();
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF8) == 0xF0) {
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF, b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xF0 && b1 < 0x90) throw bad();
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad();
+                int cp = ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+                if (cp < 0x10000 || cp > 0x10FFFF) throw bad();
+                int hi = ((cp - 0x10000) >>> 10) + 0xD800;
+                int lo = ((cp - 0x10000) & 0x3FF) + 0xDC00;
+                out[outPos++] = (char) hi;
+                out[outPos++] = (char) lo;
+                continue;
+            }
+            throw bad();
+        }
+        return new String(out);
+    }
+
+    /**
+     * Encodes {@code in} to UTF-8 into {@code out} at {@code offset}.
+     * Returns bytes written. Throws if insufficient space or malformed surrogates.
+     * Uses a VarHandle fast path for String LATIN1 (Compact String) when available.
+     */
+    public static int encodeUtf8(final String in, final byte[] out, final int offset) throws IOException {
+        Objects.requireNonNull(in, "in");
+        // Try the internal LATIN1 fast path
+        if (HAS_STRING_VH && stringCoder(in) == CODER_LATIN1) {
+            final byte[] v = stringValueBytes(in);
+            // Quick ASCII check; if all ASCII, we can memcpy directly.
+            int i = 0, n = v.length;
+            while (i < n && (v[i] & 0x80) == 0) i++;
+            if (i == n) {
+                // Pure ASCII: exact size == n
+                if (out.length - offset < n)
+                    throw new IOException("encodeUtf8: insufficient space (ASCII path)");
+                System.arraycopy(v, 0, out, offset, n);
+                return n;
+            }
+            // Mixed Latin-1: encode in one pass. Worst-case length = n (ASCII) + 2*(non-ascii bytes)
+            // Exact length is computed below (without allocating).
+            return encodeLatin1ToUtf8(v, out, offset);
+        }
+        // Portable path (handles UTF16 coder as well)
+        return encodePortable(in, out, offset);
+    }
+
+    /**
+     * Returns the exact UTF-8 byte length for {@code str}. Validates surrogate pairing.
+     * Uses internal LATIN1 fast path if available.
+     */
+    public static int encodedLength(final String str) throws IOException {
+        if (HAS_STRING_VH && stringCoder(str) == CODER_LATIN1) {
+            return encodedLengthLatin1(stringValueBytes(str));
+        }
+        // Portable path for UTF16 (or if internals not available)
+        final int n = str.length();
+        int len = 0;
+        int i = 0;
+
+        // ASCII prefix
+        while (i < n && str.charAt(i) <= 0x7F) { len++; i++; }
+        while (i < n) {
+            char c = str.charAt(i++);
+            if (c <= 0x7F) {
+                len += 1;
+            } else if (c <= 0x7FF) {
+                len += 2;
+            } else if (Character.isHighSurrogate(c)) {
+                if (i >= n) throw new IOException("encodedLength: unpaired high surrogate at end");
+                char d = str.charAt(i);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodedLength: unpaired high surrogate");
+                i++; len += 4;
+            } else if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodedLength: unpaired low surrogate");
+            } else {
+                len += 3;
+            }
+        }
+        return len;
+    }
+
+    // ---- Internal fast-path (LATIN1 String.value) --------------------------------------------
+
+    /** Exact UTF-8 length for a LATIN1 byte[] (no surrogates exist in LATIN1). */
+    private static int encodedLengthLatin1(final byte[] latin1) {
+        int ascii = 0, hi = 0; // count ASCII vs high bytes
+        for (byte b : latin1) {
+            if ((b & 0x80) == 0) ascii++; else hi++;
+        }
+        // ASCII -> 1 byte; high bytes (0x80..0xFF) -> 2-byte UTF-8
+        return ascii + (hi << 1);
+    }
+
+    /** Encodes a LATIN1 byte[] directly to UTF-8. Returns bytes written. */
+    private static int encodeLatin1ToUtf8(final byte[] latin1, final byte[] out, final int offset) {
+        int pos = offset;
+        int i = 0, n = latin1.length;
+
+        // ASCII run
+        while (i < n && (latin1[i] & 0x80) == 0) {
+            out[pos++] = latin1[i++];
+            while (i < n && (latin1[i] & 0x80) == 0) {
+                out[pos++] = latin1[i++];
+            }
+            // then fall into non-ASCII handling if applicable
+        }
+
+        while (i < n) {
+            int b = latin1[i++] & 0xFF;
+            if ((b & 0x80) == 0) {
+                // ASCII
+                out[pos++] = (byte) b;
+            } else {
+                // LATIN1 0x80..0xFF -> two-byte UTF-8: 0xC2/0xC3 prefix depending on top bit of 0x80..0xFF
+                // Values 0x80..0xBF => 0xC2 xx ; 0xC0..0xFF => 0xC3 (b - 0x40)
+                if (b < 0xC0) {
+                    out[pos++] = (byte) 0xC2;
+                    out[pos++] = (byte) b;
+                } else {
+                    out[pos++] = (byte) 0xC3;
+                    out[pos++] = (byte) (b - 0x40); // (b & 0x3F) | 0x80
+                }
+            }
+        }
+        return pos - offset;
+    }
+
+    // ---- Portable encode (UTF-16 String) -----------------------------------------------------
+
+    private static int encodePortable(final String in, final byte[] out, final int offset) throws IOException {
+        int pos = offset;
+        final int n = in.length();
+        int i = 0;
+
+        // ASCII fast path
+        while (i < n) {
+            char c = in.charAt(i);
+            if (c <= 0x7F) {
+                out[pos++] = (byte) c;
+                i++;
+                while (i < n) {
+                    char d = in.charAt(i);
+                    if (d > 0x7F) break;
+                    out[pos++] = (byte) d;
+                    i++;
+                }
+                continue;
+            }
+            if (c <= 0x7FF) {
+                out[pos++] = (byte) (0xC0 | (c >>> 6));
+                out[pos++] = (byte) (0x80 | (c & 0x3F));
+                i++;
+                continue;
+            }
+            if (Character.isHighSurrogate(c)) {
+                if (i + 1 >= n) throw new IOException("encodeUtf8: unpaired high surrogate at end");
+                char d = in.charAt(i + 1);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodeUtf8: unpaired high surrogate");
+                int cp = Character.toCodePoint(c, d);
+                out[pos++] = (byte) (0xF0 | (cp >>> 18));
+                out[pos++] = (byte) (0x80 | ((cp >>> 12) & 0x3F));
+                out[pos++] = (byte) (0x80 | ((cp >>> 6) & 0x3F));
+                out[pos++] = (byte) (0x80 | (cp & 0x3F));
+                i += 2;
+                continue;
+            }
+            if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodeUtf8: unpaired low surrogate");
+            }
+            out[pos++] = (byte) (0xE0 | (c >>> 12));
+            out[pos++] = (byte) (0x80 | ((c >>> 6) & 0x3F));
+            out[pos++] = (byte) (0x80 | (c & 0x3F));
+            i++;
+        }
+        return pos - offset;
+    }
+
+    // ---- Strict counting for decode ----------------------------------------------------------
+
+    private static int countUtf16UnitsStrict(final byte[] in, final int offset, final int end) throws IOException {
+        int i = offset, count = 0;
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                count += 1;
+                while (i < end && in[i] >= 0) { i++; count++; }
+                continue;
+            }
+            if ((b0 & 0xE0) == 0xC0) {
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                if (b0 < 0xC2) throw bad(); // overlong
+                count += 1;
+                continue;
+            }
+            if ((b0 & 0xF0) == 0xE0) {
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad();
+                if (b0 == 0xED && b1 >= 0xA0) throw bad();
+                count += 1;
+                continue;
+            }
+            if ((b0 & 0xF8) == 0xF0) {
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF, b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xF0 && b1 < 0x90) throw bad();
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad();
+                count += 2; // surrogate pair
+                continue;
+            }
+            throw bad();
+        }
+        return count;
+    }
+
+    private static IOException bad() { return new IOException("Malformed UTF-8"); }
+
+
+    public static void main(String[] args) throws IOException {
+        encodeUtf8("hello", new byte[10], 0);
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/VarInt32SizeOfBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/VarInt32SizeOfBench.java
@@ -1,0 +1,81 @@
+package com.hedera.pbj.integration.jmh.varint;
+
+import com.hedera.pbj.runtime.ProtoWriterTools;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@SuppressWarnings("unused")
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 4, time = 2)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class VarInt32SizeOfBench {
+    public static final int NUM_OF_VALUES = 1024;
+    @Param({"1", "2", "4"})
+    public int numOfBytes;
+    private int[] numbers;
+
+    @Setup
+    public void setupNumbers() {
+        Random random = new Random(9387498731984L);
+        numbers = new int[NUM_OF_VALUES];
+        final int minValue = numOfBytes == 1 ? 0 : 1 << ((numOfBytes - 1) * 7);
+        final int maxValue = (1 << (numOfBytes * 7)) - 1;
+        for (int i = 0; i < NUM_OF_VALUES; i++) {
+            this.numbers[i] = random.nextInt(minValue, maxValue);
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void pbjProtoTools(Blackhole blackhole) {
+        for (int i = 0; i < NUM_OF_VALUES; i++) blackhole.consume(ProtoWriterTools.sizeOfUnsignedVarInt32(numbers[i]));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void kafka(Blackhole blackhole) {
+        for (int i = 0; i < NUM_OF_VALUES; i++) blackhole.consume(kafkaSizeOfUnsignedVarint(numbers[i]));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void google(Blackhole blackhole) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) blackhole.consume(com.google.protobuf.CodedOutputStream
+                .computeInt32SizeNoTag(numbers[i]));
+    }
+
+    public static int kafkaSizeOfUnsignedVarint(int value) {
+        // Protocol buffers varint encoding is variable length, with a minimum of 1 byte
+        // (for zero). The values themselves are not important. What's important here is
+        // any leading zero bits are dropped from output. We can use this leading zero
+        // count w/ fast intrinsic to calc the output length directly.
+        // Test cases verify this matches the output for loop logic exactly.
+        // return (38 - leadingZeros) / 7 + leadingZeros / 32;
+        // The above formula provides the implementation, but the Java encoding is suboptimal
+        // when we have a narrow range of integers, so we can do better manually
+        int leadingZeros = Integer.numberOfLeadingZeros(value);
+        int leadingZerosBelow38DividedBy7 = ((38 - leadingZeros) * 0b10010010010010011) >>> 19;
+        return leadingZerosBelow38DividedBy7 + (leadingZeros >>> 5);
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/VarInt64SizeOfBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/VarInt64SizeOfBench.java
@@ -1,0 +1,96 @@
+package com.hedera.pbj.integration.jmh.varint;
+
+import com.hedera.pbj.runtime.ProtoWriterTools;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@SuppressWarnings("unused")
+@State(Scope.Benchmark)
+@Fork(1)
+//@Warmup(iterations = 4, time = 2)
+//@Measurement(iterations = 5, time = 2)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 4, time = 2)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class VarInt64SizeOfBench {
+    public static final int NUM_OF_VALUES = 1024;
+    /**
+     * Number of bytes to read at a time (1, 2, 4, or 8). So create inputs with 1 byte siz,e, 2 byte size, 4 byte size,
+     * and 8 byte size.
+     */
+    @Param({"1", "2", "4", "8"})
+    public int numOfBytes;
+
+    private long[] numbers;
+
+    @Setup
+    public void setupNumbers() {
+        Random random = new Random(9387498731984L);
+        numbers = new long[NUM_OF_VALUES];
+        final long minValue = numOfBytes == 1 ? 0L : 1L << ((numOfBytes - 1) * 7);
+        final long maxValue = (1L << (numOfBytes * 7)) - 1;
+        // System.out.println("Generating "+NUM_OF_VALUES+" random numbers between "+min
+        for (int i = 0; i < NUM_OF_VALUES; i++) {
+            this.numbers[i] = random.nextLong(minValue, maxValue);
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void pbjProtoTools(Blackhole blackhole) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) blackhole.consume(ProtoWriterTools.sizeOfVarInt64(numbers[i]));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void kafka(Blackhole blackhole) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) blackhole.consume(kafkaSizeOfVarlong(numbers[i]));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void google(Blackhole blackhole) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) blackhole.consume(com.google.protobuf.CodedOutputStream
+                .computeInt64SizeNoTag(numbers[i]));
+    }
+
+    public static int kafkaSizeOfVarlong(long value) {
+        long v = (value << 1) ^ (value >> 63);
+        int leadingZeros = Long.numberOfLeadingZeros(v);
+        int leadingZerosBelow70DividedBy7 = ((70 - leadingZeros) * 0b10010010010010011) >>> 19;
+        return leadingZerosBelow70DividedBy7 + (leadingZeros >>> 6);
+    }
+
+    public static int kafkaSizeOfUnsignedVarint(int value) {
+        // Protocol buffers varint encoding is variable length, with a minimum of 1 byte
+        // (for zero). The values themselves are not important. What's important here is
+        // any leading zero bits are dropped from output. We can use this leading zero
+        // count w/ fast intrinsic to calc the output length directly.
+        // Test cases verify this matches the output for loop logic exactly.
+        // return (38 - leadingZeros) / 7 + leadingZeros / 32;
+        // The above formula provides the implementation, but the Java encoding is suboptimal
+        // when we have a narrow range of integers, so we can do better manually
+        int leadingZeros = Integer.numberOfLeadingZeros(value);
+        int leadingZerosBelow38DividedBy7 = ((38 - leadingZeros) * 0b10010010010010011) >>> 19;
+        return leadingZerosBelow38DividedBy7 + (leadingZeros >>> 5);
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/VarIntWriterBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/VarIntWriterBench.java
@@ -1,0 +1,123 @@
+package com.hedera.pbj.integration.jmh.varint;
+
+import com.hedera.pbj.integration.jmh.varint.writers.GoogleCodedByteArray;
+import com.hedera.pbj.integration.jmh.varint.writers.GoogleCodedByteBufferDirect;
+import com.hedera.pbj.integration.jmh.varint.writers.GoogleCodedOutputStream;
+import com.hedera.pbj.integration.jmh.varint.writers.KafkaByteBuffer;
+import com.hedera.pbj.integration.jmh.varint.writers.PbjBufferedData;
+import com.hedera.pbj.integration.jmh.varint.writers.PbjBufferedDataDirect;
+import com.hedera.pbj.integration.jmh.varint.writers.PbjWritableStreamingData;
+import com.hedera.pbj.integration.jmh.varint.writers.RichardStartinByteArray;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@SuppressWarnings("unused")
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 4, time = 2)
+@Measurement(iterations = 5, time = 2)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class VarIntWriterBench {
+    public static final int NUM_OF_VALUES = 4096*4;
+    /**
+     * Number of bytes to read at a time (1, 2, 4, or 8). So create inputs with 1 byte siz,e, 2 byte size, 4 byte size,
+     * and 8 byte size.
+     */
+//    @Param({"1", "2", "3", "4", "8"})
+    @Param({"4"})
+    public int numOfBytes;
+
+    private long[] numbers;
+
+    @Setup
+    public void setupNumbers() {
+        Random random = new Random(9387498731984L);
+        numbers = new long[NUM_OF_VALUES];
+        final long minValue = numOfBytes == 1 ? 0L : 1L << ((numOfBytes - 1) * 7);
+        final long maxValue = (1L << (numOfBytes * 7)) - 1;
+        // System.out.println("Generating "+NUM_OF_VALUES+" random numbers between "+min
+        for (int i = 0; i < NUM_OF_VALUES; i++) {
+            this.numbers[i] = random.nextLong(minValue, maxValue);
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void googleCodedOutputStream(GoogleCodedOutputStream state) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+        state.endLoop();
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void googleCodedByteArray(GoogleCodedByteArray state) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+        state.endLoop();
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void googleCodedByteBufferDirect(GoogleCodedByteBufferDirect state) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+        state.endLoop();
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void pbjWritableStreamingData(PbjWritableStreamingData state) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+        state.endLoop();
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void pbjBufferedData(PbjBufferedData state) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+        state.endLoop();
+    }
+//
+//    @Benchmark
+//    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+//    @OperationsPerInvocation(NUM_OF_VALUES)
+//    public void pbjBufferedDataDirect(PbjBufferedDataDirect state) throws IOException {
+//        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+//        state.endLoop();
+//    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void richardStartinByteArray(RichardStartinByteArray state) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+        state.endLoop();
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(NUM_OF_VALUES)
+    public void kafkaByteBuffer(KafkaByteBuffer state) throws IOException {
+        for (int i = 0; i < NUM_OF_VALUES; i++) state.writeVarint(numbers[i]);
+        state.endLoop();
+    }
+
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/GoogleCodedByteArray.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/GoogleCodedByteArray.java
@@ -1,0 +1,30 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.google.protobuf.CodedOutputStream;
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class GoogleCodedByteArray {
+    private byte[] byteArray;
+    private CodedOutputStream output;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        byteArray = new byte[8 * VarIntWriterBench.NUM_OF_VALUES];
+        output = CodedOutputStream.newInstance(byteArray);
+    }
+
+    public void writeVarint(long value) throws IOException {
+        output.writeUInt64NoTag(value);
+    }
+
+    public void endLoop() {
+        output = CodedOutputStream.newInstance(byteArray);
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/GoogleCodedByteBufferDirect.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/GoogleCodedByteBufferDirect.java
@@ -1,0 +1,31 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.google.protobuf.CodedOutputStream;
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class GoogleCodedByteBufferDirect {
+    private ByteBuffer byteBuffer;
+    private CodedOutputStream output;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        byteBuffer = ByteBuffer.allocateDirect(8 * VarIntWriterBench.NUM_OF_VALUES);
+        output = CodedOutputStream.newInstance(byteBuffer);
+    }
+
+    public void writeVarint(long value) throws IOException {
+        output.writeUInt64NoTag(value);
+    }
+
+    public void endLoop() {
+        byteBuffer.clear();
+        output = CodedOutputStream.newInstance(byteBuffer);
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/GoogleCodedOutputStream.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/GoogleCodedOutputStream.java
@@ -1,0 +1,30 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.google.protobuf.CodedOutputStream;
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class GoogleCodedOutputStream {
+    private ByteArrayOutputStream byteArrayOutputStream;
+    private CodedOutputStream output;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        byteArrayOutputStream = new ByteArrayOutputStream(8 * VarIntWriterBench.NUM_OF_VALUES);
+        output = CodedOutputStream.newInstance(byteArrayOutputStream);
+    }
+
+    public void writeVarint(long value) throws IOException {
+        output.writeUInt64NoTag(value);
+    }
+
+    public void endLoop() {
+        byteArrayOutputStream.reset();
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/KafkaByteBuffer.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/KafkaByteBuffer.java
@@ -1,0 +1,43 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import java.nio.ByteBuffer;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * A varint writer based on the code from Kafka project
+ * <a href="https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java">ByteUtils.java</a>
+ */
+@State(Scope.Benchmark)
+public class KafkaByteBuffer {
+    private static final int[] VAR_INT_LENGTHS = new int[65];
+    static {
+        for (int i = 0; i <= 64; ++i) {
+            VAR_INT_LENGTHS[i] = ((63 - i) / 7);
+        }
+    }
+
+    private ByteBuffer buffer;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        buffer = ByteBuffer.allocate(8 * VarIntWriterBench.NUM_OF_VALUES);
+    }
+
+    @SuppressWarnings("fallthrough")
+    public void writeVarint(long v) {
+        while ((v & 0xffffffffffffff80L) != 0L) {
+            byte b = (byte) ((v & 0x7f) | 0x80);
+            buffer.put(b);
+            v >>>= 7;
+        }
+        buffer.put((byte) v);
+    }
+
+    public void endLoop() {
+        buffer.clear();
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/PbjBufferedData.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/PbjBufferedData.java
@@ -1,0 +1,29 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class PbjBufferedData {
+    private BufferedData output;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        output = BufferedData.allocate(8 * VarIntWriterBench.NUM_OF_VALUES);
+    }
+
+    public void writeVarint(long value) throws IOException {
+        output.writeVarLong(value, false);
+    }
+
+    public void endLoop() {
+        output.reset();
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/PbjBufferedDataDirect.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/PbjBufferedDataDirect.java
@@ -1,0 +1,27 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class PbjBufferedDataDirect {
+    private BufferedData output;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        output = BufferedData.allocateOffHeap(8 * VarIntWriterBench.NUM_OF_VALUES);
+    }
+
+    public void writeVarint(long value) throws IOException {
+        output.writeVarLong(value, false);
+    }
+
+    public void endLoop() {
+        output.reset();
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/PbjWritableStreamingData.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/PbjWritableStreamingData.java
@@ -1,0 +1,30 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class PbjWritableStreamingData {
+    private ByteArrayOutputStream byteArrayOutputStream;
+    private WritableStreamingData output;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        byteArrayOutputStream = new ByteArrayOutputStream(8 * VarIntWriterBench.NUM_OF_VALUES);
+        output = new WritableStreamingData(byteArrayOutputStream);
+    }
+
+    public void writeVarint(long value) throws IOException {
+        output.writeVarLong(value, false);
+    }
+
+    public void endLoop() {
+        byteArrayOutputStream.reset();
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/RichardStartinByteArray.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/writers/RichardStartinByteArray.java
@@ -1,0 +1,68 @@
+package com.hedera.pbj.integration.jmh.varint.writers;
+
+import com.hedera.pbj.integration.jmh.varint.VarIntWriterBench;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * A varint writer based on the code from Richard Startin's post
+ * <a href="https://github.com/astei/varint-writing-showdown/issues/1">Precompute varint lengths, 64 bit values</a>
+ */
+@State(Scope.Benchmark)
+public class RichardStartinByteArray {
+    private static final int[] VAR_INT_LENGTHS = new int[65];
+    static {
+        for (int i = 0; i <= 64; ++i) {
+            VAR_INT_LENGTHS[i] = ((63 - i) / 7);
+        }
+    }
+
+    private byte[] buffer;
+    private int position = 0;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        buffer = new byte[8 * VarIntWriterBench.NUM_OF_VALUES];
+    }
+
+    @SuppressWarnings("fallthrough")
+    public void writeVarint(long value) throws IOException {
+        int length = VAR_INT_LENGTHS[Long.numberOfLeadingZeros(value)];
+        buffer[position+length] = (byte)(value >>> (length * 7));
+        switch (length - 1) {
+            case 8:
+                buffer[position+8] = (byte)((value >>> 56) | 0x80);
+                // Deliberate fallthrough
+            case 7:
+                buffer[position+7] = (byte)((value >>> 49) | 0x80);
+                // Deliberate fallthrough
+            case 6:
+                buffer[position+6] = (byte)((value >>> 42) | 0x80);
+                // Deliberate fallthrough
+            case 5:
+                buffer[position+5] = (byte)((value >>> 35) | 0x80);
+                // Deliberate fallthrough
+            case 4:
+                buffer[position+4] = (byte)((value >>> 28) | 0x80);
+                // Deliberate fallthrough
+            case 3:
+                buffer[position+3] = (byte)((value >>> 21) | 0x80);
+                // Deliberate fallthrough
+            case 2:
+                buffer[position+2] = (byte)((value >>> 14) | 0x80);
+                // Deliberate fallthrough
+            case 1:
+                buffer[position+1] = (byte)((value >>> 7) | 0x80);
+                // Deliberate fallthrough
+            case 0:
+                buffer[position] = (byte)(value | 0x80);
+        }
+    }
+
+    public void endLoop() {
+        position = 0;
+    }
+}


### PR DESCRIPTION
This is prototyping work on performance gains in varint and strings that can get us between 2x and 7x faster writing of PBJ objects. There are 3 key ideas:

1. Faster varint to bytearray code from a blog
2. New write methods direct to bytearray, bypassing streaming concepts. This needs to be fully finished off eveywhere but almost all use cases we have in the consensus node revolve around writing a PBJ model object into a Bytes or bytearray. Even the streaming use cases are object by object with BufferedStreams so we can just write object by object into a reused bytearray then send that to stream without BufferedSteam. Will be much faster and save multiple array copies.
3. Changing internal storage of String fields from String to byte[]. This helps performance a lot as we rarely need to do UTF8 <-> String conversions. Most of the time we just read, modify and write. And most of the modifications are of non-string fields. So with model objects being classes not records now we can change the internal format while keeping getters, constructor and builders still in String format. So the internal bytearray is hidden from public API. Even copy builder can just reuse bytearray. Only pain is Codecs need direct access to bytearray and are in different package so no easy way to keep 100% private :-( .