### PR TITLE
feat: unrecognized enum values null/default bug

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/EnumGenerator.java
@@ -234,7 +234,10 @@ public final class EnumGenerator {
                      * @return enum for matching ordinal, or UNRECOGNIZED/UNSET value
                      */
                     public static $enumName fromObject(Object obj) {
-                        if (obj instanceof $enumName pbjEnum) {
+                        if (obj == null) {
+                            // Per protobuf spec, must return the default (protoOrdinal 0) when unset (null):
+                            return fromProtobufOrdinal(0);
+                        } else if (obj instanceof $enumName pbjEnum) {
                             return pbjEnum;
                         } else {
                             return $enumName.$unknownValue;

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnrecognizedEnumTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnrecognizedEnumTest.java
@@ -54,4 +54,18 @@ public class UnrecognizedEnumTest {
         assertEquals(
                 List.of(PbjEnumUnrecognized2.A2, PbjEnumUnrecognized2.D2, PbjEnumUnrecognized2.B2), m22.enumList());
     }
+
+    @Test
+    public void testDefaultValue() throws Exception {
+        // This initializes the enum value in the model to be literally `null` rather than the default:
+        final MessageWithUnrecognizedEnum1 msg =
+                MessageWithUnrecognizedEnum1.newBuilder().enumValue(null).build();
+
+        // However, reading it from the model MUST return the "protobuf default" value, which is at the protoOrdinal 0:
+        assertEquals(PbjEnumUnrecognized1.A1, msg.enumValue());
+
+        // Play the same trick using the ctor:
+        final MessageWithUnrecognizedEnum1 msg2 = new MessageWithUnrecognizedEnum1(null, null);
+        assertEquals(PbjEnumUnrecognized1.A1, msg2.enumValue());
+    }
 }


### PR DESCRIPTION
**Description**:
The PR fixes a bug in the current enum implementation (after support for `UNRECOGNIZED` values was added) that causes PBJ to return `UNRECOGNIZED` instead of the "default" value as the protobuf spec prescribes.

Also, marking it as `feat:` to make a new minor release because I realized that the `UNRECOGNIZED` enum feature is a major API change because it adds an extra constant to every enum and sometimes requires modifying the client code (e.g. adding a `case` to a `switch`.)

**Related issue(s)**:

Fixes #737

**Notes for reviewer**:
All tests, including the newly added one for this bug, should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
