### PR TITLE
perf: check hashCode in Bytes.equals()

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -560,6 +560,10 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     public boolean equals(@Nullable final Object o) {
         if (this == o) return true;
         if (!(o instanceof Bytes that)) return false;
+        // Don't force the hashCode computation, but if both are present, then we can short-circuit the logic:
+        if (hashCode != 0 && that.hashCode != 0 && hashCode != that.hashCode) {
+            return false;
+        }
         return Arrays.equals(buffer, start, start + length, that.buffer, that.start, that.start + that.length);
     }
 


### PR DESCRIPTION
**Description**:
Add a hashCode equality check to the `Bytes.equals()` to short-circuit the logic and avoid calling `Arrays.equals()` if they differ. Note that this only works if both the lazy hashCodes have been pre-computed already. We don't currently want to force the computation of the hashCode in this code path because the consequences of doing so are unclear from the overall performance perspective.

**Related issue(s)**:

Fixes #725 

**Notes for reviewer**:
It's impossible to actually test this specific logic because equals() is fine regardless of whether the hashCodes have been computed. Existing tests that call equals() should suffice.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
