### PR TITLE
fix: replace Level.Invocation with Level.Trial

### DIFF
--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/PbjGrpcBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/PbjGrpcBench.java
@@ -125,12 +125,12 @@ public class PbjGrpcBench {
             client = createClient(port.port(), splitEncodings);
         }
 
-        @Setup(Level.Invocation)
+        @Setup(Level.Trial)
         public void setup() {
             setup(1);
         }
 
-        @TearDown(Level.Invocation)
+        @TearDown(Level.Trial)
         public void tearDown() {
             try {
                 client.close();
@@ -181,12 +181,12 @@ public class PbjGrpcBench {
             client = createClient(port.port(), splitEncodings);
         }
 
-        @Setup(Level.Invocation)
+        @Setup(Level.Trial)
         public void setup() {
             setup(streamCount);
         }
 
-        @TearDown(Level.Invocation)
+        @TearDown(Level.Trial)
         public void tearDown() {
             try {
                 client.close();

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/block/TestBlockGrpcBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/block/TestBlockGrpcBench.java
@@ -10,8 +10,8 @@ import com.hedera.pbj.integration.jmh.grpc.PbjGrpcBench;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.grpc.GrpcClient;
 import com.hedera.pbj.runtime.grpc.Pipeline;
+import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.SocketException;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow;
@@ -97,7 +97,7 @@ public class TestBlockGrpcBench {
         PbjGrpcBench.ServerHandle server;
         TestBlockStreamerInterface.TestBlockStreamerClient client;
 
-        @Setup(Level.Invocation)
+        @Setup(Level.Trial)
         public void setup() {
             final String[] splitEncodings = encodings.split(",");
             final PbjGrpcServiceConfig serviceConfig =
@@ -108,7 +108,7 @@ public class TestBlockGrpcBench {
             client = createClient(port.port(), splitEncodings);
         }
 
-        @TearDown(Level.Invocation)
+        @TearDown(Level.Trial)
         public void tearDown() {
             try {
                 client.close();
@@ -166,9 +166,10 @@ public class TestBlockGrpcBench {
                 public void onError(Throwable throwable) {
                     latch.countDown();
                     if (throwable instanceof UncheckedIOException uioe
-                            && uioe.getCause() instanceof SocketException se
-                            && se.getMessage() != null
-                            && se.getMessage().contains("Socket closed")) {
+                            && uioe.getCause() instanceof IOException ioe
+                            && ioe.getMessage() != null
+                            // We create this message in PbjGrpcCall. It's not localized. So the check is good:
+                            && ioe.getMessage().contains("sendPing failed")) {
                         // A streaming server may close its connection sometimes before
                         // the client has received and processed all the replies. However, the client's
                         // PbjGrpcCall may try and ping the server during the processing. This results in

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GoogleGrpcBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/grpc/google/GoogleGrpcBench.java
@@ -101,12 +101,12 @@ public class GoogleGrpcBench {
             client = ClientHandle.createClient(port.port());
         }
 
-        @Setup(Level.Invocation)
+        @Setup(Level.Trial)
         public void setup() {
             setup(1);
         }
 
-        @TearDown(Level.Invocation)
+        @TearDown(Level.Trial)
         public void tearDown() {
             client.close();
             client = null;
@@ -135,12 +135,12 @@ public class GoogleGrpcBench {
             client = ClientHandle.createClient(port.port());
         }
 
-        @Setup(Level.Invocation)
+        @Setup(Level.Trial)
         public void setup() {
             setup(streamCount);
         }
 
-        @TearDown(Level.Invocation)
+        @TearDown(Level.Trial)
         public void tearDown() {
             client.close();
             client = null;


### PR DESCRIPTION
**Description**:
We used the `Level.Invocation` in a few GRPC-related benchmarks due to bugs in Helidon which led to connection drops and hence required us to recreate server/client instances on every invocation.

We've fixed the bug on PBJ side with https://github.com/hashgraph/pbj/pull/763 , so we should be able to use the more optimal `Level.Trial` now.

**Related issue(s)**:

Fixes #777 

**Notes for reviewer**:
The modified benchmarks run and don't fail.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
