### PR TITLE
feat: support reserved enum values

### DIFF
--- a/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
+++ b/pbj-core/pbj-compiler/src/main/antlr/com/hedera/hashgraph/protoparser/grammar/Protobuf3.g4
@@ -170,6 +170,7 @@ enumElement
   : optionStatement
   | optionComment
   | enumField
+  | reserved
   | emptyStatement_
   ;
 
@@ -205,6 +206,7 @@ messageElement
   | mapField
   | reserved
   | emptyStatement_
+  | DOC_COMMENT
   ;
 
 // service

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
@@ -84,6 +84,8 @@ public final class EnumGenerator {
                     System.err.printf(
                             "Unhandled Option: %s%n", item.optionStatement().getText());
                 }
+            } else if (item.reserved() != null) {
+                // Ignore reserved enum values
             } else {
                 System.err.printf("EnumGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
             }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -97,7 +97,10 @@ public final class ModelGenerator implements Generator {
 
         // Iterate over all the items in the protobuf schema
         for (final var item : msgDef.messageBody().messageElement()) {
-            if (item.messageDef() != null) { // process sub messages down below in generateClass()
+            if (item.messageDef() != null
+                    || item.enumDef() != null
+                    || item.DOC_COMMENT()
+                            != null) { // process sub messages and inner enums down below in generateClass()
             } else if (item.oneof() != null) { // process one ofs
                 oneofGetters.addAll(generateCodeForOneOf(
                         lookupHelper, item, javaRecordName, writer::addImport, oneofEnums, fields));

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/SchemaGenerator.java
@@ -32,7 +32,9 @@ public final class SchemaGenerator implements Generator {
         final String schemaClassName = lookupHelper.getUnqualifiedClassForMessage(FileType.SCHEMA, msgDef);
         final List<Field> fields = new ArrayList<>();
         for (final var item : msgDef.messageBody().messageElement()) {
-            if (item.messageDef() != null) { // process sub messages down below
+            if (item.messageDef() != null
+                    || item.enumDef() != null
+                    || item.DOC_COMMENT() != null) { // process sub messages down below
             } else if (item.oneof() != null) { // process one ofs
                 final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
                 fields.add(field);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -475,6 +475,8 @@ public final class ServiceGenerator {
                     System.err.printf(
                             "Unhandled Option: %s%n", item.optionStatement().getText());
                 }
+            } else if (item.optionComment() != null || item.emptyStatement_() != null) {
+                // Ignore these
             } else {
                 System.err.printf("ServiceGenerator Warning - Unknown element: %s -- %s%n", item, item.getText());
             }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -45,7 +45,9 @@ public final class TestGenerator implements Generator {
         writer.addImport(lookupHelper.getPackage(FileType.MODEL, msgDef) + ".*");
 
         for (final var item : msgDef.messageBody().messageElement()) {
-            if (item.messageDef() != null) { // process sub messages down below
+            if (item.messageDef() != null
+                    || item.enumDef() != null
+                    || item.DOC_COMMENT() != null) { // process sub messages down below
             } else if (item.oneof() != null) { // process one ofs
                 final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
                 fields.add(field);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -36,7 +36,9 @@ public final class JsonCodecGenerator implements Generator {
         writer.addImport(lookupHelper.getPackage(FileType.SCHEMA, msgDef) + ".*");
 
         for (var item : msgDef.messageBody().messageElement()) {
-            if (item.messageDef() != null) { // process sub messages down below
+            if (item.messageDef() != null
+                    || item.enumDef() != null
+                    || item.DOC_COMMENT() != null) { // process sub messages down below
             } else if (item.oneof() != null) { // process one ofs
                 final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
                 fields.add(field);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -40,7 +40,9 @@ public final class CodecGenerator implements Generator {
         writer.addImport(lookupHelper.getPackage(FileType.SCHEMA, msgDef) + ".*");
 
         for (var item : msgDef.messageBody().messageElement()) {
-            if (item.messageDef() != null) { // process sub messages down below
+            if (item.messageDef() != null
+                    || item.enumDef() != null
+                    || item.DOC_COMMENT() != null) { // process sub messages down below
             } else if (item.oneof() != null) { // process one ofs
                 final var field = new OneOfField(item.oneof(), modelClassName, lookupHelper);
                 fields.add(field);

--- a/pbj-integration-tests/src/main/proto/enum_reserved.proto
+++ b/pbj-integration-tests/src/main/proto/enum_reserved.proto
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+package pbj.integ.test.enumeration.reserved;
+option java_multiple_files = true;
+
+enum PbjEnumReserved {
+  reserved 6;
+
+  READ_STREAM_UNKNOWN_TEST = 0;
+  READ_STREAM_INSUFFICIENT_BALANCE_TEST = 1;
+  READ_STREAM_SUCCESS_TEST = 2;
+  READ_STREAM_INVALID_START_BLOCK_NUMBER_TEST = 3;
+  READ_STREAM_INVALID_END_BLOCK_NUMBER_TEST = 4;
+  READ_STREAM_NOT_AVAILABLE_TEST = 5;
+}
+
+message MessageWithReservedEnum {
+  PbjEnumReserved the_enum_with_reserved_values = 1;
+}


### PR DESCRIPTION
**Description**:
Introducing rudimentary support for reserved enum values. The grammar is able to parse them instead of treating them as regular enum values, and the code generator simply ignores them because PBJ doesn't support unknown enum values currently.

A new `enum_reserved.proto` is added to integration tests. W/o the fix, the model would produce a generated test that would fail because the output of the JSON codec would differ from what ProtoC generates.

Also, I'm fixing a bunch of useless warning messages that PBJ used to produce for dangling comments and similar items.

**Related issue(s)**:

Fixes #339 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
