### PR TITLE
feat: support clearing oneof fields in builders

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -1131,6 +1131,21 @@ public final class ModelGenerator implements Generator {
         for (final Field field : fields) {
             if (field.type() == Field.FieldType.ONE_OF) {
                 final OneOfField oneOfField = (OneOfField) field;
+                // spotless:off
+                builderMethods.add("""
+                        /**
+                         * Clear $fieldToSet oneof by setting it to UNSET.
+                         */
+                        public void clear$fieldName() {
+                            this.$fieldToSet = $fieldValue;
+                        }
+                        """
+                        .replace("$fieldName", oneOfField.nameCamelFirstUpper())
+                        .replace("$fieldToSet", oneOfField.nameCamelFirstLower())
+                        .replace("$fieldValue", getDefaultValue(oneOfField, msgDef, lookupHelper))
+                        .indent(DEFAULT_INDENT)
+                );
+                // spotless:on
                 for (final Field subField : oneOfField.fields()) {
                     generateBuilderMethods(builderMethods, msgDef, subField, lookupHelper);
                 }


### PR DESCRIPTION
**Description**:
Add a `Builder.clearField()` method to allow resetting `oneof` fields to `UNSET` which is useful in `copyBuilder()`'s.

**Related issue(s)**:

Fixes #160 

**Notes for reviewer**:
All tests should pass. Upon a manual inspection of the generated code, I can see proper `clear` methods added to builders, e.g. in the `AccountID.Builder`:
```java
        /**
         * Clear account oneof by setting it to UNSET.
         */
        public void clearAccount() {
            this.account = com.hedera.hapi.node.base.codec.AccountIDProtoCodec.ACCOUNT_UNSET;
        }
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
