### PR TITLE
test: implement RandomString and remove bytebuddy

### DIFF
--- a/pbj-core/hiero-dependency-versions/build.gradle.kts
+++ b/pbj-core/hiero-dependency-versions/build.gradle.kts
@@ -57,7 +57,6 @@ dependencies.constraints {
     api("com.google.guava:guava:33.5.0-jre") { because("com.google.common") }
     api("com.google.protobuf:protobuf-java:$protobuf") { because("com.google.protobuf") }
     api("com.google.protobuf:protobuf-java-util:$protobuf") { because("com.google.protobuf.util") }
-    api("net.bytebuddy:byte-buddy:1.17.7") { because("net.bytebuddy") }
     api("org.assertj:assertj-core:3.27.6") { because("org.assertj.core") }
     api("org.junit.jupiter:junit-jupiter-api:$junit5") { because("org.junit.jupiter.api") }
     api("org.junit.jupiter:junit-jupiter-engine:$junit5") { because("org.junit.jupiter.engine") }

--- a/pbj-core/pbj-runtime/build.gradle.kts
+++ b/pbj-core/pbj-runtime/build.gradle.kts
@@ -12,7 +12,6 @@ description =
 testModuleInfo {
     requires("com.google.protobuf")
     requires("org.assertj.core")
-    requires("net.bytebuddy")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -50,7 +50,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.random.RandomGenerator;
-import net.bytebuddy.utility.RandomString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
@@ -79,7 +79,6 @@ import java.util.List;
 import java.util.random.RandomGenerator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import net.bytebuddy.utility.RandomString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/RandomString.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/RandomString.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime;
+
+import java.util.Random;
+
+/**
+ * Random string generator.
+ */
+public class RandomString {
+    // A random seed to try and keep tests deterministic
+    private final Random random = new Random(9247525184L);
+    private final int length;
+
+    /**
+     * Create a new RandomString with a given `length`.
+     * @param length the length of strings to be generated
+     */
+    public RandomString(int length) {
+        this.length = length;
+    }
+
+    /**
+     * Generate a new random string.
+     * The current implementation uses ASCII characters space through ~.
+     * @return a random string of the configured `length`
+     */
+    public String nextString() {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append((char) (random.nextInt(127 - 32) + 32));
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
**Description**:
The bytebuddy fails to upgrade: https://github.com/hashgraph/pbj/pull/674
Also, we only ever use it in tests, and only ever use the `RandomString` class from it.
So I'm just adding a trivial implementation for this class in our code and removing the dependency.

**Related issue(s)**:

Fixes #676

**Notes for reviewer**:
All tests should pass as before.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
