### PR TITLE
perf: introduce GetArrayByteBench

### DIFF
--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GetArrayByteBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GetArrayByteBench.java
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh;
+
+import com.hedera.pbj.runtime.io.UnsafeUtils;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import sun.misc.Unsafe;
+
+@SuppressWarnings("unused")
+@State(Scope.Benchmark)
+@Fork(3)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class GetArrayByteBench {
+    /// Num of invocations per measurement method call.
+    private static final int INVOCATIONS = 20 * 1024;
+    /// Size of working arrays/buffers. MUST be greater than INVOCATIONS above
+    private static final int SIZE = INVOCATIONS * 2;
+
+    // Local Unsafe setup to avoid going to the OldUnsafeUtils and inline Unsafe calls directly instead:
+    private static final Unsafe UNSAFE;
+    private static final int BYTE_ARRAY_BASE_OFFSET;
+
+    static {
+        try {
+            final Field theUnsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+            theUnsafeField.setAccessible(true);
+            UNSAFE = (Unsafe) theUnsafeField.get(null);
+            BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+            throw new InternalError(e);
+        }
+    }
+
+    // Local VarHandle setup to avoid going to the UnsafeUtils and inline VarHandle calls directly instead:
+    private static final VarHandle BYTE_ARRAY_HANDLE = MethodHandles.arrayElementVarHandle(byte[].class);
+
+    @State(Scope.Thread)
+    public static class BenchState {
+        byte[] array;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            array = new byte[SIZE];
+            Random random = new Random(349572654);
+            randomize(random);
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {}
+
+        private void randomize(Random random) {
+            random.nextBytes(array);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void getArrayByteNoChecks_OldUnsafeUtils(final BenchState state, final Blackhole blackhole) {
+        for (int i = 0; i < INVOCATIONS; i++) {
+            blackhole.consume(OldUnsafeUtils.getArrayByteNoChecks(state.array, i));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void getArrayByteNoChecks_DirectUnsafeCall(final BenchState state, final Blackhole blackhole) {
+        for (int i = 0; i < INVOCATIONS; i++) {
+            blackhole.consume(UNSAFE.getByte(state.array, BYTE_ARRAY_BASE_OFFSET + i));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void getArrayByteNoChecks_NewUnsafeUtils(final BenchState state, final Blackhole blackhole) {
+        for (int i = 0; i < INVOCATIONS; i++) {
+            blackhole.consume(UnsafeUtils.getArrayByteNoChecks(state.array, i));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void getArrayByteNoChecks_DirectVarHandleCall(final BenchState state, final Blackhole blackhole) {
+        for (int i = 0; i < INVOCATIONS; i++) {
+            blackhole.consume((byte) BYTE_ARRAY_HANDLE.get(state.array, i));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void getArrayByte_SimpleJava(final BenchState state, final Blackhole blackhole) {
+        for (int i = 0; i < INVOCATIONS; i++) {
+            blackhole.consume(state.array[i]);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(GetArrayByteBench.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
**Description**:
Benchmarking various ways to access a byte from a Java byte array. The results:
```
Benchmark                                                    Mode  Cnt     Score      Error   Units
GetArrayByteBench.getArrayByteNoChecks_DirectUnsafeCall     thrpt   15  8820.574 ± 1442.053  ops/us
GetArrayByteBench.getArrayByteNoChecks_DirectVarHandleCall  thrpt   15  9458.586 ±   57.311  ops/us
GetArrayByteBench.getArrayByteNoChecks_NewUnsafeUtils       thrpt   15  9448.438 ±   35.371  ops/us
GetArrayByteBench.getArrayByteNoChecks_OldUnsafeUtils       thrpt   15  9454.953 ±   40.333  ops/us
GetArrayByteBench.getArrayByte_SimpleJava                   thrpt   15  9447.726 ±   55.963  ops/us
```

(the first one is odd, but visually it was running at ~9.4K similar to all the other ones.)

**Related issue(s)**:

Fixes #791 

**Notes for reviewer**:
Just a new benchmark to see if the UnsafeUtils are worth it for reading a single byte from an array. Apparently, they aren't.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
