### PR TITLE
fix: allow reversed order of field numbers in oneof

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -879,7 +879,6 @@ public final class ModelGenerator implements Generator {
         final List<String> oneofGetters = new ArrayList<>();
         final var oneOfField = new OneOfField(item.oneof(), javaRecordName, lookupHelper);
         final var enumName = oneOfField.nameCamelFirstUpper() + "OneOfType";
-        final int maxIndex = oneOfField.fields().getLast().fieldNumber();
         final Map<Integer, EnumValue> enumValues = new HashMap<>();
         // spotless:off
         for (final var field : oneOfField.fields()) {
@@ -949,8 +948,8 @@ public final class ModelGenerator implements Generator {
                              */"""
                         .formatted(oneOfField.name());
         // spotless:on
-        final String enumString = createEnum(enumComment, "", enumName, maxIndex, enumValues, true)
-                .indent(DEFAULT_INDENT * 2);
+        final String enumString =
+                createEnum(enumComment, "", enumName, enumValues, true).indent(DEFAULT_INDENT * 2);
         oneofEnums.add(enumString);
         fields.add(oneOfField);
         imports.accept("com.hedera.pbj.runtime.*");

--- a/pbj-integration-tests/src/main/proto/oneof.proto
+++ b/pbj-integration-tests/src/main/proto/oneof.proto
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package proto;
+
+option java_package = "com.hedera.pbj.test.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.pbj.test.proto.pbj">>> This comment is special code for setting PBJ Compiler java package
+
+import "bytes.proto";
+
+/**
+ * Verifies if a reversed order of field numbers in a oneOf definition works.
+ * Note that below, the oneOf with number 30 precedes the oneOf with number 16.
+ */
+message OneOfWithReversedFieldNumberOrder {
+  oneof staked_id {
+    MessageWithBytes staked_account_id = 30;
+    int64 staked_node_id = 16;
+  }
+}


### PR DESCRIPTION
**Description**:
Fixing a bug in the `EnumGenerator` that prevented us from specifying `oneof` constants in an arbitrary order - the PBJ generated Java classes simply wouldn't compile if the order of fields is reversed.

**Related issue(s)**:

Fixes #81 

**Notes for reviewer**:
A new `oneof.proto` is added to pbj-integration-tests to verify the new behavior. W/o the fix, the model would generate an invalid code, and the integ tests build would fail.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
