### PR TITLE
feat: Pipeline.closeConnection

### DIFF
--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -40,6 +40,7 @@ import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2StreamState;
 import io.helidon.http.http2.Http2StreamWriter;
 import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import java.util.List;
 import java.util.Objects;
@@ -78,6 +79,7 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
     private final int streamId;
     private final FlowControl.Outbound flowControl;
     private final AtomicReference<Http2StreamState> currentStreamState;
+    private final ConnectionContext connectionContext;
 
     /**
      * The service method that this connection was created for. The route has information about the
@@ -164,7 +166,8 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
             @NonNull final Http2StreamState currentStreamState,
             @NonNull final PbjConfig config,
             @NonNull final PbjMethodRoute route,
-            @NonNull final DeadlineDetector deadlineDetector) {
+            @NonNull final DeadlineDetector deadlineDetector,
+            @NonNull final ConnectionContext ctx) {
         this.headers = requireNonNull(headers);
         this.streamWriter = requireNonNull(streamWriter);
         this.streamId = streamId;
@@ -173,6 +176,7 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
         this.config = requireNonNull(config);
         this.route = requireNonNull(route);
         this.deadlineDetector = requireNonNull(deadlineDetector);
+        this.connectionContext = ctx;
     }
 
     /**
@@ -718,6 +722,11 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
                 }
                 return Http2StreamState.CLOSED;
             });
+        }
+
+        @Override
+        public void closeConnection() {
+            connectionContext.serverSocket().close();
         }
     }
 

--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolSelector.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolSelector.java
@@ -61,7 +61,7 @@ class PbjProtocolSelector implements Http2SubProtocolSelector {
      */
     @Override
     public SubProtocolResult subProtocol(
-            @NonNull final ConnectionContext ctx, // unused
+            @NonNull final ConnectionContext ctx,
             @NonNull final HttpPrologue prologue,
             @NonNull final Http2Headers headers,
             @NonNull final Http2StreamWriter streamWriter,
@@ -112,6 +112,7 @@ class PbjProtocolSelector implements Http2SubProtocolSelector {
                         currentStreamState,
                         config,
                         route,
-                        deadlineDetector));
+                        deadlineDetector,
+                        ctx));
     }
 }

--- a/pbj-core/pbj-grpc-helidon/src/main/java/module-info.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module com.hedera.pbj.grpc.helidon {
     requires transitive io.helidon.webserver;
     requires io.helidon.common.buffers;
     requires io.helidon.common.media.type;
+    requires io.helidon.common.socket;
     requires io.helidon.common.uri;
     requires io.helidon.http.http2;
     requires io.helidon.http;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipeline.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipeline.java
@@ -15,6 +15,15 @@ public interface Pipeline<T> extends Flow.Subscriber<T> {
     default void clientEndStreamReceived() {}
 
     /**
+     * Closes the network connection over which this Pipeline transmits data.
+     * Certain transport protocols, such as HTTP2, allow serving multiple requests over the same network connection
+     * via "streams". Calling this method will close any and all open streams running over the associated connection,
+     * terminating any other affected requests/Pipelines. Under normal circumstances, applications should prefer
+     * to use `onComplete()` instead, which would only affect the stream associated with this Pipeline instance.
+     */
+    default void closeConnection() {}
+
+    /**
      * {@inheritDoc}
      * @throws RuntimeException if an error occurs while trying to write data to the pipeline
      */

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipelines.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/Pipelines.java
@@ -535,6 +535,11 @@ public final class Pipelines {
         public void clientEndStreamReceived() {
             // nothing to do, as onComplete is always called inside onNext
         }
+
+        @Override
+        public void closeConnection() {
+            replies.closeConnection();
+        }
     }
 
     /**
@@ -629,6 +634,11 @@ public final class Pipelines {
             // if the client stream is ended, the entire pipeline is ended
             onComplete();
         }
+
+        @Override
+        public void closeConnection() {
+            replies.closeConnection();
+        }
     }
 
     /**
@@ -717,6 +727,11 @@ public final class Pipelines {
         public void clientEndStreamReceived() {
             onComplete();
         }
+
+        @Override
+        public void closeConnection() {
+            replies.closeConnection();
+        }
     }
 
     /**
@@ -796,6 +811,11 @@ public final class Pipelines {
             // nothing to do
             // the server will continue streaming, since the message coming from the client is a subscription request
         }
+
+        @Override
+        public void closeConnection() {
+            replies.closeConnection();
+        }
     }
 
     /**
@@ -851,6 +871,11 @@ public final class Pipelines {
         @Override
         public void onComplete() {
             next.onComplete();
+        }
+
+        @Override
+        public void closeConnection() {
+            next.closeConnection();
         }
     }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcCloseClientConnectionTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcCloseClientConnectionTest.java
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.grpc.helidon.PbjRouting;
+import com.hedera.pbj.runtime.grpc.GrpcClient;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import pbj.integration.tests.pbj.integration.tests.GreeterInterface;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+/** Test the Pipeline.closeConnection(). */
+public class GrpcCloseClientConnectionTest {
+
+    private static final int port = 18666;
+
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+
+    private static final Options OPTIONS =
+            new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
+
+    // First, implement the service and start it up
+    private static class GreeterServiceImpl implements GreeterInterface {
+
+        @Override
+        public HelloReply sayHello(HelloRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sayHelloStreamReply(HelloRequest request, Pipeline<? super HelloReply> replies) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Pipeline<? super HelloRequest> sayHelloStreamRequest(Pipeline<? super HelloReply> replies) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Pipeline<? super HelloRequest> sayHelloStreamBidi(Pipeline<? super HelloReply> replies) {
+            return new Pipeline<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    subscription.request(Long.MAX_VALUE); // turn off flow control
+                }
+
+                @Override
+                public void onNext(HelloRequest item) {
+                    if ("kill me".equals(item.name())) {
+                        replies.closeConnection();
+                        return;
+                    }
+                    final HelloReply reply = HelloReply.newBuilder()
+                            .message("Hello " + item.name())
+                            .build();
+                    replies.onNext(reply);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    replies.onError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    replies.onComplete();
+                }
+            };
+        }
+    }
+
+    private static final GreeterServiceImpl SERVICE = new GreeterServiceImpl();
+    private static WebServer SERVER;
+    private static GrpcClient GRPC_CLIENT;
+
+    @BeforeAll
+    static void setup() {
+        SERVER = WebServer.builder()
+                .port(port)
+                .addRouting(PbjRouting.builder().service(SERVICE))
+                .maxPayloadSize(10000)
+                .build()
+                .start();
+
+        final Tls tls = Tls.builder().enabled(false).build();
+        final WebClient webClient =
+                WebClient.builder().baseUri("http://localhost:" + port).tls(tls).build();
+
+        final PbjGrpcClientConfig config =
+                new PbjGrpcClientConfig(Duration.ofSeconds(10), tls, OPTIONS.authority(), OPTIONS.contentType());
+
+        GRPC_CLIENT = new PbjGrpcClient(webClient, config);
+    }
+
+    @AfterAll
+    static void teardown() {
+        SERVER.stop();
+    }
+
+    @Test
+    public void testCloseClientConnection() {
+        final GreeterInterface.GreeterClient client = new GreeterInterface.GreeterClient(GRPC_CLIENT, OPTIONS);
+
+        final List<HelloReply> replies = new ArrayList<>();
+        final List<Throwable> errors = new ArrayList<>();
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final Pipeline<? super HelloRequest> requests = client.sayHelloStreamBidi(new Pipeline<>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                // no-op
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                errors.add(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+            }
+
+            @Override
+            public void onNext(HelloReply item) throws RuntimeException {
+                replies.add(item);
+            }
+        });
+
+        requests.onNext(HelloRequest.newBuilder().name("test name 1").build());
+        requests.onNext(HelloRequest.newBuilder().name("test name 2").build());
+        requests.onNext(HelloRequest.newBuilder().name("kill me").build());
+        requests.onNext(HelloRequest.newBuilder().name("test name 3").build());
+        requests.onComplete();
+
+        // NOTE: the test method isn't blocking (because it returns a requests pipeline.)
+        // So we have to wait a tad. Both server and client are running on the current host here
+        // (in the same JVM, in fact.) So 1 second should be sufficient, unless the computer is really-really slow.
+        // If we find this not working, then we'll come up with a longer timeout and will be watching the completed
+        // flag in a loop instead.
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+        }
+
+        // Server and client run asynchronously. Depending on how fast the closing of the connection happens,
+        // the client may not even receive the very first two replies. So we cannot check the list for equality.
+        // Instead, we do this:
+        assertTrue(replies.size() <= 2);
+        if (!replies.isEmpty()) {
+            assertFalse(replies.stream()
+                    .anyMatch(hr -> hr.equals(
+                            HelloReply.newBuilder().message("Hello kill me").build())));
+            assertFalse(replies.stream()
+                    .anyMatch(hr -> hr.equals(
+                            HelloReply.newBuilder().message("Hello test name 3").build())));
+        }
+
+        // Log all errors (if any) and assert there's none
+        errors.forEach(System.err::println);
+        // Again, depending on how brutal the connection closing happened, there may in fact be errors.
+        // So we don't check them, nor do we check the completed flag for the same reason.
+
+        // Ensure the GRPCClient connection is actually closed:
+        assertThrows(
+                UncheckedIOException.class,
+                () -> client.sayHelloStreamBidi(new Pipeline<>() {
+                    @Override
+                    public void onSubscribe(Flow.Subscription subscription) {}
+
+                    @Override
+                    public void onError(Throwable throwable) {}
+
+                    @Override
+                    public void onComplete() {}
+
+                    @Override
+                    public void onNext(HelloReply item) throws RuntimeException {}
+                }));
+
+        // Also ensure that the server is still running and can accept a new connection via a new GrpcClient instance:
+        {
+            final Tls tls = Tls.builder().enabled(false).build();
+            final WebClient webClient = WebClient.builder()
+                    .baseUri("http://localhost:" + port)
+                    .tls(tls)
+                    .build();
+
+            final PbjGrpcClientConfig config =
+                    new PbjGrpcClientConfig(Duration.ofSeconds(10), tls, OPTIONS.authority(), OPTIONS.contentType());
+
+            final PbjGrpcClient grpcClient = new PbjGrpcClient(webClient, config);
+
+            final GreeterInterface.GreeterClient client2 = new GreeterInterface.GreeterClient(grpcClient, OPTIONS);
+
+            final List<HelloReply> replies2 = new ArrayList<>();
+            final List<Throwable> errors2 = new ArrayList<>();
+            final AtomicBoolean completed2 = new AtomicBoolean(false);
+            final Pipeline<? super HelloRequest> requests2 = client2.sayHelloStreamBidi(new Pipeline<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    // no-op
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    errors2.add(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    completed2.set(true);
+                }
+
+                @Override
+                public void onNext(HelloReply item) throws RuntimeException {
+                    replies2.add(item);
+                }
+            });
+
+            requests2.onNext(HelloRequest.newBuilder().name("test name 1").build());
+            requests2.onNext(HelloRequest.newBuilder().name("test name 2").build());
+            requests2.onNext(HelloRequest.newBuilder().name("test name 3").build());
+            requests2.onComplete();
+
+            // NOTE: the test method isn't blocking (because it returns a requests pipeline.)
+            // So we have to wait a tad. Both server and client are running on the current host here
+            // (in the same JVM, in fact.) So 1 second should be sufficient, unless the computer is really-really slow.
+            // If we find this not working, then we'll come up with a longer timeout and will be watching the completed
+            // flag in a loop instead.
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+            }
+
+            assertEquals(
+                    List.of(
+                            HelloReply.newBuilder().message("Hello test name 1").build(),
+                            HelloReply.newBuilder().message("Hello test name 2").build(),
+                            HelloReply.newBuilder().message("Hello test name 3").build()),
+                    replies2);
+
+            // Log all errors (if any) and assert there's none
+            errors2.forEach(System.err::println);
+            assertTrue(errors2.isEmpty());
+
+            assertTrue(completed2.get());
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
Introducing `Pipeline.closeConnection()` that allows a GRPC server implementation to close a client connection. See the new integration test for usage example.

**Related issue(s)**:

Fixes #657

**Notes for reviewer**:
An integration test is added to verify the behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
