### PR TITLE
ci(dependabot): Dependabot should automatically assign a user when PRs are opened

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,23 +5,33 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    assignees:
+      - "swirlds-automation"
   - package-ecosystem: "gradle"
     directory: "/pbj-integration-tests"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    assignees:
+      - "swirlds-automation"
   - package-ecosystem: "gradle"
     directory: "/pbj-core/hiero-dependency-versions"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    assignees:
+      - "swirlds-automation"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    assignees:
+      - "swirlds-automation"
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    assignees:
+      - "swirlds-automation"


### PR DESCRIPTION
## Description

This pull request updates the `.github/dependabot.yml` configuration to automatically assign new Dependabot pull requests to the `swirlds-automation` user. This change ensures that all dependency update PRs are consistently tracked and managed by the automation team.

Dependabot configuration updates:

* Added the `assignees` field with `swirlds-automation` to all relevant package ecosystems and directories, so that new PRs created by Dependabot are assigned to the automation team.

* Fixes error where assignee check fails on dependabot PRs.

## Related Issue(s)

Closes #801 