### PR TITLE
fix: don't compare strings with != in JSON codec

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
@@ -101,6 +101,13 @@ final class JsonCodecWriteMethodGenerator {
                 return prefix + "if (data." + field.nameCamelFirstLower() + "() != " + field.javaDefault()
                         + " && !data." + field.nameCamelFirstLower() + "().isEmpty()) fieldLines.add(" + basicFieldCode
                         + ");";
+            } else if (field.optionalValueType() && "StringValue".equals(field.messageType())) {
+                return prefix + "if (data." + field.nameCamelFirstLower() + "() != null) fieldLines.add("
+                        + basicFieldCode + ");";
+            } else if (field.type() == Field.FieldType.STRING) {
+                return prefix + "if (data." + field.nameCamelFirstLower() + "() != null"
+                        + " && !data." + field.nameCamelFirstLower() + "().isEmpty()) fieldLines.add(" + basicFieldCode
+                        + ");";
             } else {
                 return prefix + "if (data." + field.nameCamelFirstLower() + "() != " + field.javaDefault()
                         + ") fieldLines.add(" + basicFieldCode + ");";
@@ -121,23 +128,25 @@ final class JsonCodecWriteMethodGenerator {
                         "DoubleValue",
                         "BytesValue" -> "field(%s, %s)".formatted(fieldName, getValueCode);
                 case "Int64Value", "UInt64Value" -> "field(%s, %s, true)".formatted(fieldName, getValueCode);
-                default -> throw new UnsupportedOperationException(
-                        "Unhandled optional message type:" + field.messageType());
+                default ->
+                    throw new UnsupportedOperationException("Unhandled optional message type:" + field.messageType());
             };
         } else if (field.repeated()) {
             return switch (field.type()) {
-                case MESSAGE -> "arrayField(childIndent, $fieldName, $codec, $valueCode)"
-                        .replace("$fieldName", fieldName)
-                        .replace("$fieldDef", fieldDef)
-                        .replace("$valueCode", getValueCode)
-                        .replace(
-                                "$codec",
-                                ((SingleField) field).messageTypeModelPackage() + "."
-                                        + ((SingleField) field).completeClassName() + ".JSON");
-                default -> "arrayField($fieldName, $fieldDef, $valueCode)"
-                        .replace("$fieldName", fieldName)
-                        .replace("$fieldDef", fieldDef)
-                        .replace("$valueCode", getValueCode);
+                case MESSAGE ->
+                    "arrayField(childIndent, $fieldName, $codec, $valueCode)"
+                            .replace("$fieldName", fieldName)
+                            .replace("$fieldDef", fieldDef)
+                            .replace("$valueCode", getValueCode)
+                            .replace(
+                                    "$codec",
+                                    ((SingleField) field).messageTypeModelPackage() + "."
+                                            + ((SingleField) field).completeClassName() + ".JSON");
+                default ->
+                    "arrayField($fieldName, $fieldDef, $valueCode)"
+                            .replace("$fieldName", fieldName)
+                            .replace("$fieldDef", fieldDef)
+                            .replace("$valueCode", getValueCode);
             };
         } else if (field.type() == Field.FieldType.MAP) {
             final MapField mapField = (MapField) field;
@@ -156,19 +165,21 @@ final class JsonCodecWriteMethodGenerator {
                     .replace("$vComposer", "(n, v) -> " + vComposerMethod);
         } else {
             return switch (field.type()) {
-                case ENUM -> "field($fieldName, $valueCode.protoName())"
-                        .replace("$fieldName", fieldName)
-                        .replace("$fieldDef", fieldDef)
-                        .replace("$valueCode", getValueCode);
-                case MESSAGE -> "field($childIndent, $fieldName, $codec, $valueCode)"
-                        .replace("$childIndent", childIndent)
-                        .replace("$fieldName", fieldName)
-                        .replace("$fieldDef", fieldDef)
-                        .replace("$valueCode", getValueCode)
-                        .replace(
-                                "$codec",
-                                ((SingleField) field).messageTypeModelPackage() + "."
-                                        + ((SingleField) field).completeClassName() + ".JSON");
+                case ENUM ->
+                    "field($fieldName, $valueCode.protoName())"
+                            .replace("$fieldName", fieldName)
+                            .replace("$fieldDef", fieldDef)
+                            .replace("$valueCode", getValueCode);
+                case MESSAGE ->
+                    "field($childIndent, $fieldName, $codec, $valueCode)"
+                            .replace("$childIndent", childIndent)
+                            .replace("$fieldName", fieldName)
+                            .replace("$fieldDef", fieldDef)
+                            .replace("$valueCode", getValueCode)
+                            .replace(
+                                    "$codec",
+                                    ((SingleField) field).messageTypeModelPackage() + "."
+                                            + ((SingleField) field).completeClassName() + ".JSON");
                 default -> "field(%s, %s)".formatted(fieldName, getValueCode);
             };
         }


### PR DESCRIPTION
**Description**:
Implementing correct string handling in JSON codec `toJSON()` method to avoid using `!=` for string comparison.

**Related issue(s)**:

Fixes #307 

**Notes for reviewer**:
I manually inspected the generated JSON codecs for `MessageWithString` and `Everything`, and they look fine now.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
