### PR TITLE
feat: readBytes to return Bytes.EMPTY for zero length

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedData.java
@@ -159,6 +159,7 @@ final class DirectBufferedData extends BufferedData {
     @Override
     public Bytes readBytes(final int len) {
         validateLen(len);
+        if (len == 0) return Bytes.EMPTY;
         final int pos = buffer.position();
         validateCanRead(pos, len);
         final byte[] res = new byte[len];

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
@@ -4,6 +4,7 @@ package com.hedera.pbj.runtime.io.buffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.ReadableSequentialTestBase;
@@ -291,6 +292,15 @@ abstract class BufferedDataTestBase {
         bytes[3] = 127;
         bytes[4] = 127;
         assertArrayEquals(bytesOrig, readBytes.toByteArray());
+    }
+
+    @Test
+    void readBytesReturnsConstantEmptyForZeroLength() {
+        byte[] bytes = new byte[] {1, 2, 3, 4, 5};
+        final var buf = wrap(bytes);
+        final Bytes readBytes = buf.readBytes(0);
+        // NOTE: assertSame and not assertEquals, by design:
+        assertSame(Bytes.EMPTY, readBytes);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
`DirectBufferedData.readBytes()` should return `Bytes.EMPTY` instead of creating new zero-length `Bytes` objects when the length is zero.

**Related issue(s)**:

Fixes #291 

**Notes for reviewer**:
A new unit test is added to verify the behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
