### PR TITLE
fix: use @Feature annotation instead of @Features

### DIFF
--- a/pbj-core/pbj-grpc-helidon-config/src/main/java/module-info.java
+++ b/pbj-core/pbj-grpc-helidon-config/src/main/java/module-info.java
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-import io.helidon.common.features.api.Features;
+import io.helidon.common.features.api.Feature;
 import io.helidon.common.features.api.HelidonFlavor;
+import io.helidon.common.features.api.Preview;
 
-@Features.Preview
-@Features.Name("PBJConfig")
-@Features.Description("WebServer gRPC-PBJ Config")
-@Features.Flavor(HelidonFlavor.SE)
-@Features.Path({"WebServer", "PBJ"})
+@Preview
+@Feature(
+        value = "PBJConfig",
+        description = "WebServer gRPC-PBJ Config",
+        in = HelidonFlavor.SE,
+        path = {"WebServer", "PBJ"})
 module com.hedera.pbj.grpc.helidon.config {
     requires transitive io.helidon.builder.api;
     requires transitive io.helidon.common.config; // indirectly used on API of generated 'PbjConfig'


### PR DESCRIPTION
**Description**:

Fix `IllegalStateException` on Block Node startup caused by invalid Helidon feature metadata.

The `pbj-grpc-helidon-config` module uses `@Features.*` annotations which don't generate the required `m` (module name) field in `feature-metadata.properties`. This causes Helidon 4.3.2 to throw an exception during feature scanning.

* Replace `@Features.Preview` with `@Preview` annotation
* Replace `@Features.Name`, `@Features.Description`, `@Features.Flavor`, `@Features.Path` with consolidated `@Feature` annotation (which is old, but works)
* Match annotation pattern already used in `pbj-grpc-helidon` module

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-block-node/issues/1964

**Notes for reviewer**:

Before fix - `feature-metadata.properties` was missing `m` field:
```
n=PBJConfig
d=WebServer gRPC-PBJ Config
```

After fix - `feature-metadata.properties` contains all required fields:
```
m=com.hedera.pbj.grpc.helidon.config
n=PBJConfig
d=WebServer gRPC-PBJ Config
in=SE
p=WebServer,PBJpr=true
```

Checklist
- [ ] Documented (Code comments, README, etc.) - probably don't need
- [x] Tested (unit, integration, etc.)

<img width="1006" height="722" alt="Снимок экрана 2025-12-13 в 18 25 55" src="https://github.com/user-attachments/assets/ae8809ee-e880-4eb5-9ca0-ce091182a48b" />