### PR TITLE
feat: support maxSize in PbjGrpcClient

### DIFF
--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -208,7 +208,12 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
                                 datagram.compressedFlag() == 1 ? decompressor.decompress(bytes) : bytes;
 
                         try {
-                            final ReplyT reply = replyCodec.parse(replyBytes);
+                            final ReplyT reply = replyCodec.parse(
+                                    replyBytes.toReadableSequentialData(),
+                                    false,
+                                    false,
+                                    Codec.DEFAULT_MAX_DEPTH,
+                                    grpcClient.getConfig().maxSize());
                             pipeline.onNext(reply);
                         } catch (ParseException e) {
                             pipeline.onError(e);

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientConfig.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClientConfig.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.grpc.client.helidon;
 
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.grpc.GrpcCompression;
 import io.helidon.common.tls.Tls;
 import java.time.Duration;
@@ -9,6 +10,7 @@ import java.util.Set;
 
 /**
  * Configuration for PBJ GRPC client.
+ * @param maxSize the maximum size of messages that the client is able to receive, defaults to Codec.DEFAULT_MAX_SIZE.
  */
 public record PbjGrpcClientConfig(
         /** A read timeout. Duration.ofSeconds(10) is a good default. */
@@ -34,8 +36,10 @@ public record PbjGrpcClientConfig(
          * e.g. "identity", "gzip", etc.
          * Note that the encoding must be registered as a `Decompressor` with `GrpcCompression` to actually be supported.
          */
-        Set<String> acceptEncodings) {
+        Set<String> acceptEncodings,
+        int maxSize) {
 
+    /** For backward compatibility before encodings were introduced. */
     public PbjGrpcClientConfig(Duration readTimeout, Tls tls, Optional<String> authority, String contentType) {
         this(
                 readTimeout,
@@ -43,6 +47,18 @@ public record PbjGrpcClientConfig(
                 authority,
                 contentType,
                 GrpcCompression.IDENTITY,
-                GrpcCompression.getDecompressorNames());
+                GrpcCompression.getDecompressorNames(),
+                Codec.DEFAULT_MAX_SIZE);
+    }
+
+    /** For backward compatibility before maxSize was introduced. */
+    public PbjGrpcClientConfig(
+            Duration readTimeout,
+            Tls tls,
+            Optional<String> authority,
+            String contentType,
+            String encoding,
+            Set<String> acceptEncodings) {
+        this(readTimeout, tls, authority, contentType, encoding, acceptEncodings, Codec.DEFAULT_MAX_SIZE);
     }
 }

--- a/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
@@ -21,6 +21,7 @@ import com.hedera.pbj.runtime.grpc.GrpcException;
 import com.hedera.pbj.runtime.grpc.GrpcStatus;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.tls.Tls;
@@ -269,7 +270,14 @@ public class PbjGrpcCallTest {
         doReturn(bufferData).when(data).data();
 
         final Object reply = mock(Object.class);
-        doReturn(reply).when(replyCodec).parse(eq(Bytes.wrap(new byte[] {6})));
+        doReturn(reply)
+                .when(replyCodec)
+                .parse(
+                        any(ReadableSequentialData.class),
+                        eq(false),
+                        eq(false),
+                        eq(Codec.DEFAULT_MAX_DEPTH),
+                        eq(Codec.DEFAULT_MAX_SIZE));
 
         runnable.run();
 
@@ -324,7 +332,14 @@ public class PbjGrpcCallTest {
         doReturn(bufferData).when(data).data();
 
         final ParseException exception = new ParseException("test");
-        doThrow(exception).when(replyCodec).parse(eq(Bytes.wrap(new byte[] {6})));
+        doThrow(exception)
+                .when(replyCodec)
+                .parse(
+                        any(ReadableSequentialData.class),
+                        eq(false),
+                        eq(false),
+                        eq(Codec.DEFAULT_MAX_DEPTH),
+                        eq(Codec.DEFAULT_MAX_SIZE));
 
         runnable.run();
 

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/PbjGrpcBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/PbjGrpcBench.java
@@ -5,6 +5,7 @@ import com.hedera.pbj.grpc.helidon.PbjGrpcServiceConfig;
 import com.hedera.pbj.grpc.helidon.PbjRouting;
 import com.hedera.pbj.integration.grpc.GrpcTestUtils;
 import com.hedera.pbj.integration.grpc.PortsAllocator;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.grpc.GrpcClient;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
@@ -78,8 +79,8 @@ public class PbjGrpcBench {
         if (encodings == null || encodings.length == 0) {
             grpcClient = GrpcTestUtils.createGrpcClient(port, GrpcTestUtils.PROTO_OPTIONS);
         } else {
-            grpcClient =
-                    GrpcTestUtils.createGrpcClient(port, GrpcTestUtils.PROTO_OPTIONS, encodings[0], Set.of(encodings));
+            grpcClient = GrpcTestUtils.createGrpcClient(
+                    port, GrpcTestUtils.PROTO_OPTIONS, encodings[0], Set.of(encodings), Codec.DEFAULT_MAX_SIZE);
         }
 
         return new GreeterInterface.GreeterClient(grpcClient, GrpcTestUtils.PROTO_OPTIONS);

--- a/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/grpc/GrpcTestUtils.java
+++ b/pbj-integration-tests/src/main/java/com/hedera/pbj/integration/grpc/GrpcTestUtils.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.integration.grpc;
 
 import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
 import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.grpc.GrpcClient;
 import com.hedera.pbj.runtime.grpc.GrpcCompression;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
@@ -35,14 +36,20 @@ public class GrpcTestUtils {
     }
 
     public static GrpcClient createGrpcClient(final int port, final ServiceInterface.RequestOptions requestOptions) {
-        return createGrpcClient(port, requestOptions, GrpcCompression.IDENTITY, GrpcCompression.getDecompressorNames());
+        return createGrpcClient(
+                port,
+                requestOptions,
+                GrpcCompression.IDENTITY,
+                GrpcCompression.getDecompressorNames(),
+                Codec.DEFAULT_MAX_SIZE);
     }
 
     public static GrpcClient createGrpcClient(
             final int port,
             final ServiceInterface.RequestOptions requestOptions,
             String encoding,
-            Set<String> acceptEncodings) {
+            Set<String> acceptEncodings,
+            int maxSize) {
         final Tls tls = Tls.builder().enabled(false).build();
         final WebClient webClient =
                 WebClient.builder().baseUri("http://localhost:" + port).tls(tls).build();
@@ -52,7 +59,7 @@ public class GrpcTestUtils {
                 requestOptions.authority().isPresent() ? requestOptions.authority() : Optional.of("localhost:" + port);
 
         final PbjGrpcClientConfig config = new PbjGrpcClientConfig(
-                READ_TIMEOUT, tls, authority, requestOptions.contentType(), encoding, acceptEncodings);
+                READ_TIMEOUT, tls, authority, requestOptions.contentType(), encoding, acceptEncodings, maxSize);
 
         return new PbjGrpcClient(webClient, config);
     }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcClientComprehensiveTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcClientComprehensiveTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.integration.grpc.GrpcTestUtils;
 import com.hedera.pbj.integration.grpc.PortsAllocator;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.grpc.GrpcClient;
+import com.hedera.pbj.runtime.grpc.GrpcCompression;
 import com.hedera.pbj.runtime.grpc.GrpcException;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import java.util.ArrayList;
@@ -105,6 +107,32 @@ public class GrpcClientComprehensiveTest {
             final HelloReply reply = client.sayHello(request);
 
             assertEquals("Hello test name", reply.message());
+        }
+    }
+
+    @Test
+    void testUnaryMethodReceivingExtraLargePayload() {
+        try (final PortsAllocator.Port port = GrpcTestUtils.PORTS.acquire();
+                final GrpcServerGreeterHandle server = serverFactory.apply(port.port())) {
+            server.start();
+            final String extraLongString = "a".repeat(Codec.DEFAULT_MAX_SIZE * 2);
+            server.setSayHello(
+                    request -> HelloReply.newBuilder().message(extraLongString).build());
+
+            final GrpcClient grpcClient = GrpcTestUtils.createGrpcClient(
+                    port.port(),
+                    GrpcTestUtils.PROTO_OPTIONS,
+                    GrpcCompression.IDENTITY,
+                    GrpcCompression.getDecompressorNames(),
+                    Codec.DEFAULT_MAX_SIZE * 2);
+            final GreeterInterface.GreeterClient client =
+                    new GreeterInterface.GreeterClient(grpcClient, GrpcTestUtils.PROTO_OPTIONS);
+
+            final HelloRequest request =
+                    HelloRequest.newBuilder().name("test name").build();
+            final HelloReply reply = client.sayHello(request);
+
+            assertEquals(extraLongString, reply.message());
         }
     }
 

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcCompressionTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/GrpcCompressionTest.java
@@ -7,6 +7,7 @@ import com.hedera.pbj.grpc.helidon.PbjGrpcServiceConfig;
 import com.hedera.pbj.grpc.helidon.PbjRouting;
 import com.hedera.pbj.integration.grpc.GrpcTestUtils;
 import com.hedera.pbj.integration.grpc.PortsAllocator;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.grpc.GrpcClient;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -28,8 +29,8 @@ public class GrpcCompressionTest {
             server.setSayHello(request ->
                     HelloReply.newBuilder().message("Hello " + request.name()).build());
 
-            try (final GrpcClient grpcClient =
-                    GrpcTestUtils.createGrpcClient(port.port(), GrpcTestUtils.PROTO_OPTIONS, "gzip", Set.of("gzip"))) {
+            try (final GrpcClient grpcClient = GrpcTestUtils.createGrpcClient(
+                    port.port(), GrpcTestUtils.PROTO_OPTIONS, "gzip", Set.of("gzip"), Codec.DEFAULT_MAX_SIZE)) {
                 final GreeterInterface.GreeterClient client =
                         new GreeterInterface.GreeterClient(grpcClient, GrpcTestUtils.PROTO_OPTIONS);
 
@@ -107,8 +108,8 @@ public class GrpcCompressionTest {
             handle.setSayHello(request ->
                     HelloReply.newBuilder().message("Hello " + request.name()).build());
 
-            try (final GrpcClient grpcClient =
-                    GrpcTestUtils.createGrpcClient(port.port(), GrpcTestUtils.PROTO_OPTIONS, "gzip", Set.of("gzip"))) {
+            try (final GrpcClient grpcClient = GrpcTestUtils.createGrpcClient(
+                    port.port(), GrpcTestUtils.PROTO_OPTIONS, "gzip", Set.of("gzip"), Codec.DEFAULT_MAX_SIZE)) {
                 final GreeterInterface.GreeterClient client =
                         new GreeterInterface.GreeterClient(grpcClient, GrpcTestUtils.PROTO_OPTIONS);
 


### PR DESCRIPTION
**Description**:
Adding support for configuring a custom `maxSize` for the PBJ GRPC Client so that it's able to receive messages larger than 2MB (per the current `Codec.DEFAULT_MAX_SIZE`.)

**Related issue(s)**:

Fixes #748 

**Notes for reviewer**:
A new integration test is added to verify the behavior. W/o the fix, or w/o specifying the maxSize in the client config, the test fails with a ParseException about the size of the payload exceeding the limit.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
