### PR TITLE
feat: introduce MemoryData

### DIFF
--- a/pbj-core/hiero-dependency-versions/build.gradle.kts
+++ b/pbj-core/hiero-dependency-versions/build.gradle.kts
@@ -79,5 +79,5 @@ dependencies.constraints {
     api("io.helidon.webclient:helidon-webclient-http2:$helidon") {
         because("io.helidon.webclient.http2")
     }
-    api("com.github.luben:zstd-jni:1.5.7-7") { because("com.github.luben.zstd") }
+    api("com.github.luben:zstd-jni:1.5.7-7") { because("com.github.luben.zstd_jni") }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.security.MessageDigest;
+
+/// A buffer backed by a MemorySegment. It is a [BufferedSequentialData] (and therefore contains
+/// a "position" cursor into the data), a [ReadableSequentialData] (and therefore can be read from),
+/// a [WritableSequentialData] (and therefore can be written to), and a [RandomAccessData]
+/// (and therefore can be accessed at any position).
+///
+/// This class implements all the same APIs and interfaces that the BufferedData does, and it is a drop-in
+/// replacement for the latter. Applications should use interfaces that this class implements instead of using
+/// a concrete implementation type.
+public final class MemoryData
+        implements BufferedSequentialData, ReadableSequentialData, WritableSequentialData, RandomAccessData {
+    // --------------------------------------------------------------
+    // INTERNAL STATE
+
+    /// The backing MemorySegment
+    private final MemorySegment segment;
+
+    /// The current read/write position.
+    private long position = 0;
+
+    /// The current limit (aka max position to read/write at.)
+    private long limit;
+
+    // --------------------------------------------------------------
+    // FACTORY METHODS AND CONSTRUCTOR
+
+    /// Wraps an external MemorySegment of any kind (heap, native, mapped, etc.).
+    @NonNull
+    public static MemoryData wrap(@NonNull final MemorySegment segment) {
+        return new MemoryData(segment);
+    }
+
+    /// Wraps an external byte array. Applications are responsible for not modifying the content of the array
+    /// directly after this method is called.
+    @NonNull
+    public static MemoryData wrap(@NonNull final byte[] array) {
+        return new MemoryData(MemorySegment.ofArray(array));
+    }
+
+    /// Wraps a slice of an external byte array. Applications are responsible for not modifying the content of the array
+    /// directly after this method is called.
+    @NonNull
+    public static MemoryData wrap(@NonNull final byte[] array, final int offset, final int len) {
+        final MemorySegment ms1 = MemorySegment.ofArray(array);
+        final MemorySegment ms2 = ms1.asSlice(offset, len);
+        return new MemoryData(MemorySegment.ofArray(array).asSlice(offset, len));
+    }
+
+    /// Wraps a slice of an external ByteBuffer respecting its current position/limit.
+    /// Applications are responsible for not modifying the content of the ByteBuffer
+    /// directly after this method is called.
+    @NonNull
+    public static MemoryData wrap(@NonNull final ByteBuffer buffer) {
+        return new MemoryData(MemorySegment.ofBuffer(buffer));
+    }
+
+    /// Allocates a new byte[] in heap and wraps it.
+    @NonNull
+    public static MemoryData allocate(final int size) {
+        return new MemoryData(MemorySegment.ofArray(new byte[size]));
+    }
+
+    /// Convenience method to allocate a new native segment in a new auto Arena.
+    /// In most cases, applications would want to use a custom Arena to manage the life-cycle
+    /// of their MemorySegment instances more precisely, and then use the
+    /// `MemoryData.wrap(MemorySegment)` factory method instead of this one.
+    @NonNull
+    public static MemoryData allocateOffHeap(final int size) {
+        return new MemoryData(Arena.ofAuto().allocate(size));
+    }
+
+    private MemoryData(@NonNull final MemorySegment segment) {
+        this.segment = segment;
+        this.limit = segment.byteSize();
+    }
+
+    // --------------------------------------------------------------
+    // Object
+
+    /// toString that outputs data in buffer in bytes.
+    /// @return nice debug output of buffer contents
+    @Override
+    public String toString() {
+        // build string
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getSimpleName());
+        sb.append("[");
+        for (int i = 0; i < limit; i++) {
+            int v = segment.get(ValueLayout.JAVA_BYTE, i) & 0xFF;
+            sb.append(v);
+            if (i < (limit - 1)) sb.append(',');
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    // --------------------------------------------------------------
+    // SequentialData
+
+    @Override
+    public long capacity() {
+        return segment.byteSize();
+    }
+
+    @Override
+    public long position() {
+        return position;
+    }
+
+    @Override
+    public long limit() {
+        return limit;
+    }
+
+    @Override
+    public void limit(final long limit) {
+        this.limit = Math.clamp(limit, position(), capacity());
+    }
+
+    @Override
+    public void skip(final long count) {
+        if (count > remaining()) {
+            throw new BufferUnderflowException();
+        }
+        if (count <= 0) {
+            return;
+        }
+        position += count;
+    }
+
+    // --------------------------------------------------------------
+    // BufferedSequentialData
+
+    @Override
+    public void position(long position) {
+        if (position > capacity()) {
+            throw new BufferUnderflowException();
+        }
+        if (position < 0) {
+            throw new IllegalArgumentException("position cannot be negative, got " + position);
+        }
+        this.position = position;
+    }
+
+    @Override
+    public void flip() {
+        limit = position;
+        position = 0;
+    }
+
+    @Override
+    public void reset() {
+        limit = capacity();
+        position = 0;
+    }
+
+    @Override
+    public void resetPosition() {
+        position = 0;
+    }
+
+    // --------------------------------------------------------------
+    // ReadableSequentialData
+
+    @Override
+    public byte readByte() throws BufferUnderflowException {
+        if (position >= limit) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(ValueLayout.JAVA_BYTE, position++);
+    }
+
+    @NonNull
+    @Override
+    public MemoryData view(final int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("Length cannot be negative");
+        }
+
+        if (length > remaining()) {
+            throw new BufferUnderflowException();
+        }
+
+        final var pos = Math.toIntExact(position());
+        final var buf = slice(pos, length);
+        position((long) pos + length);
+        return buf;
+    }
+
+    @NonNull
+    @Override // to match BufferedData semantics and return Bytes.EMPTY
+    public Bytes readBytes(final int length) {
+        if (length < 0) throw new IllegalArgumentException("Length cannot be negative");
+        if (length == 0) return Bytes.EMPTY;
+        if (remaining() < length) throw new BufferUnderflowException();
+
+        final var bytes = getBytes(position(), length);
+        position = position + length;
+        return bytes;
+    }
+
+    // --------------------------------------------------------------
+    // WritableSequentialData
+
+    @Override
+    public void writeByte(final byte b) throws BufferOverflowException {
+        if (position >= limit) {
+            throw new BufferOverflowException();
+        }
+        segment.set(ValueLayout.JAVA_BYTE, position++, b);
+    }
+
+    // --------------------------------------------------------------
+    // RandomAccessData
+
+    @Override
+    public long length() {
+        return limit;
+    }
+
+    @Override
+    public byte getByte(final long offset) {
+        if (offset >= limit) {
+            throw new BufferUnderflowException();
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset cannot be negative, got " + offset);
+        }
+        return segment.get(ValueLayout.JAVA_BYTE, offset);
+    }
+
+    @Override // to follow BufferedData semantics and not modify the dst position
+    public long getBytes(final long offset, @NonNull final ByteBuffer dst) {
+        final var len = Math.min(dst.remaining(), length() - offset);
+        dst.put(dst.position(), segment.asByteBuffer(), Math.toIntExact(offset), Math.toIntExact(len));
+        return len;
+    }
+
+    @Override // to follow BufferedData semantics and not modify the dst position
+    public long getBytes(final long offset, @NonNull final BufferedData dst) {
+        final var len = Math.min(dst.remaining(), length() - offset);
+        dst.buffer.put(dst.buffer.position(), segment.asByteBuffer(), Math.toIntExact(offset), Math.toIntExact(len));
+        return len;
+    }
+
+    @Override
+    @NonNull
+    public MemoryData slice(final long offset, final long length) {
+        return MemoryData.wrap(segment.asSlice(offset, length));
+    }
+
+    @Override
+    public void writeTo(@NonNull OutputStream outStream) {
+        try {
+            final WritableByteChannel channel = Channels.newChannel(outStream);
+            channel.write(segment.asByteBuffer().limit(Math.toIntExact(limit)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void writeTo(@NonNull OutputStream outStream, int offset, int length) {
+        if (offset > limit - length) {
+            throw new BufferUnderflowException();
+        }
+        if (offset < 0 || length < 0) {
+            throw new IllegalArgumentException("offset/length cannot be negative, got " + offset + "/" + length);
+        }
+        try {
+            final WritableByteChannel channel = Channels.newChannel(outStream);
+            channel.write(segment.asByteBuffer().position(offset).limit(Math.toIntExact(offset + length)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void writeTo(@NonNull MessageDigest digest) {
+        digest.update(segment.asByteBuffer().limit(Math.toIntExact(limit)));
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
@@ -59,8 +59,6 @@ public final class MemoryData
     /// directly after this method is called.
     @NonNull
     public static MemoryData wrap(@NonNull final byte[] array, final int offset, final int len) {
-        final MemorySegment ms1 = MemorySegment.ofArray(array);
-        final MemorySegment ms2 = ms1.asSlice(offset, len);
         return new MemoryData(MemorySegment.ofArray(array).asSlice(offset, len));
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTest.java
@@ -4,7 +4,7 @@ package com.hedera.pbj.runtime.io.buffer;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
 
-final class BufferedDataTest extends BufferedDataTestBase {
+final class BufferedDataTest extends BufferedDataTestBase<BufferedData> {
 
     @NonNull
     @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.ReadableSequentialTestBase;
@@ -19,19 +20,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-abstract class BufferedDataTestBase {
+/// A base test class for BufferedData-like objects of type T.
+abstract class BufferedDataTestBase<
+        T extends BufferedSequentialData & ReadableSequentialData & WritableSequentialData & RandomAccessData> {
 
     // FUTURE Test that "view" shows the updated data when it is changed on the fly
     // FUTURE Verify capacity is never negative (it can't be, maybe nothing to test here)
 
     @NonNull
-    protected abstract BufferedData allocate(final int size);
+    protected abstract T allocate(final int size);
 
     @NonNull
-    protected abstract BufferedData wrap(final byte[] arr);
+    protected abstract T wrap(final byte[] arr);
 
     @NonNull
-    protected abstract BufferedData wrap(final byte[] arr, final int offset, final int len);
+    protected abstract T wrap(final byte[] arr, final int offset, final int len);
 
     @Test
     @DisplayName("allocated data length test")
@@ -52,7 +55,16 @@ abstract class BufferedDataTestBase {
     @DisplayName("wrapped data with offset length test")
     void wrapOffsetLength() {
         final var buf = wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7}, 1, 3);
-        assertThat(buf.length()).isEqualTo(4);
+        if (buf instanceof BufferedData) {
+            // FUTURE WORK: There seems to be a bug in BufferedData.length().
+            assertThat(buf.length()).isEqualTo(4);
+        } else if (buf instanceof MemoryData) {
+            // MemorySegment in JDK is strict with sliced views.
+            // And in fact the BufferedData should be too, but currently it isn't.
+            assertThat(buf.length()).isEqualTo(3);
+        } else {
+            fail("Unsupported buffer class: " + buf.getClass().getName());
+        }
     }
 
     @Test
@@ -69,7 +81,7 @@ abstract class BufferedDataTestBase {
         buf.skip(5);
         buf.limit(10);
 
-        assertThat(buf.toString()).endsWith("BufferedData[1,2,3,4,5,6,7,8,9,10]");
+        assertThat(buf.toString()).endsWith("[1,2,3,4,5,6,7,8,9,10]");
 
         assertEquals(5, buf.position());
         assertEquals(10, buf.limit());
@@ -78,16 +90,25 @@ abstract class BufferedDataTestBase {
     @Test
     void toStringWithOffsetAndLen() {
         final var buf = wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 4);
-        // toString() doesn't depend on position, but respects limit
-        assertThat(buf.toString()).endsWith("BufferedData[0,1,2,3,4,5]");
-        buf.limit(10);
-        assertThat(buf.toString()).endsWith("BufferedData[0,1,2,3,4,5,6,7,8,9]");
+        if (buf instanceof BufferedData) {
+            // toString() doesn't depend on position, but respects limit
+            assertThat(buf.toString()).endsWith("[0,1,2,3,4,5]");
+            buf.limit(10);
+            assertThat(buf.toString()).endsWith("[0,1,2,3,4,5,6,7,8,9]");
+        } else if (buf instanceof MemoryData) {
+            // MemorySegment in JDK is strict for sliced views
+            assertThat(buf.toString()).endsWith("[2,3,4,5]");
+            buf.limit(10);
+            assertThat(buf.toString()).endsWith("[2,3,4,5]");
+        } else {
+            fail("Unsupported buffer class: " + buf.getClass().getName());
+        }
     }
 
     @Test
     void toStringWithSlice() {
         final var buf = wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}).slice(2, 4);
-        assertThat(buf.toString()).endsWith("BufferedData[2,3,4,5]");
+        assertThat(buf.toString()).endsWith("[2,3,4,5]");
     }
 
     @ParameterizedTest
@@ -140,7 +161,8 @@ abstract class BufferedDataTestBase {
         buf.writeVarInt(num + 1, false);
         final long afterSecondIntPos = buf.position();
 
-        final var slicedBuf = buf.slice(afterFirstIntPos, afterSecondIntPos - afterFirstIntPos);
+        // ASSUME: every T @Overrides RandomAccessData.slice() to return T instead of Bytes.
+        final var slicedBuf = (T) buf.slice(afterFirstIntPos, afterSecondIntPos - afterFirstIntPos);
         final int readback = slicedBuf.readVarInt(false);
         assertEquals(num + 1, readback);
         assertEquals(afterSecondIntPos - afterFirstIntPos, slicedBuf.position());
@@ -245,7 +267,8 @@ abstract class BufferedDataTestBase {
         buf.writeVarLong(num + 1, false);
         final long afterSecondIntPos = buf.position();
 
-        final var slicedBuf = buf.slice(afterFirstIntPos, afterSecondIntPos - afterFirstIntPos);
+        // ASSUME: every T @Overrides RandomAccessData.slice() to return T instead of Bytes.
+        final var slicedBuf = (T) buf.slice(afterFirstIntPos, afterSecondIntPos - afterFirstIntPos);
         final long readback = slicedBuf.readVarLong(false);
         assertEquals(num + 1, readback);
         assertEquals(afterSecondIntPos - afterFirstIntPos, slicedBuf.position());
@@ -270,7 +293,8 @@ abstract class BufferedDataTestBase {
             assertEquals((byte) i, bytes.getByte(i - START));
         }
 
-        final var slicedBuf = buf.slice(START, LEN);
+        // ASSUME: every T @Overrides RandomAccessData.slice() to return T instead of Bytes.
+        final var slicedBuf = (T) buf.slice(START, LEN);
         final var slicedBytes = slicedBuf.readBytes(LEN);
         assertEquals(LEN, slicedBuf.position());
         for (int i = 0; i < LEN; i++) {
@@ -392,7 +416,7 @@ abstract class BufferedDataTestBase {
         @NonNull
         @Override
         protected byte[] extractWrittenBytes(@NonNull WritableSequentialData seq) {
-            final var buf = (BufferedData) seq;
+            final var buf = (T) seq;
             final var bytes = new byte[Math.toIntExact(buf.position())];
             buf.getBytes(0, bytes);
             return bytes;
@@ -423,7 +447,7 @@ abstract class BufferedDataTestBase {
         @NonNull
         @Override
         protected ReadableSequentialData sequence(@NonNull byte[] arr) {
-            BufferedData buf = allocate(arr.length + 20);
+            T buf = allocate(arr.length + 20);
             for (int i = 0; i < 10; i++) {
                 buf.writeByte((byte) i);
             }
@@ -446,7 +470,8 @@ abstract class BufferedDataTestBase {
         protected ReadableSequentialData emptySequence() {
             final var buf = wrap(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
             buf.position(7);
-            return new RandomAccessSequenceAdapter(buf.view(0));
+            // ASSUME: every T @Overrides ReadableSequentialData.view() to return T instead of ReadableSequentialData.
+            return new RandomAccessSequenceAdapter((T) buf.view(0));
         }
 
         @NonNull
@@ -454,7 +479,8 @@ abstract class BufferedDataTestBase {
         protected ReadableSequentialData fullyUsedSequence() {
             final var buf = wrap(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
             buf.position(2);
-            final var view = buf.view(5);
+            // ASSUME: every T @Overrides ReadableSequentialData.view() to return T instead of ReadableSequentialData.
+            final var view = (T) buf.view(5);
             view.skip(5);
             return new RandomAccessSequenceAdapter(view, 5);
         }
@@ -462,7 +488,7 @@ abstract class BufferedDataTestBase {
         @NonNull
         @Override
         protected ReadableSequentialData sequence(@NonNull byte[] arr) {
-            BufferedData buf = allocate(arr.length + 20);
+            T buf = allocate(arr.length + 20);
             for (int i = 0; i < 10; i++) {
                 buf.writeByte((byte) i);
             }
@@ -473,7 +499,8 @@ abstract class BufferedDataTestBase {
             buf.position(10);
             buf.writeBytes(arr);
             buf.position(10);
-            return new RandomAccessSequenceAdapter(buf.view(arr.length));
+            // ASSUME: every T @Overrides ReadableSequentialData.view() to return T instead of ReadableSequentialData.
+            return new RandomAccessSequenceAdapter((T) buf.view(arr.length));
         }
     }
 
@@ -485,7 +512,8 @@ abstract class BufferedDataTestBase {
             final var mb = 1024 * 1024;
             final var buf = allocate(mb * 4); // the largest expected test value is 1 mb
             buf.position(mb);
-            return buf.view(mb * 2);
+            // ASSUME: every T @Overrides ReadableSequentialData.view() to return T instead of ReadableSequentialData.
+            return (T) buf.view(mb * 2);
         }
 
         @NonNull
@@ -493,13 +521,14 @@ abstract class BufferedDataTestBase {
         protected WritableSequentialData eofSequence() {
             final var buf = wrap(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
             buf.position(7);
-            return buf.view(0);
+            // ASSUME: every T @Overrides ReadableSequentialData.view() to return T instead of ReadableSequentialData.
+            return (T) buf.view(0);
         }
 
         @NonNull
         @Override
         protected byte[] extractWrittenBytes(@NonNull WritableSequentialData seq) {
-            final var buf = (BufferedData) seq;
+            final var buf = (T) seq;
             final var bytes = new byte[Math.toIntExact(buf.position())];
             buf.getBytes(0, bytes);
             return bytes;

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedDataTest.java
@@ -4,7 +4,7 @@ package com.hedera.pbj.runtime.io.buffer;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
 
-final class ByteArrayBufferedDataTest extends BufferedDataTestBase {
+final class ByteArrayBufferedDataTest extends BufferedDataTestBase<BufferedData> {
 
     @NonNull
     @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedDataTest.java
@@ -4,7 +4,7 @@ package com.hedera.pbj.runtime.io.buffer;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
 
-final class DirectBufferedDataTest extends BufferedDataTestBase {
+final class DirectBufferedDataTest extends BufferedDataTestBase<BufferedData> {
 
     @NonNull
     @Override

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/MemoryDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/MemoryDataTest.java
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/// Test for heap MemoryData
+final class MemoryDataTest extends BufferedDataTestBase<MemoryData> {
+
+    @NonNull
+    @Override
+    protected MemoryData allocate(final int size) {
+        return MemoryData.allocate(size);
+    }
+
+    @NonNull
+    @Override
+    protected MemoryData wrap(final byte[] arr) {
+        return MemoryData.wrap(arr);
+    }
+
+    @NonNull
+    @Override
+    protected MemoryData wrap(final byte[] arr, final int offset, final int len) {
+        return MemoryData.wrap(arr, offset, len);
+    }
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/NativeMemoryDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/NativeMemoryDataTest.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/// Test for native MemoryData
+final class NativeMemoryDataTest extends BufferedDataTestBase<MemoryData> {
+
+    @NonNull
+    @Override
+    protected MemoryData allocate(final int size) {
+        return MemoryData.allocateOffHeap(size);
+    }
+
+    @NonNull
+    @Override
+    protected MemoryData wrap(final byte[] arr) {
+        final MemoryData buf = MemoryData.allocateOffHeap(arr.length);
+        buf.writeBytes(arr);
+        buf.reset();
+        return buf;
+    }
+
+    @NonNull
+    @Override
+    protected MemoryData wrap(byte[] arr, int offset, int len) {
+        final MemoryData buf = MemoryData.allocateOffHeap(len);
+        buf.writeBytes(arr, offset, len);
+        buf.reset();
+        return buf;
+    }
+}


### PR DESCRIPTION
**Description**:
Introducing the initial implementation of the new `MemoryData` class - an object similar to the `BufferedData`, but backed by a `MemorySegment` rather than a `ByteBuffer`.
This initial implementation supports all the interfaces that the `BufferedData` supports and exposes pretty much the same API. However, currently, no fast-paths exist for more optimal operations. So this initial version isn't production ready yet. Fast-paths will be delivered in future, separate PRs.

See parent story for more details: https://github.com/hashgraph/pbj/issues/767

There's also a one-liner fix in a Gradle script that removes a warning during the build.

**Related issue(s)**:

Fixes #780 

**Notes for reviewer**:
Existing `BufferedData` unit tests have been modified to support the new `MemoryData` object. So the test coverage is identical for both the classes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
