### PR TITLE
feat: support unrecognized enum values

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -286,7 +286,7 @@ public final class Common {
                     generatedCodeSoFar +=
                             ("""
                             if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
-                               result = 31 * result + Integer.hashCode($fieldName.protoOrdinal());
+                               result = 31 * result + Integer.hashCode(EnumWithProtoMetadata.protoOrdinal($fieldName));
                             }
                             """)
                                     .replace("$fieldName", f.nameCamelFirstLower());
@@ -320,55 +320,62 @@ public final class Common {
     @NonNull
     private static String getPrimitiveWrapperHashCodeGeneration(String generatedCodeSoFar, Field f) {
         switch (f.messageType()) {
-            case "StringValue" -> generatedCodeSoFar +=
-                    ("""
+            case "StringValue" ->
+                generatedCodeSoFar +=
+                        ("""
                     if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                         result = 31 * result + $fieldName.hashCode();
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
-            case "BoolValue" -> generatedCodeSoFar +=
-                    ("""
+                                .replace("$fieldName", f.nameCamelFirstLower());
+            case "BoolValue" ->
+                generatedCodeSoFar +=
+                        ("""
                     if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                         result = 31 * result + Boolean.hashCode($fieldName);
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
-            case "Int32Value", "UInt32Value" -> generatedCodeSoFar +=
-                    ("""
+                                .replace("$fieldName", f.nameCamelFirstLower());
+            case "Int32Value", "UInt32Value" ->
+                generatedCodeSoFar +=
+                        ("""
                     if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                         result = 31 * result + Integer.hashCode($fieldName);
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
-            case "Int64Value", "UInt64Value" -> generatedCodeSoFar +=
-                    ("""
+                                .replace("$fieldName", f.nameCamelFirstLower());
+            case "Int64Value", "UInt64Value" ->
+                generatedCodeSoFar +=
+                        ("""
                     if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                         result = 31 * result + Long.hashCode($fieldName);
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
-            case "FloatValue" -> generatedCodeSoFar +=
-                    ("""
+                                .replace("$fieldName", f.nameCamelFirstLower());
+            case "FloatValue" ->
+                generatedCodeSoFar +=
+                        ("""
                     if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                         result = 31 * result + Float.hashCode($fieldName);
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
-            case "DoubleValue" -> generatedCodeSoFar +=
-                    ("""
+                                .replace("$fieldName", f.nameCamelFirstLower());
+            case "DoubleValue" ->
+                generatedCodeSoFar +=
+                        ("""
                     if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                         result = 31 * result + Double.hashCode($fieldName);
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
-            case "BytesValue" -> generatedCodeSoFar +=
-                    ("""
+                                .replace("$fieldName", f.nameCamelFirstLower());
+            case "BytesValue" ->
+                generatedCodeSoFar +=
+                        ("""
                     if ($fieldName != null && !$fieldName.equals(DEFAULT.$fieldName)) {
                         result = 31 * result + ($fieldName == null ? 0 : $fieldName.hashCode());
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
+                                .replace("$fieldName", f.nameCamelFirstLower());
             default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
         }
         return generatedCodeSoFar;
@@ -543,8 +550,9 @@ public final class Common {
                     "UInt64Value",
                     "FloatValue",
                     "DoubleValue",
-                    "BytesValue" -> generatedCodeSoFar +=
-                    ("""
+                    "BytesValue" ->
+                generatedCodeSoFar +=
+                        ("""
                     if (this.$fieldName == null && thatObj.$fieldName != null) {
                         return false;
                     }
@@ -552,7 +560,7 @@ public final class Common {
                         return false;
                     }
                     """)
-                            .replace("$fieldName", f.nameCamelFirstLower());
+                                .replace("$fieldName", f.nameCamelFirstLower());
             default -> throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
         }
         return generatedCodeSoFar;
@@ -693,12 +701,17 @@ public final class Common {
                    return 1;
                }
                if ($fieldName != null) {
-                   result = $fieldName.compareTo(thatObj.$fieldName);
+                   result = $doCompare;
                }
                if (result != 0) {
                    return result;
                }
                """
+                .replace(
+                        "$doCompare",
+                        f.type() == Field.FieldType.ENUM
+                                ? f.javaFieldType() + ".compare($fieldName, thatObj.$fieldName)"
+                                : "$fieldName.compareTo(thatObj.$fieldName)")
                 .replace("$fieldName", f.nameCamelFirstLower());
     }
 
@@ -760,8 +773,8 @@ public final class Common {
                     case "UInt64Value" -> "java.lang.Long.compareUnsigned($fieldName, thatObj.$fieldName)";
                     case "FloatValue" -> "java.lang.Float.compare($fieldName, thatObj.$fieldName)";
                     case "DoubleValue" -> "java.lang.Double.compare($fieldName, thatObj.$fieldName)";
-                    default -> throw new UnsupportedOperationException(
-                            "Unhandled optional message type:" + f.messageType());
+                    default ->
+                        throw new UnsupportedOperationException("Unhandled optional message type:" + f.messageType());
                 };
 
         return template.replace("$compareStatement", compareStatement).replace("$fieldName", f.nameCamelFirstLower());

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -285,7 +285,10 @@ public final class TestGenerator implements Generator {
             case BOOL -> "BOOLEAN_TESTS_LIST";
             case STRING -> "STRING_TESTS_LIST";
             case BYTES -> "BYTES_TESTS_LIST";
-            case ENUM -> "Arrays.asList(%s.values())".formatted(javaFieldType);
+            // Skip the special UNRECOGNIZED constant in tests because it cannot(shouldn't) be set by client code
+            case ENUM ->
+                "Arrays.asList(%s.values()).stream().filter(e -> !\"UNRECOGNIZED\".equals(e.name())).toList()"
+                        .formatted(javaFieldType);
             case ONE_OF ->
                 throw new RuntimeException("Should never happen, should have been caught in generateTestData()");
             case MESSAGE -> "%s%s.ARGUMENTS".formatted(javaFieldType, FileAndPackageNamesConfig.TEST_JAVA_FILE_SUFFIX);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/EnumWithProtoMetadata.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/EnumWithProtoMetadata.java
@@ -18,4 +18,22 @@ public interface EnumWithProtoMetadata {
      * @return The original field name in protobuf for this type
      */
     String protoName();
+
+    /**
+     * Returns a protoOrdinal for an EnumWithProtoMetadata, or the value itself for an Integer,
+     * or throws IllegalArgumentException otherwise.
+     * @param obj either an EnumWithProtoMetadata or an Integer
+     * @return a protoOrdinal of the given "enum value"
+     * @throws IllegalArgumentException if the given object is not EnumWithProtoMetadata or Integer
+     */
+    static int protoOrdinal(final Object obj) {
+        if (obj instanceof EnumWithProtoMetadata pbjEnum) {
+            return pbjEnum.protoOrdinal();
+        } else if (obj instanceof Integer intObj) {
+            return intObj;
+        } else {
+            throw new IllegalArgumentException("EnumWithProtoMetadata or Integer are supported only, got "
+                    + obj.getClass().getName());
+        }
+    }
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoWriterToolsTest.java
@@ -1358,7 +1358,7 @@ class ProtoWriterToolsTest {
         T read(BufferedData bd, long pos);
     }
 
-    private static final List<EnumWithProtoMetadata> testEnumList = List.of(mockEnum(0), mockEnum(2), mockEnum(1));
+    private static final List<Integer> testEnumList = List.of(0, 2, 1);
 
     // https://clement-jean.github.io/packed_vs_unpacked_repeated_fields/
     private static Stream<Arguments> provideWritePackedListArguments() {
@@ -1383,18 +1383,18 @@ class ProtoWriterToolsTest {
                         (ReaderMethod<Boolean>) (BufferedData bd, long pos) -> (bd.getInt(pos) != 0 ? true : false)),
                 Arguments.of(
                         ENUM,
-                        (WriterMethod<? extends EnumWithProtoMetadata>) ProtoWriterTools::writeEnumList,
+                        (WriterMethod<Integer>) ProtoWriterTools::writeEnumListProtoOrdinals,
                         testEnumList,
                         3,
-                        (ReaderMethod<? extends EnumWithProtoMetadata>) (BufferedData bd, long pos) -> {
+                        (ReaderMethod<Integer>) (BufferedData bd, long pos) -> {
                             final int ordinal = bd.getVarInt(pos, false);
-                            for (EnumWithProtoMetadata e : testEnumList) {
-                                if (e.protoOrdinal() == ordinal) return e;
+                            for (Integer e : testEnumList) {
+                                if (e == ordinal) return e;
                             }
                             throw new RuntimeException("Unexpected ordinal " + ordinal
                                     + " for test enum list "
                                     + testEnumList.stream()
-                                            .map(e -> "" + e.protoOrdinal() + ": " + e.protoName())
+                                            .map(e -> "" + e)
                                             .collect(Collectors.joining(",", "{", "}")));
                         }));
     }

--- a/pbj-integration-tests/src/main/proto/enum_unrecognized.proto
+++ b/pbj-integration-tests/src/main/proto/enum_unrecognized.proto
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+package pbj.integ.test.enumeration.reserved;
+option java_multiple_files = true;
+
+// Note: constant names don't really matter. Only ordinals matter for enums:
+enum PbjEnumUnrecognized1 {
+  A1 = 0;
+  B1 = 1;
+  C1 = 2;
+}
+enum PbjEnumUnrecognized2 {
+  A2 = 0;
+  B2 = 1;
+  C2 = 2;
+  D2 = 3; // This constant is unknown to the PbjEnumUnrecognized1 above
+}
+
+// The two messages below should be "binary-compatible" on the wire, so that we can serialize/deserialize both
+// to/from the same bytes:
+message MessageWithUnrecognizedEnum1 {
+  PbjEnumUnrecognized1 enum_value = 1;
+  repeated PbjEnumUnrecognized1 enum_list = 2;
+}
+message MessageWithUnrecognizedEnum2 {
+  PbjEnumUnrecognized2 enum_value = 1;
+  repeated PbjEnumUnrecognized2 enum_list = 2;
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/CompareToTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/CompareToTest.java
@@ -273,7 +273,9 @@ class CompareToTest {
     }
 
     private static ComparableEnum nextEnum() {
-        return ComparableEnum.fromProtobufOrdinal(RandomGenerator.getDefault().nextInt(ComparableEnum.values().length));
+        // -1 to omit the last UNRECOGNIZED enum value because it cannot(shouldn't) be set by client code:
+        return ComparableEnum.fromProtobufOrdinal(
+                RandomGenerator.getDefault().nextInt(ComparableEnum.values().length - 1));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnrecognizedEnumTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnrecognizedEnumTest.java
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import pbj.integ.test.enumeration.reserved.pbj.integration.tests.MessageWithUnrecognizedEnum1;
+import pbj.integ.test.enumeration.reserved.pbj.integration.tests.MessageWithUnrecognizedEnum2;
+import pbj.integ.test.enumeration.reserved.pbj.integration.tests.PbjEnumUnrecognized1;
+import pbj.integ.test.enumeration.reserved.pbj.integration.tests.PbjEnumUnrecognized2;
+
+public class UnrecognizedEnumTest {
+    @Test
+    public void unrecognizedEnumTest() throws Exception {
+        final MessageWithUnrecognizedEnum2 m2 = MessageWithUnrecognizedEnum2.newBuilder()
+                .enumValue(PbjEnumUnrecognized2.D2)
+                .build();
+        final Bytes bytes2 = MessageWithUnrecognizedEnum2.PROTOBUF.toBytes(m2);
+
+        final MessageWithUnrecognizedEnum1 m1 = MessageWithUnrecognizedEnum1.PROTOBUF.parse(bytes2);
+
+        assertEquals(PbjEnumUnrecognized1.UNRECOGNIZED, m1.enumValue());
+        assertEquals(3, m1.enumValueProtoOrdinal());
+
+        // Now try serializing it
+        final Bytes bytes1 = MessageWithUnrecognizedEnum1.PROTOBUF.toBytes(m1);
+        // and the deserializing back into MessageWithUnrecognizedEnum2
+        final MessageWithUnrecognizedEnum2 m22 = MessageWithUnrecognizedEnum2.PROTOBUF.parse(bytes1);
+
+        assertEquals(PbjEnumUnrecognized2.D2, m22.enumValue());
+    }
+
+    @Test
+    public void unrecognizedEnumListTest() throws Exception {
+        final MessageWithUnrecognizedEnum2 m2 = MessageWithUnrecognizedEnum2.newBuilder()
+                .enumList(PbjEnumUnrecognized2.A2, PbjEnumUnrecognized2.D2, PbjEnumUnrecognized2.B2)
+                .build();
+        final Bytes bytes2 = MessageWithUnrecognizedEnum2.PROTOBUF.toBytes(m2);
+
+        final MessageWithUnrecognizedEnum1 m1 = MessageWithUnrecognizedEnum1.PROTOBUF.parse(bytes2);
+
+        assertEquals(
+                List.of(PbjEnumUnrecognized1.A1, PbjEnumUnrecognized1.UNRECOGNIZED, PbjEnumUnrecognized1.B1),
+                m1.enumList());
+        assertEquals(List.of(0, 3, 1), m1.enumListProtoOrdinals());
+
+        // Now try serializing it
+        final Bytes bytes1 = MessageWithUnrecognizedEnum1.PROTOBUF.toBytes(m1);
+        // and the deserializing back into MessageWithUnrecognizedEnum2
+        final MessageWithUnrecognizedEnum2 m22 = MessageWithUnrecognizedEnum2.PROTOBUF.parse(bytes1);
+
+        assertEquals(
+                List.of(PbjEnumUnrecognized2.A2, PbjEnumUnrecognized2.D2, PbjEnumUnrecognized2.B2), m22.enumList());
+    }
+}


### PR DESCRIPTION
**Description**:
Introducing support for unrecognized enum values.
* Generated non-oneOf enums have a new `UNRECOGNIZED(-1)` enum constant added
* Model's `enumField()` returns `UNRECOGNIZED` for unknown proto ordinals
* A new model's `int enumFieldProtoOrdinal()` returns the protoOrdinal as parsed from input
* Enum lists have `List<Integer> enumListFieldProtoOrdinals()` similar to the above
* Serializing/deserializing preserves unrecognized enum values, which is verified with a new integration test.
* New constructors are added to models and builders to support the new feature (with Object/List<?>).

The implementation avoids increasing the memory footprint of generated protobuf models by replacing the real enum type with `Object`/`List<?>` for the private fields that store these values. In other words, with this fix, Java models still maintain just a single reference field for each protobuf enum field - same as before. The Object can be either an actual enum constant or an `Integer` representing its unrecognized protoOrdinal value.

Getters for repeated enum fields (both simple and `...ProtoOrdinals()`) are penalized slightly because they have to construct new lists each time. As a future work, we could consider caching the results in runtime similar to how we do with the hashCode/length. However, this would increase the memory foot print for such models. For this reason, I haven't implemented this just yet. Note that non-repeated enum fields are unaffected by this at all and should work as fast as they do today.

**Related issue(s)**:

Fixes #476 

**Notes for reviewer**:
A new integration test is added to verify the behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
