### PR TITLE
feat: allow custom maxSize for requests in GRPC server

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -637,8 +637,8 @@ public final class ServiceGenerator {
                     Objects.requireNonNull(message);
                     Objects.requireNonNull(options);
 
-                    // not strict, and hard-code maxDepth for now:
-                    return get$simpleRequestTypeCodec(options).parse(message.toReadableSequentialData(), false, 16);
+                    // not strict, no unknown fields, hard-code maxDepth for now, and use custom maxSize:
+                    return get$simpleRequestTypeCodec(options).parse(message.toReadableSequentialData(), false, false, 16, options.maxMessageSizeBytes());
                 }
                 """
                 .replace("$requestType", requestType)

--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -277,7 +277,8 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
             // used to decide on the best way to parse or handle the request.
             final var options = new Options(
                     Optional.ofNullable(headers.authority()), // the client (see http2 spec)
-                    contentType);
+                    contentType,
+                    config.maxMessageSizeBytes());
 
             // Setup the subscribers. The "outgoing" subscriber will send messages to the client.
             // This is given to the "open" method on the service to allow it to send messages to
@@ -721,7 +722,8 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
     }
 
     /** Simple implementation of the {@link ServiceInterface.RequestOptions} interface. */
-    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+    private record Options(Optional<String> authority, String contentType, int maxMessageSizeBytes)
+            implements ServiceInterface.RequestOptions {}
 
     /**
      * A {@link ScheduledFuture} that does nothing. This is used when there is no deadline set for

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
@@ -66,6 +66,13 @@ public interface ServiceInterface extends AutoCloseable {
         String APPLICATION_GRPC_JSON = "application/grpc+json";
 
         /**
+         * Default maximum message size in bytes ({@value}).
+         *
+         * @see #maxMessageSizeBytes()
+         */
+        int DEFAULT_MAX_MESSAGE_SIZE_BYTES = 1024 * 10; // 10KB
+
+        /**
          * The authority of the client that is connecting to the service. This is the value of the ":authority" header
          * in the HTTP/2 request. This value is used by the service to determine the client's identity. It may be that
          * no authority is provided, in which case this method will return an empty optional.
@@ -101,6 +108,15 @@ public interface ServiceInterface extends AutoCloseable {
          */
         @NonNull
         String contentType();
+
+        /**
+         * Maximum size of any message in bytes. Defaults to {@value #DEFAULT_MAX_MESSAGE_SIZE_BYTES}.
+         *
+         * @return the maximum number of bytes a single message can be
+         */
+        default int maxMessageSizeBytes() {
+            return DEFAULT_MAX_MESSAGE_SIZE_BYTES;
+        }
     }
 
     /** Gets the simple name of the service. For example, "HelloService". */


### PR DESCRIPTION
**Description**:
By default, PBJ Codec would use the value of 2MB for `maxSize` when calling `parse()`. GRPC server implementation doesn't currently supply a custom value, so this default value is used.

There's a use-case for allowing some servers to process larger input requests. So we need a way to propagate the GRPC server's `PbjConfigBlueprint.maxMessageSizeBytes()` value to the GRPC server implementation so that it passes the value to the `Codec.parse()` calls when parsing input requests.

**Related issue(s)**:

Fixes #666 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
