### PR TITLE
perf: improve strings handling

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/MapField.java
@@ -58,7 +58,8 @@ public record MapField(
                         "An internal, private map entry key for %s"
                                 .formatted(mapContext.mapName().getText()),
                         false,
-                        null),
+                        null,
+                        true),
                 new SingleField(
                         false,
                         FieldType.of(mapContext.type_(), lookupHelper),
@@ -73,7 +74,8 @@ public record MapField(
                         "An internal, private map entry value for %s"
                                 .formatted(mapContext.mapName().getText()),
                         false,
-                        null),
+                        null,
+                        true),
                 false, // maps cannot be repeated
                 Integer.parseInt(mapContext.fieldNumber().getText()),
                 mapContext.mapName().getText(),

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -4,6 +4,7 @@ package com.hedera.pbj.compiler.impl;
 import static com.hedera.pbj.compiler.impl.Common.DEFAULT_INDENT;
 
 import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser;
+import com.hedera.pbj.compiler.impl.grammar.Protobuf3Parser.MessageDefContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Consumer;
 
@@ -31,7 +32,8 @@ public record SingleField(
         String messageTypeTestPackage,
         String comment,
         boolean deprecated,
-        OneOfField parent)
+        OneOfField parent,
+        boolean isMapField)
         implements Field {
 
     /**
@@ -55,7 +57,8 @@ public record SingleField(
                 Common.buildCleanFieldJavaDoc(
                         Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
                 getDeprecatedOption(fieldContext.fieldOptions()),
-                null);
+                null,
+                false);
     }
 
     /**
@@ -96,7 +99,8 @@ public record SingleField(
                 Common.buildCleanFieldJavaDoc(
                         Integer.parseInt(fieldContext.fieldNumber().getText()), fieldContext.docComment()),
                 getDeprecatedOption(fieldContext.fieldOptions()),
-                parent);
+                parent,
+                false);
     }
 
     /**
@@ -124,17 +128,52 @@ public record SingleField(
         return type == SingleField.FieldType.MESSAGE ? messageType : type.javaType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String javaFieldType() {
         return javaFieldType(true);
     }
 
+    /** {@inheritDoc} */
     @Override
     public String javaFieldTypeBase() {
         return javaFieldType(false);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String javaFieldStorageType() {
+        if (isString()) {
+            return repeated ? "List<byte[]>" : "byte[]";
+        }
+        return javaFieldType();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String storageFieldSetter(
+            final String inputVarName, final MessageDefContext msgDef, final ContextualLookupHelper lookupHelper) {
+        if (isString() && parent == null && !isMapField) {
+            if (!repeated) {
+                return inputVarName + " != null ? toUtf8Bytes(" + inputVarName + ") : "
+                        + (cannotBeNull() ? "PbjConstants.EMPTY_BYTES" : "null");
+            } else {
+                // It's List<String> -> List<byte[]> variant:
+                return "toUtf8Bytes(" + inputVarName + ")";
+            }
+        } else if (cannotBeNull()) {
+            return inputVarName + " != null ? " + inputVarName + " : " + defaultValue(msgDef, lookupHelper);
+        } else {
+            return inputVarName;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String storageFieldGetter(String fieldName) {
+        return isString()
+                ? ((cannotBeNull() ? "" : (fieldName + " == null ? null : ")) + "toUtf8String(" + fieldName + ")")
+                : fieldName;
     }
 
     @NonNull

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -362,7 +362,12 @@ public final class TestGenerator implements Generator {
                     }
 
                     // read proto bytes with ProtoC to make sure it is readable and no parse exceptions are thrown
-                    final $protocModelClass protoCModelObj = $protocModelClass.parseFrom(byteBuffer);
+                    final $protocModelClass protoCModelObj;
+                    try {
+                        protoCModelObj = $protocModelClass.parseFrom(byteBuffer);
+                    } catch (final Exception e) {
+                        throw new RuntimeException("For model:\\n" + modelObj + "\\nCAUGHT EXCEPTION: ", e);
+                    }
                 
                     // read proto bytes with PBJ parser
                     dataBuffer.resetPosition();

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -70,6 +70,7 @@ public final class JsonCodecGenerator implements Generator {
         writer.addImport("com.hedera.pbj.runtime.jsonparser.*");
         writer.addImport("static " + lookupHelper.getFullyQualifiedMessageClassname(FileType.SCHEMA, msgDef) + ".*");
         writer.addImport("static com.hedera.pbj.runtime.JsonTools.*");
+        writer.addImport("static com.hedera.pbj.runtime.Utf8Tools.*");
 
         // spotless:off
         writer.append("""

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
@@ -106,7 +106,7 @@ public class LazyGetProtobufSizeMethodGenerator {
             final String oneOfType = modelClassName == null
                     ? oneOfField.nameCamelFirstUpper() + "OneOfType"
                     : modelClassName + "." + oneOfField.nameCamelFirstUpper() + "OneOfType";
-            getValueCode = oneOfField.nameCamelFirstLower() + ".as()";
+            getValueCode = "(" + field.javaFieldType() + ")" + oneOfField.nameCamelFirstLower() + ".as()";
             prefix += "if (" + oneOfField.nameCamelFirstLower() + ".kind() == " + oneOfType + "."
                     + Common.camelToUpperSnake(field.name()) + ")";
             prefix += "\n";

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjConstants.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/PbjConstants.java
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime;
+
+/**
+ * Constants used in the PBJ runtime.
+ */
+public final class PbjConstants {
+    /** An empty byte array constant to avoid creating multiple empty arrays */
+    public static final byte[] EMPTY_BYTES = new byte[0];
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -269,6 +269,31 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a String field from data input
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return Read string
+     * @throws ParseException if the length is greater than maxSize
+     */
+    public static byte[] readStringRaw(final ReadableSequentialData input, final long maxSize)
+            throws IOException, ParseException {
+        final int length = input.readVarInt(false);
+        if (length > maxSize) {
+            throw new ParseException("size " + length + " is greater than max " + maxSize);
+        }
+        if (input.remaining() < length) {
+            throw new BufferUnderflowException();
+        }
+        byte[] result = new byte[length];
+        final long bytesRead = input.readBytes(result);
+        if (bytesRead != length) {
+            throw new BufferUnderflowException();
+        }
+        return result;
+    }
+
+    /**
      * Read a Bytes field from data input
      *
      * @param input the input to read from

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Utf8Tools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Utf8Tools.java
@@ -6,11 +6,43 @@ import static java.lang.Character.*;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * UTF8 tools based on protobuf standard library, so we are byte for byte identical
  */
 public final class Utf8Tools {
+
+    public static byte[] toUtf8Bytes(final String string) {
+        return string.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public static List<byte[]> toUtf8Bytes(final List<String> strings) {
+        return strings.stream()
+                .map(s -> {
+                    return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                })
+                .toList();
+    }
+
+    public static List<byte[]> toUtf8Bytes(final String... strings) {
+        return Arrays.stream(strings)
+                .map(s -> {
+                    return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                })
+                .toList();
+    }
+
+    public static String toUtf8String(final byte[] bytes) {
+        return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public static List<String> toUtf8String(final List<byte[]> bytesList) {
+        return bytesList.stream()
+                .map(bytes -> new String(bytes, java.nio.charset.StandardCharsets.UTF_8))
+                .toList();
+    }
 
     /**
      * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -318,8 +318,8 @@ class ProtoParserToolsTest {
         writeInteger(data, createFieldDefinition(FIXED32), rng.nextInt());
         int value = rng.nextInt(0, Integer.MAX_VALUE);
         writeInteger(data, createFieldDefinition(INT32), value);
-        writeString(data, createFieldDefinition(STRING), randomVarSizeString());
-        writeString(data, createFieldDefinition(STRING), valToRead);
+        writeString(data, createFieldDefinition(STRING), randomVarSizeString().getBytes(StandardCharsets.UTF_8));
+        writeString(data, createFieldDefinition(STRING), valToRead.getBytes(StandardCharsets.UTF_8));
 
         data.flip();
 
@@ -410,7 +410,7 @@ class ProtoParserToolsTest {
                 final WritableStreamingData out = new WritableStreamingData(bout)) {
             ProtoWriterTools.writeInteger(out, INT32_F, INT32_V);
             ProtoWriterTools.writeInteger(out, FIXED_F, FIXED32_V);
-            ProtoWriterTools.writeString(out, STRING_F, STRING_V);
+            ProtoWriterTools.writeString(out, STRING_F, STRING_V.getBytes(StandardCharsets.UTF_8));
             ProtoWriterTools.writeBytes(out, BYTES_F, BYTES_V);
             ProtoWriterTools.writeMessage(out, MESSAGE_F, MESSAGE_V, TestMessageCodec.INSTANCE);
             ProtoWriterTools.writeDouble(out, DOUBLE_F, DOUBLE32_V);
@@ -573,7 +573,7 @@ class ProtoParserToolsTest {
                 throws IOException {
             final String value = item.getValue();
             if (value != null) {
-                ProtoWriterTools.writeString(out, VALUE_FIELD, value);
+                ProtoWriterTools.writeString(out, VALUE_FIELD, value.getBytes(StandardCharsets.UTF_8));
             }
         }
 

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8Bench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8Bench.java
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks three implementations: Utf8ToolsV1, Utf8ToolsV2, Utf8ToolsV3.
+ *
+ * <p>Each implementation must provide:</p>
+ * <pre>
+ *   public final class Utf8ToolsV* {
+ *       // private static int encodedLength(String) throws IOException {...} // (not used here)
+ *       public static String decodeUtf8(byte[] in, int offset, int length) throws java.io.IOException;
+ *       public static void encodeUtf8(String in, byte[] out, int offset) throws java.io.IOException;
+ *   }
+ * </pre>
+ * <p>We precompute input strings and their UTF-8 byte[] using the JDK encoder in @Setup,
+ * and we preallocate output buffers sized to the exact UTF-8 length so the measured
+ * methods do not allocate (other than what the implementation itself does).</p>
+ *
+ * <p>Make sure you run with JVM arg <code>--add-opens java.base/java.lang=ALL-UNNAMED</code></p>
+ */
+@SuppressWarnings("SameParameterValue")
+@BenchmarkMode({Mode.AverageTime}) // ops/sec; switch to SampleTime if you want latency histograms
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 3)
+@Fork(value = 1)
+@State(Scope.Thread)
+public class Utf8Bench {
+    // -------------------- Parameters --------------------
+
+    /** Which implementation to run (maps to class switch below). */
+    @Param({"V0", "V1", "V2", "V3", "V4"})
+    //    @Param({"V4"})
+    public String impl;
+
+    /** Dataset shape: ASCII-heavy, Latin-1, Mixed BMP, Emoji (surrogates). */
+    @Param({"ascii", "latin1", "mixed", "emoji"})
+    //    @Param({"ascii"})
+    public String dataset;
+
+    /** Mean string length to generate. Actual strings vary around this length. */
+    @Param({"8", "32", "100"})
+    public int meanLen;
+
+    /** Number of distinct strings in the corpus (cycled during the run). */
+    @Param({"1024"})
+    public int corpusSize;
+
+    // -------------------- Corpus --------------------
+
+    private String[] strings; // inputs for encode & round-trip
+    private byte[][] utf8Bytes; // pre-encoded with JDK for decode benchmark
+    private byte[][] encodeBuffers; // sized exactly to utf8 length
+    private int[] utf8Lens; // lengths of utf8Bytes[i]
+    private int[] utf8LensJdk; // for correctness check of encodedLength
+    private int idxMask; // for cheap modulo (power-of-two corpus)
+
+    private final Random rnd = new Random(4141684161512124L);
+
+    public static void main(String[] args) throws Exception {
+        Options opt =
+                new OptionsBuilder().include(Utf8Bench.class.getSimpleName()).build();
+
+        new Runner(opt).run();
+    }
+
+    // -------------------- Lifecycle --------------------
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        // Ensure corpusSize is a power of two for cheap cycling
+        int pow2 = 1;
+        while (pow2 < corpusSize) pow2 <<= 1;
+        if (pow2 != corpusSize) {
+            corpusSize = pow2; // silently round up
+        }
+        idxMask = corpusSize - 1;
+
+        strings = new String[corpusSize];
+        utf8Bytes = new byte[corpusSize][];
+        utf8Lens = new int[corpusSize];
+        utf8LensJdk = new int[corpusSize];
+        encodeBuffers = new byte[corpusSize][];
+
+        // Generate corpus
+        for (int i = 0; i < corpusSize; i++) {
+            String s =
+                    switch (dataset) {
+                        case "ascii" -> genAsciiString(meanLen, 0.50);
+                        case "latin1" -> genLatin1String(meanLen, 0.50); // includes bytes 0x80..0xFF (→ 2-byte UTF-8)
+                        case "mixed" -> genMixedBmpString(meanLen, 0.30, 0.10); // some non-ASCII BMP
+                        case "emoji" -> genEmojiString(meanLen, 0.15); // surrogate pairs sprinkled in
+                        default -> throw new IllegalArgumentException("Unknown dataset: " + dataset);
+                    };
+            strings[i] = s;
+
+            // Pre-encode with the JDK for decode() input and for sizing encode buffers.
+            byte[] u = s.getBytes(StandardCharsets.UTF_8);
+            utf8Bytes[i] = u;
+            utf8Lens[i] = u.length;
+            utf8LensJdk[i] = u.length;
+            encodeBuffers[i] = new byte[u.length]; // exact size; offset=0 in benchmarks
+        }
+
+        // Quick sanity: round-trip each impl once to catch broken code before timing
+        for (String version : new String[] {"V1", "V2", "V3"}) {
+            for (int i = 0; i < Math.min(corpusSize, 128); i++) {
+                String s = strings[i];
+                byte[] buf = new byte[utf8Lens[i]];
+                encode(version, s, buf, 0);
+                String back = decode(version, buf, 0, buf.length);
+                if (!s.equals(back)) {
+                    throw new IllegalStateException(version + " failed round-trip on sample " + i);
+                }
+            }
+        }
+
+        // Sanity: encodedLength must match JDK UTF-8 byte length
+        for (String version : new String[] {"V1", "V2", "V3"}) {
+            for (int i = 0; i < Math.min(corpusSize, 1024); i++) {
+                int len = strings[i].getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+                if (len != utf8LensJdk[i]) {
+                    throw new IllegalStateException(version + " encodedLength mismatch at " + i
+                            + " expected=" + utf8LensJdk[i] + " got=" + len
+                            + " str=\"" + preview(strings[i]) + "\"");
+                }
+            }
+        }
+    }
+
+    // -------------------- Benchmarks --------------------
+
+    private int cursor = 0;
+
+    /** Encode String -> UTF-8 bytes into a pre-sized buffer. */
+    @Benchmark
+    public void encode(Blackhole bh) throws Exception {
+        final int i = (cursor++) & idxMask;
+        final String s = strings[i];
+        final byte[] out = encodeBuffers[i];
+        encode(impl, s, out, 0);
+        // Consume a couple of bytes to keep JIT honest (avoid DCE):
+        bh.consume(out[0]);
+        bh.consume(out[out.length - 1]);
+    }
+
+    /** Decode UTF-8 bytes -> String (input was pre-encoded by the JDK). */
+    @Benchmark
+    public void decode(Blackhole bh) throws Exception {
+        final int i = (cursor++) & idxMask;
+        final byte[] in = utf8Bytes[i];
+        final String s = decode(impl, in, 0, in.length);
+        // Consume length & first char (if present) to avoid DCE:
+        bh.consume(s.length());
+        if (!s.isEmpty()) bh.consume(s.charAt(0));
+    }
+
+    /** Round-trip using the impl for both encode and decode (avoids JDK encoder in timed region). */
+    @Benchmark
+    public void roundTrip(Blackhole bh) throws Exception {
+        final int i = (cursor++) & idxMask;
+        final String s = strings[i];
+        final byte[] buf = encodeBuffers[i];
+        encode(impl, s, buf, 0);
+        final String back = decode(impl, buf, 0, buf.length);
+        bh.consume(back.length());
+    }
+
+    /** Measure just the UTF-8 length computation (no encoding). */
+    @Benchmark
+    public void encodedLength(Blackhole bh) {
+        final int i = (cursor++) & idxMask;
+        final String s = strings[i];
+        final int len = encodedLength(impl, s);
+        // consume value and a char to discourage CSE / constant folding
+        bh.consume(len);
+        if (!s.isEmpty()) bh.consume(s.charAt(0));
+    }
+
+    // -------------------- Dispatch to implementations --------------------
+
+    // Replace these with your real classes (same static method signatures).
+    // Example: Utf8ToolsV1.encodeUtf8(in, out, off);
+    private static void encode(String version, String in, byte[] out, int off) throws Exception {
+        switch (version) {
+            case "V0" -> Utf8ToolsV0.encodeUtf8(in, out, off);
+            case "V1" -> Utf8ToolsV1.encodeUtf8(in, out, off);
+            case "V2" -> Utf8ToolsV2.encodeUtf8(in, out, off);
+            case "V3" -> Utf8ToolsV3.encodeUtf8(in, out, off);
+            case "V4" -> Utf8ToolsV4.encodeUtf8(in, out, off);
+            default -> throw new IllegalArgumentException(version);
+        }
+    }
+
+    private static String decode(String version, byte[] in, int off, int len) throws Exception {
+        return switch (version) {
+            case "V0" -> Utf8ToolsV0.decodeUtf8(in, off, len);
+            case "V1" -> Utf8ToolsV1.decodeUtf8(in, off, len);
+            case "V2" -> Utf8ToolsV2.decodeUtf8(in, off, len);
+            case "V3" -> Utf8ToolsV3.decodeUtf8(in, off, len);
+            case "V4" -> Utf8ToolsV4.decodeUtf8(in, off, len);
+            default -> throw new IllegalArgumentException(version);
+        };
+    }
+
+    private static int encodedLength(String version, String s) {
+        try {
+            return switch (version) {
+                case "V0" -> Utf8ToolsV0.encodedLength(s);
+                case "V1" -> Utf8ToolsV1.encodedLength(s);
+                case "V2" -> Utf8ToolsV2.encodedLength(s);
+                case "V3" -> Utf8ToolsV3.encodedLength(s);
+                case "V4" -> Utf8ToolsV4.encodedLength(s);
+                default -> throw new IllegalArgumentException(version);
+            };
+        } catch (java.io.IOException e) {
+            // Treat malformed handling as a failure in correctness check
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -------------------- Generators (fast & simple; deterministic-ish) --------------------
+
+    private String genAsciiString(int mean, double punctRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            if (rnd.nextDouble() < punctRatio) {
+                sb.append(" .,-_/+[]()".charAt(rnd.nextInt(11)));
+            } else {
+                char c = (char) ('a' + rnd.nextInt(26));
+                if (rnd.nextBoolean()) c = Character.toUpperCase(c);
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    private String genLatin1String(int mean, double highRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            if (rnd.nextDouble() < highRatio) {
+                // 0x80..0xFF (valid Latin-1; forces 2-byte UTF-8)
+                sb.append((char) (0x80 + rnd.nextInt(0x80)));
+            } else {
+                sb.append((char) (' ' + rnd.nextInt(95))); // ASCII printable
+            }
+        }
+        return sb.toString();
+    }
+
+    private String genMixedBmpString(int mean, double nonAsciiRatio, double threeByteRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            double r = rnd.nextDouble();
+            if (r < nonAsciiRatio) {
+                if (r < threeByteRatio) {
+                    // 3-byte UTF-8 BMP range excluding surrogates (e.g., Greek/Cyrillic)
+                    char c = (char) (0x0800 + rnd.nextInt(0xD7FF - 0x0800));
+                    sb.append(c);
+                } else {
+                    // Latin-1 high bytes (2-byte UTF-8)
+                    sb.append((char) (0x80 + rnd.nextInt(0x80)));
+                }
+            } else {
+                sb.append((char) (' ' + rnd.nextInt(95)));
+            }
+        }
+        return sb.toString();
+    }
+
+    private String genEmojiString(int mean, double emojiRatio) {
+        int len = jitteredLen(mean);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            if (rnd.nextDouble() < emojiRatio) {
+                // A few common emoji code points (U+1F3xx / U+1F60x / U+1F9xx)
+                int[] cps = {0x1F600, 0x1F602, 0x1F603, 0x1F60D, 0x1F680, 0x1F64C, 0x1F4AF, 0x1F3C3, 0x1F9E9};
+                int cp = cps[rnd.nextInt(cps.length)];
+                sb.appendCodePoint(cp);
+            } else {
+                sb.append((char) (' ' + rnd.nextInt(95)));
+            }
+        }
+        return sb.toString();
+    }
+
+    private int jitteredLen(int mean) {
+        // ±25% jitter around mean, min 1
+        int span = Math.max(1, mean / 4);
+        return Math.max(1, mean - span + rnd.nextInt(2 * span + 1));
+    }
+
+    private static String preview(String s) {
+        if (s.length() <= 24) return s;
+        return s.substring(0, 24) + "…(" + s.length() + ")";
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV0.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV0.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+/**
+ * UTF8 Tools based on java standard library
+ */
+@SuppressWarnings("DuplicatedCode")
+public final class Utf8ToolsV0 {
+    public static int encodedLength(final String in) {
+        return in.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+    }
+
+    public static String decodeUtf8(byte[] in, int offset, int length) {
+        return new String(in, offset, length, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public static int encodeUtf8(String in, byte[] out, int offset) {
+        byte[] b = in.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        System.arraycopy(b, 0, out, offset, b.length);
+        return b.length;
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV1.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV1.java
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.isSurrogatePair;
+import static java.lang.Character.toCodePoint;
+
+import com.hedera.pbj.runtime.MalformedProtobufException;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import java.io.IOException;
+
+/**
+ * UTF8 tools based on protobuf standard library, so we are byte for byte identical
+ */
+@SuppressWarnings("DuplicatedCode")
+public final class Utf8ToolsV1 {
+
+    /**
+     * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this
+     * method is equivalent to {@code string.getBytes(UTF_8).length}, but is more efficient in both
+     * time and space.
+     *
+     * @throws IllegalArgumentException if {@code sequence} contains ill-formed UTF-16 (unpaired
+     *     surrogates)
+     */
+    static int encodedLength(final String sequence) throws IOException {
+        if (sequence == null) {
+            return 0;
+        }
+        // Warning to maintainers: this implementation is highly optimized.
+        int utf16Length = sequence.length();
+        int utf8Length = utf16Length;
+        int i = 0;
+
+        // This loop optimizes for pure ASCII.
+        while (i < utf16Length && sequence.charAt(i) < 0x80) {
+            i++;
+        }
+
+        // This loop optimizes for chars less than 0x800.
+        for (; i < utf16Length; i++) {
+            char c = sequence.charAt(i);
+            if (c < 0x800) {
+                utf8Length += ((0x7f - c) >>> 31); // branch free!
+            } else {
+                utf8Length += encodedLengthGeneral(sequence, i);
+                break;
+            }
+        }
+
+        if (utf8Length < utf16Length) {
+            // Necessary and sufficient condition for overflow because of maximum 3x expansion
+            throw new IllegalArgumentException("UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
+        }
+        return utf8Length;
+    }
+
+    private static int encodedLengthGeneral(final CharSequence sequence, final int start) throws IOException {
+        int utf16Length = sequence.length();
+        int utf8Length = 0;
+        for (int i = start; i < utf16Length; i++) {
+            char c = sequence.charAt(i);
+            if (c < 0x800) {
+                utf8Length += (0x7f - c) >>> 31; // branch free!
+            } else {
+                utf8Length += 2;
+                // jdk7+: if (Character.isSurrogate(c)) {
+                if (Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE) {
+                    // Check that we have a well-formed surrogate pair.
+                    int cp = Character.codePointAt(sequence, i);
+                    if (cp < MIN_SUPPLEMENTARY_CODE_POINT) {
+                        throw new MalformedProtobufException("Unpaired surrogate at index " + i + " of " + utf16Length);
+                    }
+                    i++;
+                }
+            }
+        }
+        return utf8Length;
+    }
+
+    public static String decodeUtf8(byte[] in, int offset, int length) {
+        return new String(in, offset, length, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Encodes the input character sequence to a {@link WritableSequentialData} using the same algorithm as protoc, so we are
+     * byte for byte the same.
+     */
+    static void encodeUtf8(final String in, byte[] out, int off) throws IOException {
+        final int inLength = in.length();
+        for (int inIx = 0; inIx < inLength; ++inIx) {
+            final char c = in.charAt(inIx);
+            if (c < 0x80) {
+                // One byte (0xxx xxxx)
+                out[off++] = (byte) c;
+            } else if (c < 0x800) {
+                // Two bytes (110x xxxx 10xx xxxx)
+
+                // Benchmarks show put performs better than putShort here (for HotSpot).
+                out[off++] = (byte) (0xC0 | (c >>> 6));
+                out[off++] = (byte) (0x80 | (0x3F & c));
+            } else if (c < MIN_SURROGATE || MAX_SURROGATE < c) {
+                // Three bytes (1110 xxxx 10xx xxxx 10xx xxxx)
+                // Maximum single-char code point is 0xFFFF, 16 bits.
+
+                // Benchmarks show put performs better than putShort here (for HotSpot).
+                out[off++] = (byte) (0xE0 | (c >>> 12));
+                out[off++] = (byte) (0x80 | (0x3F & (c >>> 6)));
+                out[off++] = (byte) (0x80 | (0x3F & c));
+            } else {
+                // Four bytes (1111 xxxx 10xx xxxx 10xx xxxx 10xx xxxx)
+                // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
+                final char low;
+                if (inIx + 1 == inLength || !isSurrogatePair(c, (low = in.charAt(++inIx)))) {
+                    throw new MalformedProtobufException("Unpaired surrogate at index " + inIx + " of " + inLength);
+                }
+                int codePoint = toCodePoint(c, low);
+                out[off++] = (byte) ((0xF << 4) | (codePoint >>> 18));
+                out[off++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
+                out[off++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
+                out[off++] = (byte) (0x80 | (0x3F & codePoint));
+            }
+        }
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV2.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV2.java
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+
+import com.hedera.pbj.runtime.MalformedProtobufException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+/**
+ * UTF8 tools based on protobuf standard library, so we are byte for byte identical
+ */
+public final class Utf8ToolsV2 {
+
+    /**
+     * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this
+     * method is equivalent to {@code string.getBytes(UTF_8).length}, but is more efficient in both
+     * time and space.
+     *
+     * @throws IllegalArgumentException if {@code sequence} contains ill-formed UTF-16 (unpaired
+     *     surrogates)
+     */
+    public static int encodedLength(final String in) throws IOException {
+        int len = 0;
+        for (int i = 0; i < in.length(); ) {
+            int codePoint = in.codePointAt(i);
+            if (codePoint <= 0x7F) {
+                len += 1;
+            } else if (codePoint <= 0x7FF) {
+                len += 2;
+            } else if (codePoint <= 0xFFFF) {
+                len += 3;
+            } else {
+                len += 4;
+            }
+            i += Character.charCount(codePoint);
+        }
+        return len;
+        //        if (in == null) {
+        //            return 0;
+        //        }
+        //        // Warning to maintainers: this implementation is highly optimized.
+        //        int utf16Length = in.length();
+        //        int utf8Length = utf16Length;
+        //        int i = 0;
+        //
+        //        // This loop optimizes for pure ASCII.
+        //        while (i < utf16Length && in.charAt(i) < 0x80) {
+        //            i++;
+        //        }
+        //
+        //        // This loop optimizes for chars less than 0x800.
+        //        for (; i < utf16Length; i++) {
+        //            char c = in.charAt(i);
+        //            if (c < 0x800) {
+        //                utf8Length += ((0x7f - c) >>> 31); // branch free!
+        //            } else {
+        //                utf8Length += encodedLengthGeneral(in, i);
+        //                break;
+        //            }
+        //        }
+        //
+        //        if (utf8Length < utf16Length) {
+        //            // Necessary and sufficient condition for overflow because of maximum 3x expansion
+        //            throw new IllegalArgumentException("UTF-8 length does not fit in int: " + (utf8Length + (1L <<
+        // 32)));
+        //        }
+        //        return utf8Length;
+    }
+
+    private static int encodedLengthGeneral(final CharSequence sequence, final int start) throws IOException {
+        int utf16Length = sequence.length();
+        int utf8Length = 0;
+        for (int i = start; i < utf16Length; i++) {
+            char c = sequence.charAt(i);
+            if (c < 0x800) {
+                utf8Length += (0x7f - c) >>> 31; // branch free!
+            } else {
+                utf8Length += 2;
+                // jdk7+: if (Character.isSurrogate(c)) {
+                if (Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE) {
+                    // Check that we have a well-formed surrogate pair.
+                    int cp = Character.codePointAt(sequence, i);
+                    if (cp < MIN_SUPPLEMENTARY_CODE_POINT) {
+                        throw new MalformedProtobufException("Unpaired surrogate at index " + i + " of " + utf16Length);
+                    }
+                    i++;
+                }
+            }
+        }
+        return utf8Length;
+    }
+
+    public static String decodeUtf8(byte[] in, int offset, int length) {
+        return new String(in, offset, length, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Encodes the input character sequence to a byte array using the same algorithm as protoc, so we are byte for
+     * byte the same. Returns the number of bytes written.
+     *
+     * @param out    The byte array to write to
+     * @param offset The offset in the byte array to start writing at
+     * @param in     The input character sequence to encode
+     * @return The number of bytes written
+     * @throws MalformedProtobufException if the input contains unpaired surrogates
+     */
+    public static int encodeUtf8(final String in, @NonNull final byte[] out, final int offset)
+            throws MalformedProtobufException {
+        int utf16Length = in.length();
+        int i = 0;
+        int j = offset;
+        // Designed to take advantage of
+        // https://wiki.openjdk.java.net/display/HotSpotInternals/RangeCheckElimination
+        for (char c; i < utf16Length && (c = in.charAt(i)) < 0x80; i++) {
+            out[j + i] = (byte) c;
+        }
+        if (i == utf16Length) {
+            return j + utf16Length - offset;
+        }
+        j += i;
+        for (char c; i < utf16Length; i++) {
+            c = in.charAt(i);
+            if (c < 0x80) {
+                out[j++] = (byte) c;
+            } else if (c < 0x800) { // 11 bits, two UTF-8 bytes
+                out[j++] = (byte) ((0xF << 6) | (c >>> 6));
+                out[j++] = (byte) (0x80 | (0x3F & c));
+            } else if ((c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c)) {
+                // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+                out[j++] = (byte) ((0xF << 5) | (c >>> 12));
+                out[j++] = (byte) (0x80 | (0x3F & (c >>> 6)));
+                out[j++] = (byte) (0x80 | (0x3F & c));
+            } else {
+                // Minimum code point represented by a surrogate pair is 0x10000, 17 bits,
+                // four UTF-8 bytes
+                final char low;
+                if (i + 1 == in.length() || !Character.isSurrogatePair(c, (low = in.charAt(++i)))) {
+                    throw new MalformedProtobufException(
+                            "Unpaired surrogate at index " + (i - 1) + " of " + utf16Length);
+                }
+                int codePoint = Character.toCodePoint(c, low);
+                out[j++] = (byte) ((0xF << 4) | (codePoint >>> 18));
+                out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
+                out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
+                out[j++] = (byte) (0x80 | (0x3F & codePoint));
+            }
+        }
+        return j - offset;
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV3.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV3.java
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import java.io.IOException;
+
+/**
+ * UTF8 tools based on protobuf standard library, so we are byte for byte identical
+ */
+public final class Utf8ToolsV3 {
+
+    // ----------------------------------------------------------------------
+    // Public API
+    // ----------------------------------------------------------------------
+
+    /** Strict UTF-8 decode. Throws IOException on malformed sequences. */
+    public static String decodeUtf8(final byte[] in, final int offset, final int length) throws IOException {
+        if ((offset | length) < 0 || offset + length > in.length) {
+            throw new IndexOutOfBoundsException("decodeUtf8: bad offset/length");
+        }
+        final int end = offset + length;
+
+        // Fast ASCII-only pass; if all ASCII, build String directly.
+        int i = offset;
+        while (i < end && (in[i] >= 0)) i++;
+        if (i == end) {
+            // All ASCII
+            char[] chars = new char[length];
+            for (int p = 0; p < length; p++) {
+                chars[p] = (char) (in[offset + p] & 0x7F);
+            }
+            return new String(chars);
+        }
+
+        // Two-pass: count UTF-16 code units, then decode into a single char[].
+        final int charCount = countUtf16UnitsStrict(in, offset, end);
+        final char[] out = new char[charCount];
+
+        // Decode pass
+        int outPos = 0;
+        i = offset;
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                out[outPos++] = (char) b0;
+                // try to chew a few ASCII in a tight loop
+                while (i < end && (in[i] >= 0)) {
+                    out[outPos++] = (char) (in[i++] & 0x7F);
+                }
+                continue;
+            }
+            if ((b0 & 0xE0) == 0xC0) { // 2-byte
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                int cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+                // reject overlongs: must be >= 0x80; also b0 >= 0xC2
+                if (cp < 0x80 || b0 < 0xC2) throw bad();
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF0) == 0xE0) { // 3-byte
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+
+                // E0: b1 >= 0xA0 to avoid overlong; ED: b1 <= 0x9F to avoid surrogates
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad();
+                if (b0 == 0xED && b1 >= 0xA0) throw bad();
+
+                int cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+                if (cp >= 0xD800 && cp <= 0xDFFF) throw bad(); // no UTF-8-encoded surrogates
+                if (cp < 0x800) throw bad(); // overlong (should have been 2-byte)
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF8) == 0xF0) { // 4-byte
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                int b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+
+                // F0: b1 >= 0x90 (avoid overlong); F4: b1 <= 0x8F (max U+10FFFF); F5..FF invalid
+                if (b0 == 0xF0 && b1 < 0x90) throw bad();
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad();
+
+                int cp = ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+                if (cp < 0x10000 || cp > 0x10FFFF) throw bad();
+
+                // Encode as surrogate pair in UTF-16
+                int hi = ((cp - 0x10000) >>> 10) + 0xD800;
+                int lo = ((cp - 0x10000) & 0x3FF) + 0xDC00;
+                out[outPos++] = (char) hi;
+                out[outPos++] = (char) lo;
+                continue;
+            }
+            throw bad();
+        }
+
+        return new String(out);
+    }
+
+    /**
+     * Encodes {@code in} to UTF-8 into {@code out} starting at {@code offset}.
+     * Returns the number of bytes written. Throws IOException if {@code out}
+     * does not have enough space or on invalid surrogate usage.
+     */
+    public static int encodeUtf8(final String in, final byte[] out, final int offset) throws IOException {
+        if (in == null) throw new NullPointerException("in");
+        if (offset < 0 || offset > out.length) throw new IndexOutOfBoundsException("encodeUtf8: bad offset");
+
+        final int need = encodedLength(in); // also validates surrogate pairs
+        if (out.length - offset < need) {
+            throw new IOException("encodeUtf8: insufficient space: need=" + need + " have=" + (out.length - offset));
+        }
+
+        int pos = offset;
+        final int n = in.length();
+        int i = 0;
+
+        // ASCII fast path (eat a run)
+        while (i < n) {
+            char c = in.charAt(i);
+            if (c <= 0x7F) {
+                out[pos++] = (byte) c;
+                i++;
+                while (i < n) {
+                    char d = in.charAt(i);
+                    if (d > 0x7F) break;
+                    out[pos++] = (byte) d;
+                    i++;
+                }
+                continue;
+            }
+
+            if (c <= 0x7FF) {
+                out[pos++] = (byte) (0xC0 | (c >>> 6));
+                out[pos++] = (byte) (0x80 | (c & 0x3F));
+                i++;
+                continue;
+            }
+
+            if (Character.isHighSurrogate(c)) {
+                if (i + 1 >= n) throw new IOException("encodeUtf8: unpaired high surrogate at end");
+                char d = in.charAt(i + 1);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodeUtf8: unpaired high surrogate");
+                int cp = Character.toCodePoint(c, d);
+                // 4-byte
+                out[pos++] = (byte) (0xF0 | (cp >>> 18));
+                out[pos++] = (byte) (0x80 | ((cp >>> 12) & 0x3F));
+                out[pos++] = (byte) (0x80 | ((cp >>> 6) & 0x3F));
+                out[pos++] = (byte) (0x80 | (cp & 0x3F));
+                i += 2;
+                continue;
+            }
+
+            if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodeUtf8: unpaired low surrogate");
+            }
+
+            // 3-byte (BMP non-surrogate)
+            out[pos++] = (byte) (0xE0 | (c >>> 12));
+            out[pos++] = (byte) (0x80 | ((c >>> 6) & 0x3F));
+            out[pos++] = (byte) (0x80 | (c & 0x3F));
+            i++;
+        }
+        return pos - offset;
+    }
+
+    // ----------------------------------------------------------------------
+    // Private helpers
+    // ----------------------------------------------------------------------
+
+    /** Computes the exact number of UTF-8 bytes required for {@code str}. Validates surrogate pairing. */
+    public static int encodedLength(final String str) throws IOException {
+        final int n = str.length();
+        int len = 0;
+        int i = 0;
+
+        // Fast ASCII prefix
+        while (i < n) {
+            char c = str.charAt(i);
+            if (c > 0x7F) break;
+            len++;
+            i++;
+            // nibble a few ASCII in a burst
+            while (i < n) {
+                char d = str.charAt(i);
+                if (d > 0x7F) break;
+                len++;
+                i++;
+            }
+        }
+
+        while (i < n) {
+            char c = str.charAt(i++);
+            if (c <= 0x7F) {
+                len += 1;
+            } else if (c <= 0x7FF) {
+                len += 2;
+            } else if (Character.isHighSurrogate(c)) {
+                if (i >= n) throw new IOException("encodedLength: unpaired high surrogate at end");
+                char d = str.charAt(i);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodedLength: unpaired high surrogate");
+                i++; // consume pair
+                len += 4;
+            } else if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodedLength: unpaired low surrogate");
+            } else {
+                len += 3;
+            }
+        }
+        return len;
+    }
+
+    /** Counts UTF-16 code units produced by decoding strict UTF-8 in in[offset..end). */
+    private static int countUtf16UnitsStrict(final byte[] in, final int offset, final int end) throws IOException {
+        int i = offset;
+        int count = 0;
+
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                count += 1;
+                // run of ASCII
+                while (i < end && (in[i] >= 0)) {
+                    i++;
+                    count++;
+                }
+                continue;
+            }
+
+            if ((b0 & 0xE0) == 0xC0) { // 2-byte
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                int cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+                if (cp < 0x80 || b0 < 0xC2) throw bad(); // overlong / invalid
+                count += 1;
+                continue;
+            }
+
+            if ((b0 & 0xF0) == 0xE0) { // 3-byte
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad(); // overlong
+                if (b0 == 0xED && b1 >= 0xA0) throw bad(); // surrogate range
+                int cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+                if (cp < 0x800) throw bad(); // overlong
+                if (cp >= 0xD800 && cp <= 0xDFFF) throw bad(); // encoded surrogate
+                count += 1;
+                continue;
+            }
+
+            if ((b0 & 0xF8) == 0xF0) { // 4-byte
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                int b2 = in[i++] & 0xFF;
+                int b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xF0 && b1 < 0x90) throw bad(); // overlong
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad(); // > U+10FFFF
+                count += 2; // surrogate pair in UTF-16
+                continue;
+            }
+
+            throw bad();
+        }
+        return count;
+    }
+
+    private static IOException bad() {
+        return new IOException("Malformed UTF-8 input");
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV4.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/utf8/Utf8ToolsV4.java
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh.utf8;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+
+/**
+ * UTF8 tools based on protobuf standard library, so we are byte for byte identical
+ */
+public final class Utf8ToolsV4 {
+
+    // ---- Internal fast-path plumbing ---------------------------------------------------------
+
+    // Compact Strings: coder == 0 (LATIN1), 1 (UTF16)
+    private static final byte CODER_LATIN1 = 0;
+    private static final byte CODER_UTF16 = 1;
+
+    // Guard: if these are non-null, we can fast-path on String internals.
+    private static final VarHandle STRING_VALUE_VH;
+    private static final VarHandle STRING_CODER_VH;
+    private static final boolean HAS_STRING_VH;
+
+    static {
+        VarHandle v = null, c = null;
+        boolean ok = false;
+        try {
+            MethodHandles.Lookup l = MethodHandles.privateLookupIn(String.class, MethodHandles.lookup());
+            v = l.findVarHandle(String.class, "value", byte[].class);
+            c = l.findVarHandle(String.class, "coder", byte.class);
+            ok = (v != null && c != null);
+        } catch (Throwable ignore) {
+            ignore.printStackTrace();
+            ok = false;
+        }
+        STRING_VALUE_VH = v;
+        STRING_CODER_VH = c;
+        HAS_STRING_VH = ok;
+    }
+
+    // Helpers
+    private static byte[] stringValueBytes(String s) {
+        return (byte[]) STRING_VALUE_VH.get(s);
+    }
+
+    private static byte stringCoder(String s) {
+        return (byte) STRING_CODER_VH.get(s);
+    }
+
+    // ---- Public API --------------------------------------------------------------------------
+
+    /** Strict UTF-8 decode. Throws IOException on malformed sequences. */
+    public static String decodeUtf8(final byte[] in, final int offset, final int length) throws IOException {
+        if ((offset | length) < 0 || offset + length > in.length) {
+            throw new IndexOutOfBoundsException("decodeUtf8: bad offset/length");
+        }
+        final int end = offset + length;
+
+        // ASCII run fast path
+        int i = offset;
+        while (i < end && in[i] >= 0) i++;
+        if (i == end) {
+            char[] chars = new char[length];
+            for (int p = 0; p < length; p++) chars[p] = (char) (in[offset + p] & 0x7F);
+            return new String(chars);
+        }
+
+        // Count UTF-16 units (strict validation)
+        final int charCount = countUtf16UnitsStrict(in, offset, end);
+        final char[] out = new char[charCount];
+
+        // Decode
+        int outPos = 0;
+        i = offset;
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                out[outPos++] = (char) b0;
+                while (i < end && in[i] >= 0) out[outPos++] = (char) (in[i++] & 0x7F);
+                continue;
+            }
+            if ((b0 & 0xE0) == 0xC0) {
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                int cp = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+                if (cp < 0x80 || b0 < 0xC2) throw bad(); // overlong
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF0) == 0xE0) {
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad();
+                if (b0 == 0xED && b1 >= 0xA0) throw bad();
+                int cp = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+                if (cp < 0x800 || (cp >= 0xD800 && cp <= 0xDFFF)) throw bad();
+                out[outPos++] = (char) cp;
+                continue;
+            }
+            if ((b0 & 0xF8) == 0xF0) {
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF, b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xF0 && b1 < 0x90) throw bad();
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad();
+                int cp = ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+                if (cp < 0x10000 || cp > 0x10FFFF) throw bad();
+                int hi = ((cp - 0x10000) >>> 10) + 0xD800;
+                int lo = ((cp - 0x10000) & 0x3FF) + 0xDC00;
+                out[outPos++] = (char) hi;
+                out[outPos++] = (char) lo;
+                continue;
+            }
+            throw bad();
+        }
+        return new String(out);
+    }
+
+    /**
+     * Encodes {@code in} to UTF-8 into {@code out} at {@code offset}.
+     * Returns bytes written. Throws if insufficient space or malformed surrogates.
+     * Uses a VarHandle fast path for String LATIN1 (Compact String) when available.
+     */
+    public static int encodeUtf8(final String in, final byte[] out, final int offset) throws IOException {
+        Objects.requireNonNull(in, "in");
+        // Try the internal LATIN1 fast path
+        if (HAS_STRING_VH && stringCoder(in) == CODER_LATIN1) {
+            final byte[] v = stringValueBytes(in);
+            // Quick ASCII check; if all ASCII, we can memcpy directly.
+            int i = 0, n = v.length;
+            while (i < n && (v[i] & 0x80) == 0) i++;
+            if (i == n) {
+                // Pure ASCII: exact size == n
+                if (out.length - offset < n) throw new IOException("encodeUtf8: insufficient space (ASCII path)");
+                System.arraycopy(v, 0, out, offset, n);
+                return n;
+            }
+            // Mixed Latin-1: encode in one pass. Worst-case length = n (ASCII) + 2*(non-ascii bytes)
+            // Exact length is computed below (without allocating).
+            return encodeLatin1ToUtf8(v, out, offset);
+        }
+        // Portable path (handles UTF16 coder as well)
+        return encodePortable(in, out, offset);
+    }
+
+    /**
+     * Returns the exact UTF-8 byte length for {@code str}. Validates surrogate pairing.
+     * Uses internal LATIN1 fast path if available.
+     */
+    public static int encodedLength(final String str) throws IOException {
+        if (HAS_STRING_VH && stringCoder(str) == CODER_LATIN1) {
+            return encodedLengthLatin1(stringValueBytes(str));
+        }
+        // Portable path for UTF16 (or if internals not available)
+        final int n = str.length();
+        int len = 0;
+        int i = 0;
+
+        // ASCII prefix
+        while (i < n && str.charAt(i) <= 0x7F) {
+            len++;
+            i++;
+        }
+        while (i < n) {
+            char c = str.charAt(i++);
+            if (c <= 0x7F) {
+                len += 1;
+            } else if (c <= 0x7FF) {
+                len += 2;
+            } else if (Character.isHighSurrogate(c)) {
+                if (i >= n) throw new IOException("encodedLength: unpaired high surrogate at end");
+                char d = str.charAt(i);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodedLength: unpaired high surrogate");
+                i++;
+                len += 4;
+            } else if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodedLength: unpaired low surrogate");
+            } else {
+                len += 3;
+            }
+        }
+        return len;
+    }
+
+    // ---- Internal fast-path (LATIN1 String.value) --------------------------------------------
+
+    /** Exact UTF-8 length for a LATIN1 byte[] (no surrogates exist in LATIN1). */
+    private static int encodedLengthLatin1(final byte[] latin1) {
+        int ascii = 0, hi = 0; // count ASCII vs high bytes
+        for (byte b : latin1) {
+            if ((b & 0x80) == 0) ascii++;
+            else hi++;
+        }
+        // ASCII -> 1 byte; high bytes (0x80..0xFF) -> 2-byte UTF-8
+        return ascii + (hi << 1);
+    }
+
+    /** Encodes a LATIN1 byte[] directly to UTF-8. Returns bytes written. */
+    private static int encodeLatin1ToUtf8(final byte[] latin1, final byte[] out, final int offset) {
+        int pos = offset;
+        int i = 0, n = latin1.length;
+
+        // ASCII run
+        while (i < n && (latin1[i] & 0x80) == 0) {
+            out[pos++] = latin1[i++];
+            while (i < n && (latin1[i] & 0x80) == 0) {
+                out[pos++] = latin1[i++];
+            }
+            // then fall into non-ASCII handling if applicable
+        }
+
+        while (i < n) {
+            int b = latin1[i++] & 0xFF;
+            if ((b & 0x80) == 0) {
+                // ASCII
+                out[pos++] = (byte) b;
+            } else {
+                // LATIN1 0x80..0xFF -> two-byte UTF-8: 0xC2/0xC3 prefix depending on top bit of 0x80..0xFF
+                // Values 0x80..0xBF => 0xC2 xx ; 0xC0..0xFF => 0xC3 (b - 0x40)
+                if (b < 0xC0) {
+                    out[pos++] = (byte) 0xC2;
+                    out[pos++] = (byte) b;
+                } else {
+                    out[pos++] = (byte) 0xC3;
+                    out[pos++] = (byte) (b - 0x40); // (b & 0x3F) | 0x80
+                }
+            }
+        }
+        return pos - offset;
+    }
+
+    // ---- Portable encode (UTF-16 String) -----------------------------------------------------
+
+    private static int encodePortable(final String in, final byte[] out, final int offset) throws IOException {
+        int pos = offset;
+        final int n = in.length();
+        int i = 0;
+
+        // ASCII fast path
+        while (i < n) {
+            char c = in.charAt(i);
+            if (c <= 0x7F) {
+                out[pos++] = (byte) c;
+                i++;
+                while (i < n) {
+                    char d = in.charAt(i);
+                    if (d > 0x7F) break;
+                    out[pos++] = (byte) d;
+                    i++;
+                }
+                continue;
+            }
+            if (c <= 0x7FF) {
+                out[pos++] = (byte) (0xC0 | (c >>> 6));
+                out[pos++] = (byte) (0x80 | (c & 0x3F));
+                i++;
+                continue;
+            }
+            if (Character.isHighSurrogate(c)) {
+                if (i + 1 >= n) throw new IOException("encodeUtf8: unpaired high surrogate at end");
+                char d = in.charAt(i + 1);
+                if (!Character.isLowSurrogate(d)) throw new IOException("encodeUtf8: unpaired high surrogate");
+                int cp = Character.toCodePoint(c, d);
+                out[pos++] = (byte) (0xF0 | (cp >>> 18));
+                out[pos++] = (byte) (0x80 | ((cp >>> 12) & 0x3F));
+                out[pos++] = (byte) (0x80 | ((cp >>> 6) & 0x3F));
+                out[pos++] = (byte) (0x80 | (cp & 0x3F));
+                i += 2;
+                continue;
+            }
+            if (Character.isLowSurrogate(c)) {
+                throw new IOException("encodeUtf8: unpaired low surrogate");
+            }
+            out[pos++] = (byte) (0xE0 | (c >>> 12));
+            out[pos++] = (byte) (0x80 | ((c >>> 6) & 0x3F));
+            out[pos++] = (byte) (0x80 | (c & 0x3F));
+            i++;
+        }
+        return pos - offset;
+    }
+
+    // ---- Strict counting for decode ----------------------------------------------------------
+
+    private static int countUtf16UnitsStrict(final byte[] in, final int offset, final int end) throws IOException {
+        int i = offset, count = 0;
+        while (i < end) {
+            int b0 = in[i++] & 0xFF;
+            if (b0 < 0x80) {
+                count += 1;
+                while (i < end && in[i] >= 0) {
+                    i++;
+                    count++;
+                }
+                continue;
+            }
+            if ((b0 & 0xE0) == 0xC0) {
+                if (i >= end) throw bad();
+                int b1 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80) throw bad();
+                if (b0 < 0xC2) throw bad(); // overlong
+                count += 1;
+                continue;
+            }
+            if ((b0 & 0xF0) == 0xE0) {
+                if (i + 1 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xE0 && b1 < 0xA0) throw bad();
+                if (b0 == 0xED && b1 >= 0xA0) throw bad();
+                count += 1;
+                continue;
+            }
+            if ((b0 & 0xF8) == 0xF0) {
+                if (i + 2 >= end) throw bad();
+                int b1 = in[i++] & 0xFF, b2 = in[i++] & 0xFF, b3 = in[i++] & 0xFF;
+                if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) throw bad();
+                if (b0 == 0xF0 && b1 < 0x90) throw bad();
+                if (b0 > 0xF4 || (b0 == 0xF4 && b1 > 0x8F)) throw bad();
+                count += 2; // surrogate pair
+                continue;
+            }
+            throw bad();
+        }
+        return count;
+    }
+
+    private static IOException bad() {
+        return new IOException("Malformed UTF-8");
+    }
+
+    public static void main(String[] args) throws IOException {
+        encodeUtf8("hello", new byte[10], 0);
+    }
+}

--- a/pbj-integration-tests/src/main/proto/extendedUtf8StingTest.proto
+++ b/pbj-integration-tests/src/main/proto/extendedUtf8StingTest.proto
@@ -27,12 +27,31 @@ option java_package = "com.hedera.pbj.test.proto.java";
 option java_multiple_files = true;
 // <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
 
+import "google/protobuf/wrappers.proto";
+
 /**
  * Simple message with a string for extended UTF8 testing
  */
+// <<<pbj.comparable = "aTestString" >>>
 message MessageWithString {
     /**
      * A single string for extended testing
      */
     string aTestString = 1;
+}
+
+// <<<pbj.comparable = "boxedString" >>>
+message MessageWithBoxedString {
+    google.protobuf.StringValue boxedString = 5;
+}
+
+message MessageWithRepeatedString {
+  repeated string repeatedText = 1;
+}
+
+// <<<pbj.comparable = "oneofExample" >>>
+message MessageWithOneOfString {
+  oneof oneofExample {
+    string text = 1;
+  }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/HashEqualsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/HashEqualsTest.java
@@ -4,9 +4,14 @@ package com.hedera.pbj.integration.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.pbj.test.proto.pbj.MessageWithBoxedString;
+import com.hedera.pbj.test.proto.pbj.MessageWithRepeatedString;
+import com.hedera.pbj.test.proto.pbj.MessageWithString;
 import com.hedera.pbj.test.proto.pbj.TimestampTest;
 import com.hedera.pbj.test.proto.pbj.TimestampTest2;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class HashEqualsTest {
@@ -88,5 +93,40 @@ class HashEqualsTest {
         TimestampTest2 tst2 = new TimestampTest2(1, 2, 3);
 
         assertNotEquals(tst.hashCode(), tst2.hashCode());
+    }
+
+    @Test
+    void testStrings() {
+        // new String() to ensure we actually create a brand-new string instance
+        final MessageWithString msg1 = new MessageWithString(new String("test"));
+        // Same characters, but a brand-new string instance again
+        final MessageWithString msg2 = new MessageWithString(new String("test"));
+
+        assertEquals(msg1.hashCode(), msg2.hashCode());
+        assertTrue(msg1.equals(msg2));
+    }
+
+    @Test
+    void testBoxedStrings() {
+        // new String() to ensure we actually create a brand-new string instance
+        final MessageWithBoxedString msg1 = new MessageWithBoxedString(new String("test"));
+        // Same characters, but a brand-new string instance again
+        final MessageWithBoxedString msg2 = new MessageWithBoxedString(new String("test"));
+
+        assertEquals(msg1.hashCode(), msg2.hashCode());
+        assertTrue(msg1.equals(msg2));
+    }
+
+    @Test
+    void testRepeatedStrings() {
+        // new String() to ensure we actually create a brand-new string instance
+        final MessageWithRepeatedString msg1 =
+                new MessageWithRepeatedString(List.of(new String("test1"), new String("test2")));
+        // Same characters, but a brand-new string instance again
+        final MessageWithRepeatedString msg2 =
+                new MessageWithRepeatedString(List.of(new String("test1"), new String("test2")));
+
+        assertEquals(msg1.hashCode(), msg2.hashCode());
+        assertTrue(msg1.equals(msg2));
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SampleFuzzTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/SampleFuzzTest.java
@@ -60,7 +60,7 @@ public class SampleFuzzTest {
      * The fuzz test as a whole is considered passed
      * if that many individual model tests pass.
      */
-    private static final double PASS_RATE_THRESHOLD = 1.;
+    private static final double PASS_RATE_THRESHOLD = .997;
 
     /**
      * A threshold for the mean value of the shares of DESERIALIZATION_FAILED
@@ -70,7 +70,7 @@ public class SampleFuzzTest {
      * if the mean value of all the individual DESERIALIZATION_FAILED
      * shares is greater than this threshold.
      */
-    private static final double DESERIALIZATION_FAILED_MEAN_THRESHOLD = .9829;
+    private static final double DESERIALIZATION_FAILED_MEAN_THRESHOLD = .9824;
 
     /**
      * Fuzz tests are tagged with this tag to allow Gradle/JUnit


### PR DESCRIPTION
**Description**:
This is the last part of changes extracted from @jasperpotts 's draft PoC https://github.com/hashgraph/pbj/pull/612 . We store string fields as UTF-8 byte arrays internally in models. We allow codecs to parse original UTF-8 and implant them directly into the model w/o performing the UTF-8 decoding (which internally would convert the text into UTF-16 (or Latin-1) because that's how Java stores strings.) The public API of the models is unchanged, and whenever anyone calls a getter for a string field, the model will encode it into a Java string on the fly.

The idea behind this optimization is that we rarely read or use strings in our business logic. So we could as well skip the decoding part when parsing models.

Three caveats come with the fix:
1. New public constructors are introduced that accept raw `byte[]` for strings and also have a fake unused argument so as to resolve a generic erasure clash. This looks a bit ugly. Also, this is not very safe because it allows a malicious code to create a mutable model instance (by retaining references to their `byte[]`) and then pass the object to a code that expects the models to be immutable. We could make the constructors `private`, but we'd have to move all the codecs into the same package with their models, which could be a breaking change.
2. If we end up reading the string multiple times, either directly or via log/toString(), either now or in the future, then this optimization will be defeated as we'll be encoding the bytes multiple times. We could work-around this by adding caching for the encoded strings, same as we do with hashCode/protobufSize already.
3. The fuzz test thresholds had to be relaxed because PBJ no longer decodes UTF-8 strings when parsing models, so it now fails less often than Protoc. Also, this means that encoding errors may now happen inside our business logic code rather than at deserialization points as before. There isn't a simple solution for this caveat.

**Related issue(s)**:

Fixes #620

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
