### PR TITLE
perf: update GrpcBench to test compression

### DIFF
--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/PbjGrpcBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/PbjGrpcBench.java
@@ -116,19 +116,19 @@ public class PbjGrpcBench {
             try {
                 client.close();
             } catch (Exception ex) {
-                new RuntimeException(ex).printStackTrace();
+                ex.printStackTrace();
             }
             client = null;
             try {
                 server.close();
             } catch (Exception ex) {
-                new RuntimeException(ex).printStackTrace();
+                ex.printStackTrace();
             }
             server = null;
             try {
                 port.close();
             } catch (Exception ex) {
-                new RuntimeException(ex).printStackTrace();
+                ex.printStackTrace();
             }
             port = null;
         }
@@ -169,19 +169,19 @@ public class PbjGrpcBench {
             try {
                 client.close();
             } catch (Exception ex) {
-                new RuntimeException(ex).printStackTrace();
+                ex.printStackTrace();
             }
             client = null;
             try {
                 server.close();
             } catch (Exception ex) {
-                new RuntimeException(ex).printStackTrace();
+                ex.printStackTrace();
             }
             server = null;
             try {
                 port.close();
             } catch (Exception ex) {
-                new RuntimeException(ex).printStackTrace();
+                ex.printStackTrace();
             }
             port = null;
         }
@@ -196,7 +196,7 @@ public class PbjGrpcBench {
             }
         } catch (Exception e) {
             // Keep running because network may fail sometimes.
-            new RuntimeException(e).printStackTrace();
+            e.printStackTrace();
         }
     }
 
@@ -216,7 +216,9 @@ public class PbjGrpcBench {
                     public void onSubscribe(Flow.Subscription subscription) {}
 
                     @Override
-                    public void onError(Throwable throwable) {}
+                    public void onError(Throwable throwable) {
+                        new RuntimeException(throwable).printStackTrace();
+                    }
 
                     @Override
                     public void onComplete() {
@@ -231,7 +233,7 @@ public class PbjGrpcBench {
             }
         } catch (Exception e) {
             // Keep running because network may fail sometimes.
-            new RuntimeException(e).printStackTrace();
+            e.printStackTrace();
         }
     }
 
@@ -274,7 +276,7 @@ public class PbjGrpcBench {
             }
         } catch (Exception e) {
             // Keep running because network may fail sometimes.
-            new RuntimeException(e).printStackTrace();
+            e.printStackTrace();
         }
     }
 
@@ -317,7 +319,7 @@ public class PbjGrpcBench {
             }
         } catch (Exception e) {
             // Keep running because network may fail sometimes.
-            new RuntimeException(e).printStackTrace();
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
**Description**:
1. Adding `encodings` parameter to test different compression algorithms.
2. Renaming GrpcBench to PbjGrpcBench so that its main() doesn't run the GoogleGrpcBench (which matched the regexp previously.)
3. Adding try/catch/print in critical places to allow the benchmark to run and not hung. It's because it uses a real network connection (through the loopback interface), and networks sometimes fail. The numbers of iterations and invocations allow us to ignore those exceptions.

**Related issue(s)**:

Fixes #741

**Notes for reviewer**:
Test results:
```
Benchmark                          (encodings)  (streamCount)  (weight)   Mode  Cnt     Score      Error  Units
PbjGrpcBench.benchBidiStreaming       identity              1     LIGHT  thrpt    5  7998.635 ±  743.896  ops/s
PbjGrpcBench.benchBidiStreaming       identity              1    NORMAL  thrpt    5  7895.842 ±  290.447  ops/s
PbjGrpcBench.benchBidiStreaming       identity              1     HEAVY  thrpt    5  5055.877 ±  134.743  ops/s
PbjGrpcBench.benchBidiStreaming       identity             10     LIGHT  thrpt    5  2636.082 ±  101.572  ops/s
PbjGrpcBench.benchBidiStreaming       identity             10    NORMAL  thrpt    5  2111.546 ±   19.351  ops/s
PbjGrpcBench.benchBidiStreaming       identity             10     HEAVY  thrpt    5   236.538 ±    2.795  ops/s
PbjGrpcBench.benchBidiStreaming           gzip              1     LIGHT  thrpt    5  6007.552 ± 1565.961  ops/s
PbjGrpcBench.benchBidiStreaming           gzip              1    NORMAL  thrpt    5  5957.409 ±  451.220  ops/s
PbjGrpcBench.benchBidiStreaming           gzip              1     HEAVY  thrpt    5  2963.566 ±  215.356  ops/s
PbjGrpcBench.benchBidiStreaming           gzip             10     LIGHT  thrpt    5   696.050 ±  727.534  ops/s
PbjGrpcBench.benchBidiStreaming           gzip             10    NORMAL  thrpt    5   604.035 ±  384.219  ops/s
PbjGrpcBench.benchBidiStreaming           gzip             10     HEAVY  thrpt    5   123.544 ±    1.923  ops/s
PbjGrpcBench.benchClientStreaming     identity              1     LIGHT  thrpt    5  7848.965 ±  533.296  ops/s
PbjGrpcBench.benchClientStreaming     identity              1    NORMAL  thrpt    5  7622.147 ±  127.163  ops/s
PbjGrpcBench.benchClientStreaming     identity              1     HEAVY  thrpt    5  4873.928 ±  144.704  ops/s
PbjGrpcBench.benchClientStreaming     identity             10     LIGHT  thrpt    5  7131.037 ±  293.391  ops/s
PbjGrpcBench.benchClientStreaming     identity             10    NORMAL  thrpt    5  5853.965 ±   28.697  ops/s
PbjGrpcBench.benchClientStreaming     identity             10     HEAVY  thrpt    5   945.218 ±  141.465  ops/s
PbjGrpcBench.benchClientStreaming         gzip              1     LIGHT  thrpt    5  5665.605 ± 1223.836  ops/s
PbjGrpcBench.benchClientStreaming         gzip              1    NORMAL  thrpt    5  5425.950 ±   86.522  ops/s
PbjGrpcBench.benchClientStreaming         gzip              1     HEAVY  thrpt    5  3188.147 ±  270.522  ops/s
PbjGrpcBench.benchClientStreaming         gzip             10     LIGHT  thrpt    5  3542.766 ±  864.976  ops/s
PbjGrpcBench.benchClientStreaming         gzip             10    NORMAL  thrpt    5  2660.160 ± 1085.557  ops/s
PbjGrpcBench.benchClientStreaming         gzip             10     HEAVY  thrpt    5   523.708 ±   39.723  ops/s
PbjGrpcBench.benchServerStreaming     identity              1     LIGHT  thrpt    5  7982.163 ±  307.763  ops/s
PbjGrpcBench.benchServerStreaming     identity              1    NORMAL  thrpt    5  7608.325 ±  273.204  ops/s
PbjGrpcBench.benchServerStreaming     identity              1     HEAVY  thrpt    5  4858.465 ±   68.738  ops/s
PbjGrpcBench.benchServerStreaming     identity             10     LIGHT  thrpt    5  6833.669 ±  127.550  ops/s
PbjGrpcBench.benchServerStreaming     identity             10    NORMAL  thrpt    5  6119.665 ±  306.813  ops/s
PbjGrpcBench.benchServerStreaming     identity             10     HEAVY  thrpt    5  1705.576 ±   97.256  ops/s
PbjGrpcBench.benchServerStreaming         gzip              1     LIGHT  thrpt    5  5677.653 ±  397.466  ops/s
PbjGrpcBench.benchServerStreaming         gzip              1    NORMAL  thrpt    5  5480.451 ±  347.349  ops/s
PbjGrpcBench.benchServerStreaming         gzip              1     HEAVY  thrpt    5  2971.255 ±  264.357  ops/s
PbjGrpcBench.benchServerStreaming         gzip             10     LIGHT  thrpt    5  2641.559 ±  464.049  ops/s
PbjGrpcBench.benchServerStreaming         gzip             10    NORMAL  thrpt    5  2433.383 ±  480.144  ops/s
PbjGrpcBench.benchServerStreaming         gzip             10     HEAVY  thrpt    5   866.013 ±   91.523  ops/s
PbjGrpcBench.benchUnary               identity            N/A     LIGHT  thrpt    5  8295.708 ±  175.507  ops/s
PbjGrpcBench.benchUnary               identity            N/A    NORMAL  thrpt    5  8050.094 ±  315.754  ops/s
PbjGrpcBench.benchUnary               identity            N/A     HEAVY  thrpt    5  4840.239 ±  125.601  ops/s
PbjGrpcBench.benchUnary                   gzip            N/A     LIGHT  thrpt    5  6560.751 ±  555.112  ops/s
PbjGrpcBench.benchUnary                   gzip            N/A    NORMAL  thrpt    5  6070.967 ±  447.452  ops/s
PbjGrpcBench.benchUnary                   gzip            N/A     HEAVY  thrpt    5  2788.272 ±  176.471  ops/s
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
