### PR TITLE
perf: fast-paths for MemoryData

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -381,6 +383,16 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     }
 
     /**
+     * A helper method for efficient copy of our data into a MemorySegment starting at a given `position`
+     * without creating a defensive copy of the data or writing each byte one at a time.
+     * @param segment a destination MemorySegment
+     * @param position a position at the destination `segment` to write data at
+     */
+    public void writeTo(@NonNull MemorySegment segment, final long position) {
+        MemorySegment.copy(buffer, start, segment, ValueLayout.JAVA_BYTE, position, length);
+    }
+
+    /**
      * A helper method for efficient copy of our data into an MessageDigest without creating a defensive copy
      * of the data. The implementation relies on a well-behaved MessageDigest that doesn't modify the buffer data.
      * The destination object may receive a direct reference to the underlying byte array, and it MUST NOT modify it.
@@ -493,6 +505,15 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
                 }
             }
         };
+    }
+
+    /**
+     * Exposes this {@link Bytes} as a read-only {@link MemorySegment}. This is a zero-copy operation.
+     *
+     * @return a read-only on-heap MemorySegment mapping this Bytes' content
+     */
+    public MemorySegment toMemorySegment() {
+        return MemorySegment.ofArray(buffer).asSlice(start, length).asReadOnly();
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
@@ -256,6 +256,7 @@ public final class MemoryData
         // MemorySegment.ofBuffer() captures the current position/limit of the buffer, so dstOffset is 0:
         MemorySegment.copy(segment, position, MemorySegment.ofBuffer(dst), 0, length);
         position += length;
+        dst.position(Math.toIntExact(dst.position() + length));
         return length;
     }
 
@@ -268,6 +269,7 @@ public final class MemoryData
         // MemorySegment.ofBuffer() captures the current position/limit of the buffer, so dstOffset is 0:
         MemorySegment.copy(segment, position, MemorySegment.ofBuffer(dst.buffer), 0, length);
         position += length;
+        dst.position(Math.toIntExact(dst.position() + length));
         return length;
     }
 
@@ -404,6 +406,7 @@ public final class MemoryData
 
         MemorySegment.copy(MemorySegment.ofBuffer(src), 0, segment, position, srcRemaining);
         position += srcRemaining;
+        src.position(src.position() + srcRemaining);
     }
 
     @Override
@@ -415,6 +418,7 @@ public final class MemoryData
 
         MemorySegment.copy(MemorySegment.ofBuffer(src.buffer), 0, segment, position, srcRemaining);
         position += srcRemaining;
+        src.position(src.position() + srcRemaining);
     }
 
     @Override
@@ -426,10 +430,10 @@ public final class MemoryData
             buf.writeTo(segment, position);
             position += buf.length();
         } else if (src instanceof MemoryData md) {
-            if ((limit() - position()) < md.segment.byteSize()) {
+            if ((limit() - position()) < md.length()) {
                 throw new BufferOverflowException();
             }
-            MemorySegment.copy(md.segment, 0, segment, position, md.segment.byteSize());
+            MemorySegment.copy(md.segment, 0, segment, position, md.length());
             position += md.segment.byteSize();
         } else {
             WritableSequentialData.super.writeBytes(src);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
@@ -434,7 +434,7 @@ public final class MemoryData
                 throw new BufferOverflowException();
             }
             MemorySegment.copy(md.segment, 0, segment, position, md.length());
-            position += md.segment.byteSize();
+            position += md.length();
         } else {
             WritableSequentialData.super.writeBytes(src);
         }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
@@ -5,6 +5,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.lang.foreign.Arena;
@@ -13,9 +14,12 @@ import java.lang.foreign.ValueLayout;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.security.MessageDigest;
+import java.util.Objects;
+import java.util.Optional;
 
 /// A buffer backed by a MemorySegment. It is a [BufferedSequentialData] (and therefore contains
 /// a "position" cursor into the data), a [ReadableSequentialData] (and therefore can be read from),
@@ -27,6 +31,40 @@ import java.security.MessageDigest;
 /// a concrete implementation type.
 public final class MemoryData
         implements BufferedSequentialData, ReadableSequentialData, WritableSequentialData, RandomAccessData {
+    // --------------------------------------------------------------
+    // CONSTANTS
+    private static final ValueLayout.OfInt JAVA_INT_BIG_ENDIAN = ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfInt JAVA_INT_BIG_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfInt JAVA_INT_LITTLE_ENDIAN =
+            ValueLayout.JAVA_INT.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfInt JAVA_INT_LITTLE_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfLong JAVA_LONG_BIG_ENDIAN =
+            ValueLayout.JAVA_LONG.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfLong JAVA_LONG_BIG_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfLong JAVA_LONG_LITTLE_ENDIAN =
+            ValueLayout.JAVA_LONG.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfLong JAVA_LONG_LITTLE_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfFloat JAVA_FLOAT_BIG_ENDIAN =
+            ValueLayout.JAVA_FLOAT.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfFloat JAVA_FLOAT_BIG_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfFloat JAVA_FLOAT_LITTLE_ENDIAN =
+            ValueLayout.JAVA_FLOAT.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfFloat JAVA_FLOAT_LITTLE_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfDouble JAVA_DOUBLE_BIG_ENDIAN =
+            ValueLayout.JAVA_DOUBLE.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfDouble JAVA_DOUBLE_BIG_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_DOUBLE_UNALIGNED.withOrder(ByteOrder.BIG_ENDIAN);
+    private static final ValueLayout.OfDouble JAVA_DOUBLE_LITTLE_ENDIAN =
+            ValueLayout.JAVA_DOUBLE.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfDouble JAVA_DOUBLE_LITTLE_ENDIAN_UNALIGNED =
+            ValueLayout.JAVA_DOUBLE_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
     // --------------------------------------------------------------
     // INTERNAL STATE
 
@@ -186,6 +224,53 @@ public final class MemoryData
         return segment.get(ValueLayout.JAVA_BYTE, position++);
     }
 
+    @Override
+    public int readUnsignedByte() throws BufferUnderflowException {
+        if (position >= limit) {
+            throw new BufferUnderflowException();
+        }
+        return Byte.toUnsignedInt(segment.get(ValueLayout.JAVA_BYTE, position++));
+    }
+
+    @Override
+    public long readBytes(@NonNull final byte[] dst, final int offset, final int maxLength)
+            throws UncheckedIOException {
+        if (maxLength < 0) {
+            throw new IllegalArgumentException("Negative maxLength not allowed");
+        }
+        final int length = Math.min(maxLength, Math.toIntExact(remaining()));
+        if (length == 0) {
+            return 0;
+        }
+        MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, position, dst, offset, length);
+        position += length;
+        return length;
+    }
+
+    @Override
+    public long readBytes(@NonNull final ByteBuffer dst) throws UncheckedIOException {
+        final var length = Math.min(dst.remaining(), remaining());
+        if (length == 0) {
+            return 0;
+        }
+        // MemorySegment.ofBuffer() captures the current position/limit of the buffer, so dstOffset is 0:
+        MemorySegment.copy(segment, position, MemorySegment.ofBuffer(dst), 0, length);
+        position += length;
+        return length;
+    }
+
+    @Override
+    public long readBytes(@NonNull final BufferedData dst) throws UncheckedIOException {
+        final var length = Math.min(dst.remaining(), remaining());
+        if (length == 0) {
+            return 0;
+        }
+        // MemorySegment.ofBuffer() captures the current position/limit of the buffer, so dstOffset is 0:
+        MemorySegment.copy(segment, position, MemorySegment.ofBuffer(dst.buffer), 0, length);
+        position += length;
+        return length;
+    }
+
     @NonNull
     @Override
     public MemoryData view(final int length) {
@@ -215,6 +300,46 @@ public final class MemoryData
         return bytes;
     }
 
+    @Override
+    public int readInt() throws BufferUnderflowException {
+        if (remaining() < Integer.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        final int num = segment.get(determineIntLayout(ByteOrder.BIG_ENDIAN, position), position);
+        position += Integer.BYTES;
+        return num;
+    }
+
+    @Override
+    public int readInt(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException {
+        if (remaining() < Integer.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        final int num = segment.get(determineIntLayout(byteOrder, position), position);
+        position += Integer.BYTES;
+        return num;
+    }
+
+    @Override
+    public long readLong() throws BufferUnderflowException, UncheckedIOException {
+        if (remaining() < Long.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        final long num = segment.get(determineLongLayout(ByteOrder.BIG_ENDIAN, position), position);
+        position += Long.BYTES;
+        return num;
+    }
+
+    @Override
+    public long readLong(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException {
+        if (remaining() < Long.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        final long num = segment.get(determineLongLayout(byteOrder, position), position);
+        position += Long.BYTES;
+        return num;
+    }
+
     // --------------------------------------------------------------
     // WritableSequentialData
 
@@ -224,6 +349,209 @@ public final class MemoryData
             throw new BufferOverflowException();
         }
         segment.set(ValueLayout.JAVA_BYTE, position++, b);
+    }
+
+    @Override
+    public void writeByte2(byte b1, byte b2) {
+        if (remaining() < 2) {
+            throw new BufferOverflowException();
+        }
+        segment.set(ValueLayout.JAVA_BYTE, position++, b1);
+        segment.set(ValueLayout.JAVA_BYTE, position++, b2);
+    }
+
+    @Override
+    public void writeByte3(byte b1, byte b2, byte b3) {
+        if (remaining() < 3) {
+            throw new BufferOverflowException();
+        }
+        segment.set(ValueLayout.JAVA_BYTE, position++, b1);
+        segment.set(ValueLayout.JAVA_BYTE, position++, b2);
+        segment.set(ValueLayout.JAVA_BYTE, position++, b3);
+    }
+
+    @Override
+    public void writeByte4(byte b1, byte b2, byte b3, byte b4) {
+        if (remaining() < 4) {
+            throw new BufferOverflowException();
+        }
+        segment.set(ValueLayout.JAVA_BYTE, position++, b1);
+        segment.set(ValueLayout.JAVA_BYTE, position++, b2);
+        segment.set(ValueLayout.JAVA_BYTE, position++, b3);
+        segment.set(ValueLayout.JAVA_BYTE, position++, b4);
+    }
+
+    @Override
+    public void writeBytes(@NonNull final byte[] src, final int offset, final int length)
+            throws BufferOverflowException, UncheckedIOException {
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be >= 0");
+        }
+        if (remaining() < length) {
+            throw new BufferOverflowException();
+        }
+
+        MemorySegment.copy(MemorySegment.ofArray(src), offset, segment, position, length);
+        position += length;
+    }
+
+    @Override
+    public void writeBytes(@NonNull final ByteBuffer src) throws BufferOverflowException, UncheckedIOException {
+        final int srcRemaining = src.remaining();
+        if (remaining() < srcRemaining) {
+            throw new BufferOverflowException();
+        }
+
+        MemorySegment.copy(MemorySegment.ofBuffer(src), 0, segment, position, srcRemaining);
+        position += srcRemaining;
+    }
+
+    @Override
+    public void writeBytes(@NonNull final BufferedData src) throws BufferOverflowException, UncheckedIOException {
+        final long srcRemaining = src.remaining();
+        if (remaining() < srcRemaining) {
+            throw new BufferOverflowException();
+        }
+
+        MemorySegment.copy(MemorySegment.ofBuffer(src.buffer), 0, segment, position, srcRemaining);
+        position += srcRemaining;
+    }
+
+    @Override
+    public void writeBytes(@NonNull final RandomAccessData src) throws BufferOverflowException, UncheckedIOException {
+        if (src instanceof Bytes buf) {
+            if ((limit() - position()) < src.length()) {
+                throw new BufferOverflowException();
+            }
+            buf.writeTo(segment, position);
+            position += buf.length();
+        } else if (src instanceof MemoryData md) {
+            if ((limit() - position()) < md.segment.byteSize()) {
+                throw new BufferOverflowException();
+            }
+            MemorySegment.copy(md.segment, 0, segment, position, md.segment.byteSize());
+            position += md.segment.byteSize();
+        } else {
+            WritableSequentialData.super.writeBytes(src);
+        }
+    }
+
+    @Override
+    public int writeBytes(@NonNull final InputStream src, final int maxLength) {
+        if (segment.heapBase().isPresent() && segment.heapBase().get() instanceof byte[] array) {
+            Objects.requireNonNull(src);
+            if (maxLength < 0) {
+                throw new IllegalArgumentException("The length must be >= 0");
+            }
+
+            // If the length is zero, then we have nothing to read
+            if (maxLength == 0) {
+                return 0;
+            }
+
+            // We are going to read from the input stream up to either "len" or the number of bytes
+            // remaining in this DataOutput, whichever is lesser.
+            final long numBytesToRead = Math.min(maxLength, remaining());
+            if (numBytesToRead == 0) {
+                return 0;
+            }
+
+            try {
+                int totalBytesRead = 0;
+                while (totalBytesRead < numBytesToRead) {
+                    int bytesRead = src.read(
+                            array,
+                            Math.toIntExact(segment.address() + position),
+                            (int) numBytesToRead - totalBytesRead);
+                    if (bytesRead == -1) {
+                        return totalBytesRead;
+                    }
+                    position += bytesRead;
+                    totalBytesRead += bytesRead;
+                }
+                return totalBytesRead;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        } else {
+            return WritableSequentialData.super.writeBytes(src, maxLength);
+        }
+    }
+
+    @Override
+    public void writeInt(final int value) throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Integer.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineIntLayout(ByteOrder.BIG_ENDIAN, position), position, value);
+        position += Integer.BYTES;
+    }
+
+    @Override
+    public void writeInt(final int value, @NonNull final ByteOrder byteOrder)
+            throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Integer.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineIntLayout(byteOrder, position), position, value);
+        position += Integer.BYTES;
+    }
+
+    @Override
+    public void writeLong(final long value) throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Long.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineLongLayout(ByteOrder.BIG_ENDIAN, position), position, value);
+        position += Long.BYTES;
+    }
+
+    @Override
+    public void writeLong(final long value, @NonNull final ByteOrder byteOrder)
+            throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Long.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineLongLayout(byteOrder, position), position, value);
+        position += Long.BYTES;
+    }
+
+    @Override
+    public void writeFloat(final float value) throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Float.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineFloatLayout(ByteOrder.BIG_ENDIAN, position), position, value);
+        position += Float.BYTES;
+    }
+
+    @Override
+    public void writeFloat(final float value, @NonNull final ByteOrder byteOrder)
+            throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Float.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineFloatLayout(byteOrder, position), position, value);
+        position += Float.BYTES;
+    }
+
+    @Override
+    public void writeDouble(final double value) throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Double.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineDoubleLayout(ByteOrder.BIG_ENDIAN, position), position, value);
+        position += Double.BYTES;
+    }
+
+    @Override
+    public void writeDouble(final double value, @NonNull final ByteOrder byteOrder)
+            throws BufferOverflowException, UncheckedIOException {
+        if (remaining() < Double.BYTES) {
+            throw new BufferOverflowException();
+        }
+        segment.set(determineDoubleLayout(byteOrder, position), position, value);
+        position += Double.BYTES;
     }
 
     // --------------------------------------------------------------
@@ -243,6 +571,23 @@ public final class MemoryData
             throw new IllegalArgumentException("offset cannot be negative, got " + offset);
         }
         return segment.get(ValueLayout.JAVA_BYTE, offset);
+    }
+
+    @Override
+    public long getBytes(final long offset, @NonNull final byte[] dst, final int dstOffset, final int maxLength) {
+        if (maxLength < 0) {
+            throw new IllegalArgumentException("Negative maxLength not allowed");
+        }
+
+        final var len = Math.min(maxLength, length() - offset);
+
+        final Optional<Object> heapBaseOptional = segment.heapBase();
+        if (heapBaseOptional.isPresent() && heapBaseOptional.get() instanceof byte[] array) {
+            System.arraycopy(array, Math.toIntExact(segment.address() + offset), dst, dstOffset, Math.toIntExact(len));
+        } else {
+            MemorySegment.copy(segment, offset, MemorySegment.ofArray(dst).asSlice(dstOffset, len), 0, len);
+        }
+        return len;
     }
 
     @Override // to follow BufferedData semantics and not modify the dst position
@@ -294,5 +639,177 @@ public final class MemoryData
     @Override
     public void writeTo(@NonNull MessageDigest digest) {
         digest.update(segment.asByteBuffer().limit(Math.toIntExact(limit)));
+    }
+
+    @Override
+    public int getInt(final long offset) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Integer.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineIntLayout(ByteOrder.BIG_ENDIAN, offset), offset);
+    }
+
+    @Override
+    public int getInt(final long offset, @NonNull final ByteOrder byteOrder) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Integer.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineIntLayout(byteOrder, offset), offset);
+    }
+
+    @Override
+    public long getLong(final long offset) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Long.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineLongLayout(ByteOrder.BIG_ENDIAN, offset), offset);
+    }
+
+    @Override
+    public long getLong(final long offset, @NonNull final ByteOrder byteOrder) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Long.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineLongLayout(byteOrder, offset), offset);
+    }
+
+    @Override
+    public float getFloat(final long offset) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Float.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineFloatLayout(ByteOrder.BIG_ENDIAN, offset), offset);
+    }
+
+    @Override
+    public float getFloat(final long offset, @NonNull final ByteOrder byteOrder) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Float.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineFloatLayout(byteOrder, offset), offset);
+    }
+
+    @Override
+    public double getDouble(final long offset) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Double.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineDoubleLayout(ByteOrder.BIG_ENDIAN, offset), offset);
+    }
+
+    @Override
+    public double getDouble(final long offset, @NonNull final ByteOrder byteOrder) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Double.BYTES) {
+            throw new BufferUnderflowException();
+        }
+        return segment.get(determineDoubleLayout(byteOrder, offset), offset);
+    }
+
+    @Override
+    public boolean contains(final long offset, @NonNull final byte[] bytes) {
+        checkOffset(offset, length());
+        if (length() - offset < bytes.length) {
+            return false;
+        }
+        return MemorySegment.mismatch(
+                        segment, offset, offset + bytes.length, MemorySegment.ofArray(bytes), 0, bytes.length)
+                == -1;
+    }
+
+    @Override
+    public boolean contains(final long offset, @NonNull final RandomAccessData data) {
+        if (length() == 0) {
+            return data.length() == 0;
+        }
+
+        checkOffset(offset, length());
+
+        if (length() - offset < data.length()) {
+            return false;
+        }
+
+        return switch (data) {
+            case MemoryData otherData -> {
+                final int dataLength = Math.toIntExact(data.length());
+                yield MemorySegment.mismatch(segment, offset, offset + dataLength, otherData.segment, 0, dataLength)
+                        == -1;
+            }
+            case BufferedData bd -> {
+                final int dataLength = Math.toIntExact(data.length());
+                yield MemorySegment.mismatch(
+                                segment, offset, offset + dataLength, MemorySegment.ofBuffer(bd.buffer), 0, dataLength)
+                        == -1;
+            }
+            case Bytes bytes -> {
+                final int dataLength = Math.toIntExact(data.length());
+                yield MemorySegment.mismatch(
+                                segment, offset, offset + dataLength, bytes.toMemorySegment(), 0, dataLength)
+                        == -1;
+            }
+            default -> BufferedSequentialData.super.contains(offset, data);
+        };
+    }
+
+    // --------------------------------------------------------------
+    // Utilities
+
+    private ValueLayout.OfInt determineIntLayout(final ByteOrder byteOrder, final long offset) {
+        if (byteOrder == ByteOrder.BIG_ENDIAN) {
+            return segment.maxByteAlignment() >= JAVA_INT_BIG_ENDIAN.byteAlignment()
+                            && ((offset & (Integer.BYTES - 1)) == 0L)
+                    ? JAVA_INT_BIG_ENDIAN
+                    : JAVA_INT_BIG_ENDIAN_UNALIGNED;
+        }
+        return segment.maxByteAlignment() >= JAVA_INT_LITTLE_ENDIAN.byteAlignment()
+                        && ((offset & (Integer.BYTES - 1)) == 0L)
+                ? JAVA_INT_LITTLE_ENDIAN
+                : JAVA_INT_LITTLE_ENDIAN_UNALIGNED;
+    }
+
+    private ValueLayout.OfLong determineLongLayout(final ByteOrder byteOrder, final long offset) {
+        if (byteOrder == ByteOrder.BIG_ENDIAN) {
+            return segment.maxByteAlignment() >= JAVA_LONG_BIG_ENDIAN.byteAlignment()
+                            && ((offset & (Long.BYTES - 1)) == 0L)
+                    ? JAVA_LONG_BIG_ENDIAN
+                    : JAVA_LONG_BIG_ENDIAN_UNALIGNED;
+        }
+        return segment.maxByteAlignment() >= JAVA_LONG_LITTLE_ENDIAN.byteAlignment()
+                        && ((offset & (Long.BYTES - 1)) == 0L)
+                ? JAVA_LONG_LITTLE_ENDIAN
+                : JAVA_LONG_LITTLE_ENDIAN_UNALIGNED;
+    }
+
+    private ValueLayout.OfFloat determineFloatLayout(final ByteOrder byteOrder, final long offset) {
+        if (byteOrder == ByteOrder.BIG_ENDIAN) {
+            return segment.maxByteAlignment() >= JAVA_FLOAT_BIG_ENDIAN.byteAlignment()
+                            && ((offset & (Float.BYTES - 1)) == 0L)
+                    ? JAVA_FLOAT_BIG_ENDIAN
+                    : JAVA_FLOAT_BIG_ENDIAN_UNALIGNED;
+        }
+        return segment.maxByteAlignment() >= JAVA_FLOAT_LITTLE_ENDIAN.byteAlignment()
+                        && ((offset & (Float.BYTES - 1)) == 0L)
+                ? JAVA_FLOAT_LITTLE_ENDIAN
+                : JAVA_FLOAT_LITTLE_ENDIAN_UNALIGNED;
+    }
+
+    private ValueLayout.OfDouble determineDoubleLayout(final ByteOrder byteOrder, final long offset) {
+        if (byteOrder == ByteOrder.BIG_ENDIAN) {
+            return segment.maxByteAlignment() >= JAVA_DOUBLE_BIG_ENDIAN.byteAlignment()
+                            && ((offset & (Double.BYTES - 1)) == 0L)
+                    ? JAVA_DOUBLE_BIG_ENDIAN
+                    : JAVA_DOUBLE_BIG_ENDIAN_UNALIGNED;
+        }
+        return segment.maxByteAlignment() >= JAVA_DOUBLE_LITTLE_ENDIAN.byteAlignment()
+                        && ((offset & (Double.BYTES - 1)) == 0L)
+                ? JAVA_DOUBLE_LITTLE_ENDIAN
+                : JAVA_DOUBLE_LITTLE_ENDIAN_UNALIGNED;
     }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/ReadableStreamingData.java
@@ -222,6 +222,7 @@ public class ReadableStreamingData implements ReadableSequentialData, Closeable 
             if (bytesRead < len) {
                 eof = true;
             }
+            dst.position(dstPos + bytesRead);
             return bytesRead;
         } catch (final IOException e) {
             throw new UncheckedIOException(e);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/stream/WritableStreamingData.java
@@ -238,6 +238,7 @@ public class WritableStreamingData implements WritableSequentialData, Closeable,
         final int len = Math.toIntExact(src.remaining());
         src.writeTo(out, pos, len);
         position += len;
+        src.position(src.position() + len);
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/ReadableSequentialTestBase.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -117,7 +118,23 @@ public abstract class ReadableSequentialTestBase extends ReadableTestBase {
         final var read = stream.readBytes(buf);
         assertEquals(10, read);
         assertThat(stream.position()).isEqualTo(10);
+        assertThat(buf.position()).isEqualTo(10);
         assertThat(buf.asUtf8String()).isEqualTo("0123456789\u0000\u0000");
+        assertThat(stream.hasRemaining()).isFalse();
+        assertThat(stream.remaining()).isZero();
+    }
+
+    @Test
+    @DisplayName("Read past the ByteBuffer - EOF")
+    void readPastEndByteBuffer() {
+        final var stream = sequence("0123456789".getBytes(StandardCharsets.UTF_8));
+        stream.limit(12);
+        final var buf = ByteBuffer.allocate(12);
+        final var read = stream.readBytes(buf);
+        assertEquals(10, read);
+        assertThat(stream.position()).isEqualTo(10);
+        assertThat(buf.position()).isEqualTo(10);
+        assertThat(buf.array()).isEqualTo(new byte[] {48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0});
         assertThat(stream.hasRemaining()).isFalse();
         assertThat(stream.remaining()).isZero();
     }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/WritableTestBase.java
@@ -396,6 +396,7 @@ public abstract class WritableTestBase extends SequentialTestBase {
             // Then the sequence received those bytes and the position is updated
             assertThat(extractWrittenBytes(seq)).isEqualTo(src.array());
             assertThat(seq.position()).isEqualTo(pos + 5);
+            assertThat(src.position()).isEqualTo(5);
         }
 
         @Test
@@ -430,6 +431,7 @@ public abstract class WritableTestBase extends SequentialTestBase {
             assertThat(src.getBytes(0, writtenBytes)).isEqualTo(5);
             assertThat(extractWrittenBytes(seq)).isEqualTo(Arrays.copyOfRange(writtenBytes, 0, 5));
             assertThat(seq.position()).isEqualTo(pos + 5);
+            assertThat(src.position()).isEqualTo(5);
         }
 
         @Test


### PR DESCRIPTION
**Description**:
Implementing all possible fast-paths for the `MemoryData`. As a reminder, it's covered by the existing `BufferedDataTestBase`, so we cover all the new methods via the existing unit tests.

As a side-effect, `Bytes` get two new convenience APIs: `toMemorySegment()` and `writeTo(MemorySegment segment, long position)`.

**Related issue(s)**:

Fixes #784

**Notes for reviewer**:
All tests pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
