### PR TITLE
build: upgrade grpc to 1.76.0

### DIFF
--- a/pbj-core/hiero-dependency-versions/build.gradle.kts
+++ b/pbj-core/hiero-dependency-versions/build.gradle.kts
@@ -2,7 +2,7 @@
 group = "com.hedera.hashgraph"
 
 val antlr = "4.13.2"
-val grpc = "1.71.0"
+val grpc = "1.76.0"
 val helidon = "4.2.7"
 val protobuf = "4.31.1"
 
@@ -46,7 +46,7 @@ dependencies.constraints {
     // Code generation tools
     api("org.antlr:antlr4:$antlr")
     api("com.google.protobuf:protoc:$protobuf")
-    api("io.grpc:protoc-gen-grpc-java:1.72.0")
+    api("io.grpc:protoc-gen-grpc-java:$grpc")
     tasks.checkVersionConsistency {
         excludes.add("org.antlr:antlr4")
         excludes.add("com.google.protobuf:protoc")


### PR DESCRIPTION
**Description**:
Dependabot fails to upgrade grpc version at https://github.com/hashgraph/pbj/pull/647

This is because we have a bug in how we define the version that leads to an inconsistency.

So I'm fixing the bug and upgrading to 1.76.0 manually in this PR.

**Related issue(s)**:

Fixes #678

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
