### PR TITLE
docs: document generateTestClasses Gradle plugin option

### DIFF
--- a/pbj-core/pbj-compiler/README.md
+++ b/pbj-core/pbj-compiler/README.md
@@ -142,7 +142,15 @@ immutable.
 ### Generated Unit Tests
 
 For each generated model object there is a unit test generated that tests the protobuf and JSON codecs against the
-*protoc* generated code to make sure they are 100% byte for byte binary compatible.
+*protoc* generated code to make sure they are 100% byte for byte binary compatible. This requires a dependency on
+Google Protobuf libraries which may not be always desirable. To disable tests generation and avoid having to add
+a dependency on Google Protobuf libraries, add the following configuration to your `build.gradle.kts`:
+
+```kotlin
+pbj {
+   generateTestClasses = false
+}
+```
 
 ## Generated Code Formatting
 


### PR DESCRIPTION
**Description**:
Adding documentation on how to disable tests generation.

**Related issue(s)**:

Fixes #632 

**Notes for reviewer**:
Trivial change.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
