### PR TITLE
feat: expose remote peer TCP/IP and TLS info

### DIFF
--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcClient.java
@@ -21,6 +21,7 @@ import io.helidon.webclient.http2.Http2ClientConnection;
 import io.helidon.webclient.http2.Http2ClientImpl;
 import io.helidon.webclient.http2.Http2StreamConfig;
 import java.io.UncheckedIOException;
+import java.net.SocketAddress;
 import java.net.SocketException;
 import java.time.Duration;
 import java.util.Collections;
@@ -118,6 +119,11 @@ public final class PbjGrpcClient implements GrpcClient, AutoCloseable {
 
     ClientConnection getClientConnection() {
         return clientConnection;
+    }
+
+    /// Return the local `SocketAddress` of this client instance.
+    public SocketAddress getLocalAddress() {
+        return clientConnection.helidonSocket().localPeer().address();
     }
 
     Http2ClientConnection createHttp2ClientConnection(final ClientConnection clientConnection) {

--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -45,6 +45,8 @@ import io.helidon.http.http2.Http2StreamWriter;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
+import java.net.SocketAddress;
+import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -308,7 +310,9 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
                     Optional.ofNullable(headers.authority()), // the client (see http2 spec)
                     contentType,
                     config.maxMessageSizeBytes(),
-                    metadata);
+                    metadata,
+                    connectionContext.remotePeer().address(),
+                    connectionContext.remotePeer().tlsCertificates());
 
             // Setup the subscribers. The "outgoing" subscriber will send messages to the client.
             // This is given to the "open" method on the service to allow it to send messages to
@@ -770,7 +774,12 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
 
     /** Simple implementation of the {@link ServiceInterface.RequestOptions} interface. */
     private record Options(
-            Optional<String> authority, String contentType, int maxMessageSizeBytes, Map<String, String> metadata)
+            Optional<String> authority,
+            String contentType,
+            int maxMessageSizeBytes,
+            Map<String, String> metadata,
+            SocketAddress remoteAddress,
+            Optional<Certificate[]> remoteCertificateChain)
             implements ServiceInterface.RequestOptions {}
 
     /**

--- a/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
+++ b/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
@@ -39,8 +39,12 @@ import io.helidon.webserver.Router;
 import io.netty.handler.codec.http2.Http2Flags;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
+import java.net.SocketAddress;
+import java.security.Principal;
+import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutorService;
@@ -67,6 +71,8 @@ class PbjProtocolHandlerTest {
     private ServiceInterfaceStub service;
     private ConnectionContext connectionContext;
 
+    private PeerInfo remotePeer;
+
     @BeforeEach
     void setUp() {
         headers = Http2Headers.create(WritableHeaders.create().add(HeaderNames.CONTENT_TYPE, "application/grpc+proto"));
@@ -78,6 +84,16 @@ class PbjProtocolHandlerTest {
         service = new ServiceInterfaceStub();
         route = new PbjMethodRoute(service, PbjGrpcServiceConfig.DEFAULT, ServiceInterfaceStub.METHOD);
         deadlineDetector = new DeadlineDetectorStub();
+
+        record PeerInfoRecord(
+                SocketAddress address,
+                String host,
+                int port,
+                Optional<Principal> tlsPrincipal,
+                Optional<Certificate[]> tlsCertificates)
+                implements PeerInfo {}
+        remotePeer = new PeerInfoRecord(null, null, 0, Optional.empty(), Optional.empty());
+
         connectionContext = new ConnectionContext() {
             @Override
             public ListenerContext listenerContext() {
@@ -106,7 +122,7 @@ class PbjProtocolHandlerTest {
 
             @Override
             public PeerInfo remotePeer() {
-                throw new UnsupportedOperationException();
+                return remotePeer;
             }
 
             @Override

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/grpc/ServiceInterface.java
@@ -3,6 +3,8 @@ package com.hedera.pbj.runtime.grpc;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.SocketAddress;
+import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -137,6 +139,16 @@ public interface ServiceInterface extends AutoCloseable {
          */
         default Map<String, String> metadata() {
             return Map.of();
+        }
+
+        /// The `SocketAddress` of the remote peer, or null if unknown or undefined.
+        default SocketAddress remoteAddress() {
+            return null;
+        }
+
+        /// The TLS certificate chain of the remote peer, or empty if unknown, undefined, or the connection isn't TLS.
+        default Optional<Certificate[]> remoteCertificateChain() {
+            return Optional.empty();
         }
     }
 

--- a/pbj-integration-tests/src/main/proto/ipService.proto
+++ b/pbj-integration-tests/src/main/proto/ipService.proto
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+package pbj.integration.tests;
+option java_multiple_files = true;
+
+service TCPIPInfoProvider {
+  rpc provideTCPIP (TCPIPRequest) returns (TCPIPReply) {}
+}
+
+message TCPIPRequest {
+  string name = 1;
+}
+
+message TCPIPReply {
+  string name = 1;
+
+  string host = 2;
+  int32 port = 3;
+
+  // We don't have TLS tests, so we don't bother modeling the certs.
+  int32 numOfCertificates = 4;
+}

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/TCPIPInfoProviderTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/grpc/TCPIPInfoProviderTest.java
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.test.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.helidon.PbjGrpcServiceConfig;
+import com.hedera.pbj.grpc.helidon.PbjRouting;
+import com.hedera.pbj.grpc.helidon.config.PbjConfig;
+import com.hedera.pbj.integration.grpc.GrpcTestUtils;
+import com.hedera.pbj.integration.grpc.PortsAllocator;
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.grpc.GrpcClient;
+import com.hedera.pbj.runtime.grpc.GrpcCompression;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.webserver.WebServer;
+import java.net.InetSocketAddress;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import pbj.integration.tests.pbj.integration.tests.TCPIPInfoProviderInterface;
+import pbj.integration.tests.pbj.integration.tests.TCPIPReply;
+import pbj.integration.tests.pbj.integration.tests.TCPIPRequest;
+
+public class TCPIPInfoProviderTest {
+    private static final String TEST_NAME = "TCPIPInfoProviderTest Name";
+
+    private static PortsAllocator.Port PORT;
+    private static ServerHandle SERVER;
+    private static GrpcClient GRPC_CLIENT;
+
+    public static class TCPIPInfoProviderService implements TCPIPInfoProviderInterface {
+        @Override
+        public @NonNull TCPIPReply provideTCPIP(
+                @NonNull TCPIPRequest request, ServiceInterface.RequestOptions requestOptions) {
+            final InetSocketAddress inetSocketAddress = (InetSocketAddress) requestOptions.remoteAddress();
+            return TCPIPReply.newBuilder()
+                    .name(request.name())
+                    .host(inetSocketAddress.getHostString())
+                    .port(inetSocketAddress.getPort())
+                    .numOfCertificates(requestOptions
+                            .remoteCertificateChain()
+                            .map(certs -> certs.length)
+                            .orElse(-1))
+                    .build();
+        }
+    }
+
+    private record ServerHandle(WebServer server) implements AutoCloseable {
+        @Override
+        public void close() {
+            server.stop();
+        }
+
+        static ServerHandle start(
+                final int port, final ServiceInterface service, final PbjGrpcServiceConfig serviceConfig) {
+            final int maxPayloadSize = 20 * 1024 * 1024;
+            final PbjConfig pbjConfig = PbjConfig.builder()
+                    .name("pbj")
+                    .maxMessageSizeBytes(maxPayloadSize)
+                    .build();
+            return new ServerHandle(WebServer.builder()
+                    .port(port)
+                    .addProtocol(pbjConfig)
+                    .addRouting(PbjRouting.builder().service(service, serviceConfig))
+                    .maxPayloadSize(maxPayloadSize)
+                    .build()
+                    .start());
+        }
+    }
+
+    @BeforeAll
+    static void setup() {
+        final PbjGrpcServiceConfig serviceConfig =
+                new PbjGrpcServiceConfig(GrpcCompression.IDENTITY, Set.of(GrpcCompression.IDENTITY));
+        PORT = GrpcTestUtils.PORTS.acquire();
+        SERVER = ServerHandle.start(PORT.port(), new TCPIPInfoProviderService(), serviceConfig);
+        GRPC_CLIENT = GrpcTestUtils.createGrpcClient(
+                PORT.port(),
+                GrpcTestUtils.PROTO_OPTIONS,
+                GrpcCompression.IDENTITY,
+                Set.of(GrpcCompression.IDENTITY),
+                Codec.DEFAULT_MAX_SIZE,
+                Codec.DEFAULT_MAX_SIZE * 5);
+    }
+
+    @AfterAll
+    static void teardown() {
+        GRPC_CLIENT.close();
+        SERVER.close();
+        PORT.close();
+    }
+
+    @Test
+    void testTCPIPInfoProvider() {
+        TCPIPInfoProviderInterface.TCPIPInfoProviderClient client =
+                new TCPIPInfoProviderInterface.TCPIPInfoProviderClient(GRPC_CLIENT, GrpcTestUtils.PROTO_OPTIONS);
+
+        final TCPIPReply reply =
+                client.provideTCPIP(TCPIPRequest.newBuilder().name(TEST_NAME).build());
+
+        assertEquals(TEST_NAME, reply.name());
+        assertEquals("127.0.0.1", reply.host());
+
+        PbjGrpcClient pbjGrpcClient = (PbjGrpcClient) GRPC_CLIENT;
+        InetSocketAddress localAddress = (InetSocketAddress) pbjGrpcClient.getLocalAddress();
+        assertEquals(localAddress.getPort(), reply.port());
+
+        assertEquals(-1, reply.numOfCertificates());
+    }
+}


### PR DESCRIPTION
**Description**:
Adding `RequestOptions.remoteAddress()` and `RequestOptions.remoteCertificateChain()` to expose data about the TCP/IP connection and the TLS data of the remote peer. A GRPC service implementation can use this additional information to decide how to process the request best.

A new integration test is added that demonstrates the usage and verifies the implementation.

Also, `PbjGrpcClient.getLocalAddress()` is added to support the new integration test.

**Related issue(s)**:

Fixes #819 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
