### PR TITLE
feat: implement WritableMessageDigest.digest()/reset()

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/hashing/WritableMessageDigest.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/hashing/WritableMessageDigest.java
@@ -20,7 +20,7 @@ public class WritableMessageDigest implements WritableSequentialData {
     /**
      * A fake position that we keep increasing as we add data. We have to maintain it because there's code
      * in ProtoWriterTools that checks the position before and after writing data, and errors out if the position
-     * hasn't changed as expected.
+     * hasn't changed as expected. Both `reset()` and `digest()` reset the position to zero.
      */
     private long position = 0;
 
@@ -30,6 +30,22 @@ public class WritableMessageDigest implements WritableSequentialData {
      */
     public WritableMessageDigest(@NonNull final MessageDigest digest) {
         this.digest = Objects.requireNonNull(digest);
+    }
+
+    /**
+     * A delegate for the wrapped MessageDigest.reset() method.
+     */
+    public void reset() {
+        position = 0;
+        digest.reset();
+    }
+
+    /**
+     * A delegate for the wrapped MessageDigest.digest() method.
+     */
+    public byte[] digest() {
+        position = 0;
+        return digest.digest();
     }
 
     @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/hashing/WritableMessageDigestTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/hashing/WritableMessageDigestTest.java
@@ -43,11 +43,10 @@ public class WritableMessageDigestTest {
         final MessageDigest ctrlDigest = buildDigest();
         ctrlDigest.update(b);
 
-        final MessageDigest testDigest = buildDigest();
-        final WritableMessageDigest wmd = new WritableMessageDigest(testDigest);
+        final WritableMessageDigest wmd = new WritableMessageDigest(buildDigest());
         wmd.writeByte(b);
 
-        assertArrayEquals(ctrlDigest.digest(), testDigest.digest());
+        assertArrayEquals(ctrlDigest.digest(), wmd.digest());
     }
 
     private static final byte[] FULL_RANGE_ARRAY = new byte[256];


### PR DESCRIPTION
**Description**:
Implementing `WritableMessageDigest.digest()/reset()` that delegate the operation to the wrapped `MessageDigest` object.

**Related issue(s)**:

Fixes #658 

**Notes for reviewer**:
A unit test is updated to verify the new code path.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
