### PR TITLE
feat: add getters to generated builders

### DIFF
--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/BuilderGetterTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/BuilderGetterTest.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.test.proto.pbj.Everything;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class BuilderGetterTest {
+    @Test
+    void getterTest() {
+        Everything obj = Everything.DEFAULT;
+
+        assertTrue(obj.sfixed32NumberList().isEmpty());
+
+        final Everything.Builder builder = obj.copyBuilder();
+        assertTrue(builder.sfixed32NumberList().isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> builder.sfixed32NumberList()
+                .add(666));
+
+        builder.sfixed32NumberList(new ArrayList<>());
+        builder.sfixed32NumberList().add(666);
+        assertEquals(List.of(666), builder.sfixed32NumberList());
+
+        Everything obj2 = builder.build();
+        assertEquals(List.of(666), obj2.sfixed32NumberList());
+    }
+}


### PR DESCRIPTION
**Description**:
Adding getters to generated builds to help build complex objects.
NOTE: if a model has a field named `build`, then its getter in the Builder will have a method name of `_build()` to avoid a clash with the actual `Model Builder.build()` method.

**Related issue(s)**:

Fixes #668

**Notes for reviewer**:
A new integration test is added to verify the behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
