### PR TITLE
fix: forward maxSize when parsing nested messages

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -216,7 +216,8 @@ public record SingleField(
     @Override
     public String parseCode() {
         if (type == FieldType.MESSAGE) {
-            return "%s.PROTOBUF.parse(input, strictMode, parseUnknownFields, maxDepth - 1)".formatted(messageType);
+            return "%s.PROTOBUF.parse(input, strictMode, parseUnknownFields, maxDepth - 1, maxSize)"
+                    .formatted(messageType);
         } else {
             return "input";
         }


### PR DESCRIPTION
**Description**:
Forwarding a custom `maxSize` value to `parse()` calls for nested messages, so that the custom value is respected when parsing them.

**Related issue(s)**:

Fixes #699

**Notes for reviewer**:
A new integration test is added to verify the behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
