### PR TITLE
fix: switch to helidon-common-features-codegen for @Features metadata

### DIFF
--- a/pbj-core/gradle/modules.properties
+++ b/pbj-core/gradle/modules.properties
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Module to Maven artifact mappings for JPMS
+io.helidon.common.features.codegen=io.helidon.common.features:helidon-common-features-codegen

--- a/pbj-core/hiero-dependency-versions/build.gradle.kts
+++ b/pbj-core/hiero-dependency-versions/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies.constraints {
     api("io.helidon.common.features:helidon-common-features-processor:$helidon") {
         because("io.helidon.common.features.processor")
     }
+    api("io.helidon.common.features:helidon-common-features-codegen:$helidon") {
+        because("io.helidon.common.features.codegen")
+    }
     api("io.helidon.config.metadata:helidon-config-metadata-codegen:$helidon") {
         because("io.helidon.config.metadata.codegen")
     }

--- a/pbj-core/pbj-grpc-helidon-config/build.gradle.kts
+++ b/pbj-core/pbj-grpc-helidon-config/build.gradle.kts
@@ -7,7 +7,7 @@ description = "Configuration for a Helidon gRPC plugin for PBJ"
 tasks.compileJava { options.compilerArgs.remove("-Werror") }
 
 mainModuleInfo {
-    annotationProcessor("io.helidon.common.features.processor")
+    annotationProcessor("io.helidon.common.features.codegen")
     annotationProcessor("io.helidon.config.metadata.processor")
     annotationProcessor("io.helidon.codegen.apt")
     annotationProcessor("io.helidon.builder.codegen")

--- a/pbj-core/pbj-grpc-helidon-config/src/main/java/module-info.java
+++ b/pbj-core/pbj-grpc-helidon-config/src/main/java/module-info.java
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.Features;
 import io.helidon.common.features.api.HelidonFlavor;
-import io.helidon.common.features.api.Preview;
 
-@Preview
-@Feature(
-        value = "PBJConfig",
-        description = "WebServer gRPC-PBJ Config",
-        in = HelidonFlavor.SE,
-        path = {"WebServer", "PBJ"})
+@Features.Preview
+@Features.Name("PBJConfig")
+@Features.Description("WebServer gRPC-PBJ Config")
+@Features.Flavor(HelidonFlavor.SE)
+@Features.Path({"WebServer", "PBJ"})
 module com.hedera.pbj.grpc.helidon.config {
     requires transitive io.helidon.builder.api;
     requires transitive io.helidon.common.config; // indirectly used on API of generated 'PbjConfig'
@@ -16,7 +14,6 @@ module com.hedera.pbj.grpc.helidon.config {
     requires transitive io.helidon.config;
     requires io.helidon.webserver;
     requires static io.helidon.common.features.api;
-    requires static io.helidon.common.features.processor;
     requires static io.helidon.config.metadata.codegen;
 
     exports com.hedera.pbj.grpc.helidon.config;


### PR DESCRIPTION
**Description**:
Use the new helidon-common-features-codegen annotation processor with @Features.* annotations as recommended by Helidon developers.

This generates feature-registry.json (new format) instead of feature-metadata.properties, which is the recommended approach for Helidon 4.x and will be required in Helidon 5.x.

Changes:
* Use @Features.* annotations instead of deprecated @Feature
* Replace helidon-common-features-processor with codegen
* Add helidon-common-features-codegen dependency
* Add module mapping in gradle/modules.properties

Ref: https://github.com/helidon-io/helidon/issues/10936
Fixes: https://github.com/hiero-ledger/hiero-block-node/issues/1964


<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:  https://github.com/hiero-ledger/hiero-block-node/issues/1964 


**Notes for reviewer**:
Used the original approach which is about Helidon developer advice.

**Checklist**
Verified the build and verified https://github.com/hiero-ledger/hiero-block-node/issues/1964 
<img width="987" height="726" alt="Снимок экрана 2025-12-20 в 23 57 30" src="https://github.com/user-attachments/assets/2b711461-71b4-46ab-9cdd-d225c19f5a5c" />



- [ ] Documented (Code comments, README, etc.) - probably this step is not required for these changes
- [x] Tested (unit, integration, etc.)
