### PR TITLE
perf: avoid copying immutable Bytes

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessSequenceAdapter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessSequenceAdapter.java
@@ -180,8 +180,15 @@ final class RandomAccessSequenceAdapter implements ReadableSequentialData {
         // Always create a copy because Bytes.getBytes() returns a view
         // and the RandomAccessSequenceAdapter.readBytes(int) method is unaware of
         // the underlying buffer ownership, but users of Bytes assume it's immutable.
-        // We could make this conditional on `delegate instanceof Bytes` if we have to.
-        bytes = bytes.replicate();
+        // But if the `delegate` is Bytes, then we assume that the bytes are immutable, and we skip copying.
+        // Note that this assumption is rather fragile. There's no guarantees that the `delegate`
+        // isn't a Bytes.slice() of another Bytes object that itself is "mutable", or that
+        // the application otherwise doesn't have any other live references to the underlying bytes.
+        // But if the application is well-behaved, then skipping the copy allows us to save RAM
+        // and boost the performance.
+        if (!(delegate instanceof Bytes)) {
+            bytes = bytes.replicate();
+        }
 
         position += bytes.length();
         return bytes;

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/ParserNeverWrapsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/ParserNeverWrapsTest.java
@@ -102,31 +102,10 @@ public class ParserNeverWrapsTest {
                         seq.writeBytes(bytes);
                     });
         }
-
-        static <T> WrapTestData<T> createBytes(int size) {
-            final byte[] byteArray = new byte[size];
-            final Bytes bytes = Bytes.wrap(byteArray);
-
-            final BytesWritableSequentialData seq = new BytesWritableSequentialData(byteArray);
-
-            return new WrapTestData<T>(
-                    () -> seq, // Only write once.
-                    new UncheckedThrowingFunction<>(codec -> codec.parse(bytes)),
-                    () -> {}, // reset() not supported and not needed for Bytes
-                    () -> byteArray, // return the actual array this Bytes object is wrapping
-                    (pos, arr) -> {
-                        for (int i = 0; i < arr.length; i++) {
-                            byteArray[pos + i] = arr[i];
-                        }
-                    });
-        }
     }
 
     static Stream<Function<Integer, WrapTestData>> provideWrapTestArguments() {
-        return Stream.of(
-                WrapTestData::createByteArrayBufferedData,
-                WrapTestData::createDirectBufferedData,
-                WrapTestData::createBytes);
+        return Stream.of(WrapTestData::createByteArrayBufferedData, WrapTestData::createDirectBufferedData);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
**Description**:
Adding an `instanceof Bytes` check to `RandomAccessSequenceAdapter.readBytes()` to avoid making a copy of a Bytes view because we assume that well-behaved applications keep Bytes truly immutable.

An existing test has to be modified because in addition to testing BufferedData objects for no-wrapping, it also tested Bytes by cheating and retaining a reference to the wrapped bytes. We just assume normal applications don't do that. Note that we cannot prove that, though.

I didn't find any other places in PBJ where we'd do anything similar when working with `Bytes`.

**Related issue(s)**:

Fixes #809 

**Notes for reviewer**:
All tests should pass. The removed variant of an old test is the proof that the fix works as intended.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
