### PR TITLE
fix: add integ test for write(byte[]) and fix all bugs

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -349,15 +349,16 @@ public final class TestGenerator implements Generator {
                     }
                     // This check is not precise. An IOOB exception would be best. But we don't want to create new arrays
                     // for each test so as not to overwhelm the Java GC. So we do this instead:
-                    Arrays.parallelSort(bytesArray, protoBufByteCount, bytesArray.length);
-                    if (bytesArray[protoBufByteCount] != 0 || bytesArray[bytesArray.length - 1] != 0) {
-                        // Don't print the array because the tail is sorted (so that the test is fast.)
-                        // Use the other data to help find and run the failing test manually:
-                        fail("write(byte[]) wrote more bytes than "  + protoBufByteCount +
-                                ". Buffer:\\n" + dataBuffer.toString() +
-                                "\\nModel:\\n" + modelObj +
-                                "\\nProtobuf size:\\n" + protoBufByteCount
-                        );
+                    for (int i = protoBufByteCount; i < bytesArray.length; i++) {
+                        if (bytesArray[i] != 0) {
+                            fail("write(byte[]) wrote more bytes into array than write(WritableSequentialData) into buffer," +
+                                    " e.g. at index " + i + " got " + bytesArray[i] + " but expected zero." +
+                                    "\\nBuffer:\\n" + dataBuffer.toString() +
+                                    "\\nArray:\\n" + Arrays.toString(Arrays.copyOf(bytesArray, protoBufByteCount)) +
+                                    "\\nModel:\\n" + modelObj +
+                                    "\\nProtobuf size:\\n" + protoBufByteCount
+                            );
+                        }
                     }
 
                     // read proto bytes with ProtoC to make sure it is readable and no parse exceptions are thrown

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoTestTools.java
@@ -46,6 +46,19 @@ public final class ProtoTestTools {
     private static final ThreadLocal<CharBuffer> THREAD_LOCAL_CHAR_BUFFERS_2 =
             ThreadLocal.withInitial(() -> CharBuffer.allocate(CHAR_BUFFER_SIZE));
 
+    /** Thread local set of reusable byte arrays */
+    private static final ThreadLocal<byte[]> THREAD_LOCAL_BYTE_ARRAY =
+            ThreadLocal.withInitial(() -> new byte[BUFFER_SIZE]);
+
+    /**
+     * Get the thread local instance of byte[].
+     *
+     * @return a byte[] that can be reused by current thread
+     */
+    public static byte[] getThreadLocalByteArray() {
+        return THREAD_LOCAL_BYTE_ARRAY.get();
+    }
+
     /**
      * Get the thread local instance of DataBuffer, reset and ready to use.
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -1020,7 +1020,7 @@ public final class ProtoWriterTools {
      * @return the number of bytes for encoded value
      */
     public static int sizeOfUnsignedVarInt32(final int value) {
-        return sizeOfUnsignedVarInt64(value);
+        return sizeOfUnsignedVarInt64(Integer.toUnsignedLong(value));
     }
 
     /**


### PR DESCRIPTION
**Description**:
* Adding integration tests for the new `write(byte[])` feature to check the output against the existing `write(WritableSequentialData)` API
* Fixing all the bugs found along the way

**Related issue(s)**:

Fixes #626

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
