### PR TITLE
feat: make parsed lists read-only

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -1171,10 +1171,11 @@ public final class ModelGenerator implements Generator {
             // NOTE: for performance reasons, repeated fields are initialized with unmodifiable lists. Similarly,
             // Builder.repeatedField(Type... values) methods would wrap the values into unmodifiable lists.
             // If an application needs to dynamically modify repeated fields in builders, then it must first call
-            // the Builder.repeatedField(List<Type> list) method and supply a modifiable list, such as an ArrayList
-            // instance. After that, the application must only use the getter method to access the list.
-            // If the application wants to finalize the list after the building is finished, then it may call
-            // Builder.repeatedField(builder.repeatedField().toArray(new Type[0])) as one last final step.
+            // the Builder.repeatedField(List<Type> list) method and supply a modifiable list, such as
+            // an com.hedera.pbj.runtime.UnmodifiableArrayList instance.
+            // After that, the application must only use the getter method to access the list.
+            // To finalize the list once its building is finished, simply call
+            // ((UnmodifiableArrayList) builder.repeatedField()).makeReadOnly().
 
             $getterMethods}"""
                 .replace("$fields", fields.stream().map(field ->

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -88,6 +88,7 @@ class CodecParseMethodGenerator {
                         List<UnknownField> $unknownFields = null;
 
                         $parseLoop
+                $listFieldsWriteProtection
                         if ($unknownFields != null) {
                             Collections.sort($unknownFields);
                             $initialSizeOfUnknownFieldsArray = Math.max($initialSizeOfUnknownFieldsArray, $unknownFields.size());
@@ -109,6 +110,11 @@ class CodecParseMethodGenerator {
                 + (fields.isEmpty() ? "" : ", ") + "$unknownFields"
         )
         .replace("$parseLoop", generateParseLoop(generateCaseStatements(fields, schemaClassName), "", schemaClassName))
+        .replace("$listFieldsWriteProtection", fields.stream()
+                .filter(Field::repeated)
+                .map(field -> "if (temp_" + field.name() + " instanceof UnmodifiableArrayList ual) ual.makeReadOnly();")
+                .collect(Collectors.joining("\n"))
+                .indent(DEFAULT_INDENT * 2))
         .indent(DEFAULT_INDENT);
         // spotless:on
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -12,7 +12,6 @@ import java.nio.ByteOrder;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -47,7 +46,7 @@ public final class ProtoParserTools {
      */
     public static <T> List<T> addToList(List<T> list, T newItem) {
         if (list == Collections.EMPTY_LIST) {
-            list = new ArrayList<>();
+            list = new UnmodifiableArrayList<>();
         }
         list.add(newItem);
         return list;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/UnmodifiableArrayList.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/UnmodifiableArrayList.java
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.ListIterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * An extension of the `java.util.ArrayList` that can be write-protected by calling the `makeReadOnly()` method.
+ * This is designed to be equivalent to using `Collections.unmodifiableList()`, but it's more memory efficient
+ * because this class doesn't require an extra wrapper object.
+ * @param <E> the type of elements
+ */
+public class UnmodifiableArrayList<E> extends ArrayList<E> {
+    private boolean isReadOnly = false;
+
+    /**
+     * Mark this list as read-only.
+     * After this call, any mutating methods will throw the `UnsupportedOperationException`.
+     */
+    public void makeReadOnly() {
+        isReadOnly = true;
+    }
+
+    private void checkReadOnly() {
+        if (isReadOnly) {
+            // Note that technically, this should be an IllegalStateException.
+            // However, we throw UnsupportedOperationException for consistency with JDK unmodifiable collections.
+            throw new UnsupportedOperationException("This list is read-only");
+        }
+    }
+
+    @Override
+    public E set(int index, E element) {
+        checkReadOnly();
+        return super.set(index, element);
+    }
+
+    @Override
+    public boolean add(E o) {
+        checkReadOnly();
+        return super.add(o);
+    }
+
+    @Override
+    public void add(int index, E element) {
+        checkReadOnly();
+        super.add(index, element);
+    }
+
+    @Override
+    public void addFirst(E element) {
+        checkReadOnly();
+        super.addFirst(element);
+    }
+
+    @Override
+    public void addLast(E element) {
+        checkReadOnly();
+        super.addLast(element);
+    }
+
+    @Override
+    public E remove(int index) {
+        checkReadOnly();
+        return super.remove(index);
+    }
+
+    @Override
+    public E removeFirst() {
+        checkReadOnly();
+        return super.removeFirst();
+    }
+
+    @Override
+    public E removeLast() {
+        checkReadOnly();
+        return super.removeLast();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        checkReadOnly();
+        return super.remove(o);
+    }
+
+    @Override
+    public void clear() {
+        checkReadOnly();
+        super.clear();
+    }
+
+    @Override
+    public boolean addAll(Collection c) {
+        checkReadOnly();
+        return super.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection c) {
+        checkReadOnly();
+        return super.addAll(index, c);
+    }
+
+    @Override
+    protected void removeRange(int fromIndex, int toIndex) {
+        checkReadOnly();
+        super.removeRange(fromIndex, toIndex);
+    }
+
+    @Override
+    public boolean removeAll(Collection c) {
+        checkReadOnly();
+        return super.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection c) {
+        checkReadOnly();
+        return super.retainAll(c);
+    }
+
+    @Override
+    public boolean removeIf(Predicate filter) {
+        checkReadOnly();
+        return super.removeIf(filter);
+    }
+
+    @Override
+    public void replaceAll(UnaryOperator operator) {
+        checkReadOnly();
+        super.replaceAll(operator);
+    }
+
+    @Override
+    public void sort(Comparator c) {
+        checkReadOnly();
+        super.sort(c);
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        return listIterator(0);
+    }
+
+    @Override
+    public ListIterator<E> listIterator(final int index) {
+        return new ListIterator<>() {
+            private final ListIterator<E> i = UnmodifiableArrayList.super.listIterator(index);
+
+            public boolean hasNext() {
+                return i.hasNext();
+            }
+
+            public E next() {
+                return i.next();
+            }
+
+            public boolean hasPrevious() {
+                return i.hasPrevious();
+            }
+
+            public E previous() {
+                return i.previous();
+            }
+
+            public int nextIndex() {
+                return i.nextIndex();
+            }
+
+            public int previousIndex() {
+                return i.previousIndex();
+            }
+
+            public void remove() {
+                checkReadOnly();
+                i.remove();
+            }
+
+            public void set(E e) {
+                checkReadOnly();
+                i.set(e);
+            }
+
+            public void add(E e) {
+                checkReadOnly();
+                i.add(e);
+            }
+
+            @Override
+            public void forEachRemaining(Consumer<? super E> action) {
+                i.forEachRemaining(action);
+            }
+        };
+    }
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnmodifiableListsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnmodifiableListsTest.java
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.test.proto.pbj.Everything;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class UnmodifiableListsTest {
+    @Test
+    public void testUnmodifiableList() throws Exception {
+        // This list is unmodifiable, but can be modifiable technically if one were to supply an ArrayList instance
+        // here.
+        Everything obj =
+                Everything.newBuilder().sfixed32NumberList(List.of(666)).build();
+        final Bytes bytes = Everything.PROTOBUF.toBytes(obj);
+
+        // However, a list in a parsed object is guaranteed to be unmodifiable.
+        final Everything parsedObj = Everything.PROTOBUF.parse(bytes);
+        assertEquals(List.of(666), parsedObj.sfixed32NumberList());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> parsedObj.sfixed32NumberList().add(777));
+    }
+}


### PR DESCRIPTION
**Description**:
Currently, models parsed with PBJ `PROTOBUF` codec may contain modifiable lists for repeated fields that have elements. With this fix, such lists will be read-only.

**Related issue(s)**:

Fixes #681

**Notes for reviewer**:
A new integration test is added to verify the behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
