### PR TITLE
perf: improve GetArrayByteBench

### DIFF
--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GetArrayByteBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GetArrayByteBench.java
@@ -61,6 +61,11 @@ public class GetArrayByteBench {
     public static class BenchState {
         byte[] array;
 
+        // Maintain the sum in state to avoid JVM putting it into a CPU register.
+        // Make it a byte, and not a long. We don't care about overflows here.
+        // But we don't want to touch more significant bytes either.
+        byte sum;
+
         @Setup(Level.Trial)
         public void setup() {
             array = new byte[SIZE];
@@ -79,41 +84,51 @@ public class GetArrayByteBench {
     @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void getArrayByteNoChecks_OldUnsafeUtils(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
         for (int i = 0; i < INVOCATIONS; i++) {
-            blackhole.consume(OldUnsafeUtils.getArrayByteNoChecks(state.array, i));
+            state.sum += OldUnsafeUtils.getArrayByteNoChecks(state.array, i);
         }
+        blackhole.consume(state.sum);
     }
 
     @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void getArrayByteNoChecks_DirectUnsafeCall(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
         for (int i = 0; i < INVOCATIONS; i++) {
-            blackhole.consume(UNSAFE.getByte(state.array, BYTE_ARRAY_BASE_OFFSET + i));
+            state.sum += UNSAFE.getByte(state.array, BYTE_ARRAY_BASE_OFFSET + i);
         }
+        blackhole.consume(state.sum);
     }
 
     @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void getArrayByteNoChecks_NewUnsafeUtils(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
         for (int i = 0; i < INVOCATIONS; i++) {
-            blackhole.consume(UnsafeUtils.getArrayByteNoChecks(state.array, i));
+            state.sum += UnsafeUtils.getArrayByteNoChecks(state.array, i);
         }
+        blackhole.consume(state.sum);
     }
 
     @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void getArrayByteNoChecks_DirectVarHandleCall(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
         for (int i = 0; i < INVOCATIONS; i++) {
-            blackhole.consume((byte) BYTE_ARRAY_HANDLE.get(state.array, i));
+            state.sum += (byte) BYTE_ARRAY_HANDLE.get(state.array, i);
         }
+        blackhole.consume(state.sum);
     }
 
     @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void getArrayByte_SimpleJava(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
         for (int i = 0; i < INVOCATIONS; i++) {
-            blackhole.consume(state.array[i]);
+            state.sum += state.array[i];
         }
+        blackhole.consume(state.sum);
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
**Description**:
Apparently, the current benchmark measures calls to `blackhole.consume()` which seems to dominate compared to the operation of fetching a byte.

In the updated version in this PR, I call `blackhole.consume()` only once. However, I make the loop compute a sum of all the bytes. This slows down the benchmark as a whole. However, this now clearly shows the difference between the various approaches:

```
Benchmark                                                    Mode  Cnt     Score    Error   Units
GetArrayByteBench.getArrayByteNoChecks_DirectUnsafeCall     thrpt   15  1570.078 ± 12.093  ops/us
GetArrayByteBench.getArrayByteNoChecks_DirectVarHandleCall  thrpt   15  1229.827 ±  5.855  ops/us
GetArrayByteBench.getArrayByteNoChecks_NewUnsafeUtils       thrpt   15  1241.066 ± 10.676  ops/us
GetArrayByteBench.getArrayByteNoChecks_OldUnsafeUtils       thrpt   15  1586.338 ±  5.765  ops/us
GetArrayByteBench.getArrayByte_SimpleJava                   thrpt   15  1231.709 ±  9.861  ops/us
```

You can see that both the OldUnsafeUtils and DirectUnsafeCall run at 1.5K, it's because they actually skip the bounds checks. However, both the VarHandle/NewUnsafeUtils and the simple java array access do perform the bounds check, and hence they run slower - at 1.2K.

Long story short, since we deprecated the OldUnsafeUtils, it no longer makes sense to use the new UnsafeUtils for accessing bytes in arrays - a simple Java array indexing operator is as fast as accessing the arrays via the VarHandle.

**Related issue(s)**:

Fixes #793 

**Notes for reviewer**:
See above.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
