### PR TITLE
feat: support GRPC metadata

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -54,7 +54,7 @@ public final class ServiceGenerator {
                     .indent(indent);
         }
 
-        private String formatMethodSignature(String methodModifier) {
+        private String formatMethodSignature(String methodModifier, boolean withRequestOptions) {
             // Examples:
             //    // Unary, a single request/response call.
             //    HelloReply sayHello(HelloRequest request);
@@ -97,12 +97,15 @@ public final class ServiceGenerator {
             if (requestStream || replyStream) {
                 sb.append("@NonNull final Pipeline<? super ").append(replyType).append("> replies");
             }
+            if (withRequestOptions) {
+                sb.append(", ").append("@NonNull final RequestOptions requestOptions");
+            }
             sb.append(")");
 
             return sb.toString();
         }
 
-        String formatMethodDeclaration() {
+        String formatMethodDeclaration(String methodModifier, boolean withRequestOptions, boolean withSemicolon) {
             final StringBuilder sb = new StringBuilder();
             if (javaDoc.contains("\n")) {
                 sb.append("/**\n");
@@ -112,33 +115,111 @@ public final class ServiceGenerator {
                 sb.append("/** ").append(javaDoc).append(" */\n");
             }
 
-            sb.append(formatMethodSignature(null));
-            sb.append(";");
+            sb.append(formatMethodSignature(methodModifier, withRequestOptions));
+            if (withSemicolon) {
+                sb.append(";");
+            }
+
+            return sb.toString();
+        }
+
+        /**
+         * Format a default implementation of a handler method.
+         * @param withRequestOptions if true, add the RequestOptions arg and delegate to the method w/o the arg;
+         *                           if false, the generated implementation throws.
+         * @return the default method implementation for a handler
+         */
+        String formatDefaultMethod(boolean withRequestOptions) {
+            final StringBuilder sb = new StringBuilder();
+
+            sb.append(formatMethodDeclaration("default", withRequestOptions, false));
+            sb.append(" {\n");
+            if (!withRequestOptions) {
+                sb.append("    throw new UnsupportedOperationException(\"unimplemented\")");
+            } else {
+                // return type:
+                if (!requestStream && !replyStream) {
+                    sb.append("    return ");
+                } else if (!requestStream) {
+                    sb.append("    ");
+                } else {
+                    sb.append("    return ");
+                }
+
+                // name and args:
+                sb.append(name).append('(');
+                if (!requestStream) {
+                    sb.append("request");
+                    if (replyStream) {
+                        sb.append(", ");
+                    }
+                }
+                if (requestStream || replyStream) {
+                    sb.append("replies");
+                }
+                sb.append(")");
+            }
+
+            sb.append(";\n}\n");
+
+            return sb.toString();
+        }
+
+        String formatDelegateToMethodWithOptions() {
+            final StringBuilder sb = new StringBuilder();
+
+            // return type:
+            if (!requestStream && !replyStream) {
+                sb.append("return ");
+            } else if (!requestStream) {
+                // no-op because void return type
+            } else {
+                sb.append("return ");
+            }
+
+            // name and args:
+            sb.append(name).append('(');
+            if (!requestStream) {
+                sb.append("request");
+                if (replyStream) {
+                    sb.append(", ");
+                }
+            }
+            if (requestStream || replyStream) {
+                sb.append("replies");
+            }
+            sb.append(", this.requestOptions);");
 
             return sb.toString();
         }
 
         String formatCaseStatement() {
             final String kind;
+            final String methodLambda;
             if (!requestStream && !replyStream) {
                 kind = "unary";
+                methodLambda = "request -> " + name + "(request, options)";
             } else if (requestStream && !replyStream) {
                 kind = "clientStreaming";
+                methodLambda = "typedReplies -> " + name + "(typedReplies, options)";
             } else if (!requestStream && replyStream) {
                 kind = "serverStreaming";
+                methodLambda = "(request, typedReplies) -> " + name + "(request, typedReplies, options)";
             } else {
                 kind = "bidiStreaming";
+                methodLambda = "typedReplies -> " + name + "(typedReplies, options)";
             }
 
             return """
                     case $methodName -> Pipelines.<$requestType, $replyType>$kind()
                             .mapRequest(bytes -> parse$simpleRequestType(bytes, options))
-                            .method(this::$methodName)
+                            .method($methodLambda)
                             .mapResponse(reply -> serialize$simpleReplyType(reply, options))
                             .respondTo(replies)
                             .build();
                     """
                     .replace("$methodName", name)
+                    .replace("$methodLambda", methodLambda)
                     .replace("$requestType", requestType)
                     .replace("$simpleRequestType", requestType.replace(".", ""))
                     .replace("$replyType", replyType)
@@ -149,7 +230,12 @@ public final class ServiceGenerator {
         private String formatUnaryMethodImplementation() {
             return """
                         @Override
-                        $methodSignature {
+                        $methodSignatureWithoutOptions {
+                            $delegateToMethodWithOptions
+                        }
+
+                        @Override
+                        $methodSignatureWithOptions {
                             final AtomicReference<$replyType> replyRef = new AtomicReference<>();
                             final AtomicReference<Throwable> errorRef = new AtomicReference<>();
                             final CountDownLatch latch = new CountDownLatch(1);
@@ -181,7 +267,8 @@ public final class ServiceGenerator {
                                     FULL_NAME + "/$methodName",
                                     get$simpleRequestTypeCodec(requestOptions),
                                     get$simpleReplyTypeCodec(requestOptions),
-                                    pipeline
+                                    pipeline,
+                                    requestOptions.metadata()
                                     );
                             call.sendRequest(request, true);
                             try {
@@ -203,7 +290,9 @@ public final class ServiceGenerator {
                             throw new RuntimeException("Call to $methodName completed w/o receiving a reply or an error explicitly. The request was: " + request);
                         }
                         """
-                    .replace("$methodSignature", formatMethodSignature("public"))
+                    .replace("$methodSignatureWithoutOptions", formatMethodSignature("public", false))
+                    .replace("$delegateToMethodWithOptions", formatDelegateToMethodWithOptions())
+                    .replace("$methodSignatureWithOptions", formatMethodSignature("public", true))
                     .replace("$requestType", requestType)
                     .replace("$simpleRequestType", requestType.replace(".", ""))
                     .replace("$replyType", replyType)
@@ -214,7 +303,12 @@ public final class ServiceGenerator {
         private String formatClientStreamingMethodImplementation() {
             return """
                         @Override
-                        $methodSignature {
+                        $methodSignatureWithoutOptions {
+                            $delegateToMethodWithOptions
+                        }
+
+                        @Override
+                        $methodSignatureWithOptions {
                             final AtomicReference<$replyType> replyRef = new AtomicReference<>();
                             final Pipeline<$replyType> pipeline = new Pipeline<>() {
                                 @Override
@@ -243,7 +337,8 @@ public final class ServiceGenerator {
                                     FULL_NAME + "/$methodName",
                                     get$simpleRequestTypeCodec(requestOptions),
                                     get$simpleReplyTypeCodec(requestOptions),
-                                    pipeline
+                                    pipeline,
+                                    requestOptions.metadata()
                                     );
 
                             return new Pipeline<$requestType>() {
@@ -266,7 +361,9 @@ public final class ServiceGenerator {
                             };
                         }
                         """
-                    .replace("$methodSignature", formatMethodSignature("public"))
+                    .replace("$methodSignatureWithoutOptions", formatMethodSignature("public", false))
+                    .replace("$delegateToMethodWithOptions", formatDelegateToMethodWithOptions())
+                    .replace("$methodSignatureWithOptions", formatMethodSignature("public", true))
                     .replace("$requestType", requestType)
                     .replace("$simpleRequestType", requestType.replace(".", ""))
                     .replace("$replyType", replyType)
@@ -277,7 +374,12 @@ public final class ServiceGenerator {
         private String formatServerStreamingMethodImplementation() {
             return """
                         @Override
-                        $methodSignature {
+                        $methodSignatureWithoutOptions {
+                            $delegateToMethodWithOptions
+                        }
+
+                        @Override
+                        $methodSignatureWithOptions {
                             final CountDownLatch latch = new CountDownLatch(1);
                             final Pipeline<$replyType> pipeline = new Pipeline<>() {
                                 @Override
@@ -304,7 +406,8 @@ public final class ServiceGenerator {
                                     FULL_NAME + "/$methodName",
                                     get$simpleRequestTypeCodec(requestOptions),
                                     get$simpleReplyTypeCodec(requestOptions),
-                                    pipeline
+                                    pipeline,
+                                    requestOptions.metadata()
                                     );
                             call.sendRequest(request, true);
                             try {
@@ -318,7 +421,9 @@ public final class ServiceGenerator {
                             // Alternatively, the client could time out if the replies pipeline never saw onComplete().
                         }
                         """
-                    .replace("$methodSignature", formatMethodSignature("public"))
+                    .replace("$methodSignatureWithoutOptions", formatMethodSignature("public", false))
+                    .replace("$delegateToMethodWithOptions", formatDelegateToMethodWithOptions())
+                    .replace("$methodSignatureWithOptions", formatMethodSignature("public", true))
                     .replace("$requestType", requestType)
                     .replace("$simpleRequestType", requestType.replace(".", ""))
                     .replace("$replyType", replyType)
@@ -329,7 +434,12 @@ public final class ServiceGenerator {
         private String formatBidiStreamingMethodImplementation() {
             return """
                         @Override
-                        $methodSignature {
+                        $methodSignatureWithoutOptions {
+                            $delegateToMethodWithOptions
+                        }
+
+                        @Override
+                        $methodSignatureWithOptions {
                             final Pipeline<$replyType> pipeline = new Pipeline<>() {
                                 @Override
                                 public void onSubscribe(final Flow.Subscription subscription) {
@@ -353,7 +463,8 @@ public final class ServiceGenerator {
                                     FULL_NAME + "/$methodName",
                                     get$simpleRequestTypeCodec(requestOptions),
                                     get$simpleReplyTypeCodec(requestOptions),
-                                    pipeline
+                                    pipeline,
+                                    requestOptions.metadata()
                                     );
 
                             return new Pipeline<$requestType>() {
@@ -377,7 +488,9 @@ public final class ServiceGenerator {
                             };
                         }
                         """
-                    .replace("$methodSignature", formatMethodSignature("public"))
+                    .replace("$methodSignatureWithoutOptions", formatMethodSignature("public", false))
+                    .replace("$delegateToMethodWithOptions", formatDelegateToMethodWithOptions())
+                    .replace("$methodSignatureWithOptions", formatMethodSignature("public", true))
                     .replace("$requestType", requestType)
                     .replace("$simpleRequestType", requestType.replace(".", ""))
                     .replace("$replyType", replyType)
@@ -517,7 +630,7 @@ public final class ServiceGenerator {
                 $methodNames
                     }
                 
-                $methodSignatures
+                $serviceMethods
                 
                     @NonNull
                     default String serviceName() {
@@ -554,7 +667,23 @@ public final class ServiceGenerator {
                 $getCodecMethods
                 $requestReplySerdeMethods
                 
-                    /** A client class for $serviceName. */
+                    /**
+                     * A client class for $serviceName.
+                     * <p>
+                     * Its constructor accepts the default RequestOptions for all requests. Individual service call
+                     * methods have versions that accept a RequestOptions argument which overrides this default value
+                     * for that specific call.
+                     * <p>
+                     * In the context of a client, these RequestOptions control the contentType used to encode/decode
+                     * requests and replies, and the contentType MUST match the contentType defined in the PbjGrpcClientConfig
+                     * that the PbjGrpcClient was created with. The behavior is undefined if a per-request (or the per-stub)
+                     * RequestOptions.contentType() differs from that. With the exception of the metadata, all the other
+                     * RequestOptions values are unused in the client code.
+                     * <p>
+                     * However, the RequestOptions.metadata() is something that a client application may change freely
+                     * from one request to another, and this is the primary reason for the overridden method versions
+                     * in this client stub class.
+                     */
                     public class $serviceNameClient implements $serviceName$suffix {
                         private final GrpcClient grpcClient;
                         private final RequestOptions requestOptions;
@@ -578,7 +707,9 @@ public final class ServiceGenerator {
                 .replace("$serviceName", serviceName)
                 .replace("$suffix", SUFFIX)
                 .replace("$methodNames", RPC.formatForEach(rpcList, RPC::name, ",\n", DEFAULT_INDENT * 2))
-                .replace("$methodSignatures", RPC.formatForEach(rpcList, RPC::formatMethodDeclaration, "\n\n", DEFAULT_INDENT))
+                .replace("$serviceMethods", RPC.formatForEach(rpcList, rpc ->
+                    rpc.formatDefaultMethod(true) + "\n" + rpc.formatDefaultMethod(false)
+                , "\n\n", DEFAULT_INDENT))
                 .replace("$fullyQualifiedProtoServiceName", lookupHelper.getLookupHelper().getFullyQualifiedProtoNameForContext(serviceDef))
                 .replace("$methodCaseStatements", RPC.formatForEach(rpcList, RPC::formatCaseStatement, "\n", DEFAULT_INDENT * 4))
                 .replace("$getCodecMethods", formatGetCodecMethods(rpcList).indent(DEFAULT_INDENT))

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -129,6 +129,21 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
         headers.add(HeaderValues.create(
                 GRPC_ACCEPT_ENCODING, String.join(",", grpcClient.getConfig().acceptEncodings())));
         headers.add(HeaderValues.create(GRPC_ENCODING, grpcOutgoingEncoding));
+
+        if (requestOptions.metadata() != null && !requestOptions.metadata().isEmpty()) {
+            for (String key : requestOptions.metadata().keySet()) {
+                if (key.startsWith("grpc-")) {
+                    throw new IllegalArgumentException(
+                            "Custom metadata key names must not start with grpc- prefix, got: " + key);
+                }
+
+                String value = requestOptions.metadata().get(key);
+                if (value != null) {
+                    headers.add(HeaderNames.create(key), value);
+                }
+            }
+        }
+
         clientStream.writeHeaders(Http2Headers.create(headers), false);
 
         // We must start this loop only AFTER writing headers above because that operation initializes

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.net.SocketException;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -82,17 +83,20 @@ public final class PbjGrpcClient implements GrpcClient, AutoCloseable {
      * @param requestCodec a PBJ codec for requests that MUST correspond to the content type in the PbjGrpcClientConfig
      * @param replyCodec a PBJ codec for replies that MUST correspond to the content type in the PbjGrpcClientConfig
      * @param pipeline a pipeline for receiving replies
+     * @param metadata metadata to be sent to the service
      */
     @Override
     public <RequestT, ReplyT> GrpcCall<RequestT, ReplyT> createCall(
             final String fullMethodName,
             final Codec<RequestT> requestCodec,
             final Codec<ReplyT> replyCodec,
-            final Pipeline<ReplyT> pipeline) {
+            final Pipeline<ReplyT> pipeline,
+            final Map<String, String> metadata) {
+        final Options options = new Options(Optional.of(resolvedAuthority), config.contentType(), metadata);
         return new PbjGrpcCall(
                 this,
                 createPbjGrpcClientStream(connection, clientConnection),
-                new Options(Optional.of(resolvedAuthority), config.contentType()),
+                options,
                 fullMethodName,
                 requestCodec,
                 replyCodec,
@@ -153,7 +157,8 @@ public final class PbjGrpcClient implements GrpcClient, AutoCloseable {
     }
 
     /** Simple implementation of the {@link ServiceInterface.RequestOptions} interface. */
-    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+    private record Options(Optional<String> authority, String contentType, Map<String, String> metadata)
+            implements ServiceInterface.RequestOptions {}
 
     private ClientConnection createClientConnection() {
         // We cannot (don't want to) establish connections when unit-testing, so we use a marker:

--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -45,6 +45,7 @@ import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +56,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of gRPC based on PBJ. This class specifically contains the glue logic for bridging
@@ -242,6 +244,11 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
                         ex);
             }
 
+            // Metadata, aka additional GRPC headers, provided by the client with the request.
+            final Map<String, String> metadata = requestHeaders.stream()
+                    .filter(header -> !header.name().toLowerCase().startsWith("grpc-"))
+                    .collect(Collectors.toUnmodifiableMap(Header::name, Header::values));
+
             // The client may have sent a "grpc-accept-encoding" header. Note that
             // "grpc-accept-encoding" is not well specified. I am following what I see work with
             // the grpc.io client library, and the definition of "accept-encoding" for HTTP, such
@@ -295,7 +302,8 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
             final var options = new Options(
                     Optional.ofNullable(headers.authority()), // the client (see http2 spec)
                     contentType,
-                    config.maxMessageSizeBytes());
+                    config.maxMessageSizeBytes(),
+                    metadata);
 
             // Setup the subscribers. The "outgoing" subscriber will send messages to the client.
             // This is given to the "open" method on the service to allow it to send messages to
@@ -756,7 +764,8 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
     }
 
     /** Simple implementation of the {@link ServiceInterface.RequestOptions} interface. */
-    private record Options(Optional<String> authority, String contentType, int maxMessageSizeBytes)
+    private record Options(
+            Optional<String> authority, String contentType, int maxMessageSizeBytes, Map<String, String> metadata)
             implements ServiceInterface.RequestOptions {}
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/GrpcClient.java
@@ -2,6 +2,7 @@
 package com.hedera.pbj.runtime.grpc;
 
 import com.hedera.pbj.runtime.Codec;
+import java.util.Map;
 
 /**
  * An interface for GRPC client.
@@ -19,9 +20,14 @@ public interface GrpcClient extends AutoCloseable {
      * @param requestCodec a PBJ codec for requests
      * @param replyCodec a PBJ codec for replies
      * @param pipeline a pipeline for receiving replies
+     * @param metadata metadata to be sent to the service
      */
     <RequestT, ReplyT> GrpcCall<RequestT, ReplyT> createCall(
-            String fullMethodName, Codec<RequestT> requestCodec, Codec<ReplyT> replyCodec, Pipeline<ReplyT> pipeline);
+            String fullMethodName,
+            Codec<RequestT> requestCodec,
+            Codec<ReplyT> replyCodec,
+            Pipeline<ReplyT> pipeline,
+            Map<String, String> metadata);
 
     /**
      * Closes this GrpcClient instance releasing all resources, such as open network connections etc.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
@@ -4,6 +4,7 @@ package com.hedera.pbj.runtime.grpc;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -116,6 +117,26 @@ public interface ServiceInterface extends AutoCloseable {
          */
         default int maxMessageSizeBytes() {
             return DEFAULT_MAX_MESSAGE_SIZE_BYTES;
+        }
+
+        /**
+         * Metadata associated with a request. Key names MUST NOT start with "grpc-" prefix. The metadata is sent
+         * via HTTP2 headers, and the total size of the headers, both system and these custom metadata headers,
+         * is often limited by 8KB. So the metadata mechanism is only suited for passing samll amounts of data.
+         * Also, in HTTP2, header names are usually all-lower-case, so it's strongly recommended to use lower-case
+         * key names in this map.
+         * <p>
+         * A client application can implement this method in a RequestOptions object that it passes to a client
+         * stub constructor, e.g. the GreeterInterface.GreeterClient, or its service call methods that accept
+         * the additional RequestOptions argument.
+         * <p>
+         * A server application can access the client's metadata using the RequestOptions parameter passed to the
+         * ServiceInterface stub methods.
+         *
+         * @return an immutable, non-null, but possibly empty Map to access metadata values using their keys
+         */
+        default Map<String, String> metadata() {
+            return Map.of();
         }
     }
 

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PbjGrpcMetadataTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/PbjGrpcMetadataTest.java
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.pbj.grpc.helidon.PbjGrpcServiceConfig;
+import com.hedera.pbj.grpc.helidon.PbjRouting;
+import com.hedera.pbj.grpc.helidon.config.PbjConfig;
+import com.hedera.pbj.integration.grpc.GrpcTestUtils;
+import com.hedera.pbj.integration.grpc.PortsAllocator;
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.grpc.GrpcClient;
+import com.hedera.pbj.runtime.grpc.GrpcCompression;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.webserver.WebServer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import pbj.integration.tests.pbj.integration.tests.GreeterInterface;
+import pbj.integration.tests.pbj.integration.tests.HelloReply;
+import pbj.integration.tests.pbj.integration.tests.HelloRequest;
+
+public class PbjGrpcMetadataTest {
+    private static final String DATA_NAME = "test-greeter-metadata-header-name";
+
+    private static PortsAllocator.Port PORT;
+    private static ServerHandle SERVER;
+    private static GrpcClient GRPC_CLIENT;
+
+    record OptionsWithMetadata(Optional<String> authority, String contentType, Map<String, String> metadata)
+            implements ServiceInterface.RequestOptions {}
+
+    public static class MetadataGreeterService implements GreeterInterface {
+        @Override
+        public HelloReply sayHello(HelloRequest request, RequestOptions requestOptions) {
+            return HelloReply.newBuilder()
+                    .message("Hello " + request.name()
+                            + (requestOptions.metadata().containsKey(DATA_NAME)
+                                    ? (" " + requestOptions.metadata().get(DATA_NAME))
+                                    : ""))
+                    .build();
+        }
+    }
+
+    private record ServerHandle(WebServer server) implements AutoCloseable {
+        @Override
+        public void close() {
+            server.stop();
+        }
+
+        static ServerHandle start(
+                final int port, final ServiceInterface service, final PbjGrpcServiceConfig serviceConfig) {
+            final int maxPayloadSize = 20 * 1024 * 1024;
+            final PbjConfig pbjConfig = PbjConfig.builder()
+                    .name("pbj")
+                    .maxMessageSizeBytes(maxPayloadSize)
+                    .build();
+            return new ServerHandle(WebServer.builder()
+                    .port(port)
+                    .addProtocol(pbjConfig)
+                    .addRouting(PbjRouting.builder().service(service, serviceConfig))
+                    .maxPayloadSize(maxPayloadSize)
+                    .build()
+                    .start());
+        }
+    }
+
+    @BeforeAll
+    static void setup() {
+        final PbjGrpcServiceConfig serviceConfig =
+                new PbjGrpcServiceConfig(GrpcCompression.IDENTITY, Set.of(GrpcCompression.IDENTITY));
+        PORT = GrpcTestUtils.PORTS.acquire();
+        SERVER = ServerHandle.start(PORT.port(), new MetadataGreeterService(), serviceConfig);
+        GRPC_CLIENT = GrpcTestUtils.createGrpcClient(
+                PORT.port(),
+                GrpcTestUtils.PROTO_OPTIONS,
+                GrpcCompression.IDENTITY,
+                Set.of(GrpcCompression.IDENTITY),
+                Codec.DEFAULT_MAX_SIZE,
+                Codec.DEFAULT_MAX_SIZE * 5);
+    }
+
+    @AfterAll
+    static void teardown() {
+        GRPC_CLIENT.close();
+        SERVER.close();
+        PORT.close();
+    }
+
+    @Test
+    void testNoMetadata() {
+        // Use default options, so there's no any metadata
+        GreeterInterface.GreeterClient client =
+                new GreeterInterface.GreeterClient(GRPC_CLIENT, GrpcTestUtils.PROTO_OPTIONS);
+
+        final HelloReply reply =
+                client.sayHello(HelloRequest.newBuilder().name("name").build());
+
+        assertEquals("Hello name", reply.message());
+    }
+
+    @Test
+    void testWithEmptyMetadata() {
+        OptionsWithMetadata options =
+                new OptionsWithMetadata(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC, Map.of());
+        GreeterInterface.GreeterClient client = new GreeterInterface.GreeterClient(GRPC_CLIENT, options);
+
+        final HelloReply reply =
+                client.sayHello(HelloRequest.newBuilder().name("name").build());
+
+        assertEquals("Hello name", reply.message());
+    }
+
+    @Test
+    void testWithRandomMetadata() {
+        OptionsWithMetadata options = new OptionsWithMetadata(
+                Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC, Map.of("random-header", "data"));
+        GreeterInterface.GreeterClient client = new GreeterInterface.GreeterClient(GRPC_CLIENT, options);
+
+        final HelloReply reply =
+                client.sayHello(HelloRequest.newBuilder().name("name").build());
+
+        assertEquals("Hello name", reply.message());
+    }
+
+    @Test
+    void testWithTestMetadata() {
+        OptionsWithMetadata options = new OptionsWithMetadata(
+                Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC, Map.of(DATA_NAME, "the data"));
+        GreeterInterface.GreeterClient client = new GreeterInterface.GreeterClient(GRPC_CLIENT, options);
+
+        final HelloReply reply =
+                client.sayHello(HelloRequest.newBuilder().name("name").build());
+
+        assertEquals("Hello name the data", reply.message());
+    }
+
+    @Test
+    void testWithTestMetadataPerRequest() {
+        GreeterInterface.GreeterClient client =
+                new GreeterInterface.GreeterClient(GRPC_CLIENT, GrpcTestUtils.PROTO_OPTIONS);
+
+        OptionsWithMetadata options = new OptionsWithMetadata(
+                Optional.empty(),
+                ServiceInterface.RequestOptions.APPLICATION_GRPC,
+                Map.of(DATA_NAME, "per-request data"));
+        final HelloReply reply =
+                client.sayHello(HelloRequest.newBuilder().name("name").build(), options);
+
+        assertEquals("Hello name per-request data", reply.message());
+    }
+}


### PR DESCRIPTION
**Description**:
Adding support for passing GRPC metadata from a PBJ GRPC Client to a service and accessing the metadata in a PBJ GRPC Service implementation. Key changes:
* `Map<String, String> ServiceInterface.RequestOptions.metadata()` to hold the metadata
* `ServiceInterface.*` service methods have overridden versions with the additional `RequestOptions` argument added. Their default implementations delegate to the versions of the methods w/o the `RequestOptions` argument. While the latter legacy methods also have default implementations that throw `UnsupportedOperationException`. This way, the interface change is backward-compatible and existing services don't need to change, until/unless they want to start accessing the metadata.
* Client stub uses its instance `RequestOptions` object, and also supports the newly introduced overridden versions that accept per-request `RequestOptions` objects. So the client is free to either create new stubs for new metadata, or simply pass a new `RequestOptions` instance to a service call method.
* A new integration test is added to demonstrate and verify the behavior.

Excerpts from the generated `GreeterInterface.java` for the unary method (streaming methods have similar changes):
```java
public interface GreeterInterface extends ServiceInterface {
    /** sayHello */
    @NonNull
    default HelloReply sayHello(@NonNull final HelloRequest request, @NonNull final RequestOptions requestOptions) {
        return sayHello(request);
    }
    
    /** sayHello */
    @NonNull
    default HelloReply sayHello(@NonNull final HelloRequest request) {
        throw new UnsupportedOperationException("unimplemented");
    }

    public class GreeterClient implements GreeterInterface {
        private final RequestOptions requestOptions;

        @Override
        @NonNull
        public HelloReply sayHello(@NonNull final HelloRequest request) {
            return sayHello(request, this.requestOptions);
        }
        
        @Override
        @NonNull
        public HelloReply sayHello(@NonNull final HelloRequest request, @NonNull final RequestOptions requestOptions) {
            // ...
        }
    }
}
```

See the new integration test for usage example.


**Related issue(s)**:

Fixes #765

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
