### PR TITLE
perf: unroll VarInt parsing loops

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
@@ -473,15 +473,58 @@ public interface ReadableSequentialData extends SequentialData {
      * @throws DataEncodingException if the variable long cannot be decoded
      */
     default long readVarLong(final boolean zigZag) throws BufferUnderflowException, UncheckedIOException {
-        long value = 0;
-
-        for (int i = 0; i < 10; i++) {
-            final byte b = readByte();
-            value |= (long) (b & 0x7F) << (i * 7);
-            if (b >= 0) {
-                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
-            }
+        byte b;
+        long v = (b = readByte()) & 0x7F;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
         }
+
+        v |= ((b = readByte()) & 0x7F) << 7;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = readByte()) & 0x7F) << 14;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = readByte()) & 0x7F) << 21;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = readByte()) & 0x7FL) << 28;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = readByte()) & 0x7FL) << 35;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = readByte()) & 0x7FL) << 42;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = readByte()) & 0x7FL) << 49;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = readByte()) & 0x7FL) << 56;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        b = readByte();
+        if ((b & 0x80) == 0) {
+            v |= (long) b << 63;
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
         throw new DataEncodingException("Malformed var int");
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ReadableSequentialData.java
@@ -473,56 +473,76 @@ public interface ReadableSequentialData extends SequentialData {
      * @throws DataEncodingException if the variable long cannot be decoded
      */
     default long readVarLong(final boolean zigZag) throws BufferUnderflowException, UncheckedIOException {
-        byte b;
-        long v = (b = readByte()) & 0x7F;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        final byte b;
+        int vi;
+        long vl;
+
+        if ((vi = readByte()) >= 0) {
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = readByte()) & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vi ^= readByte() << 7) < 0) {
+            vi ^= (~0 << 7);
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = readByte()) & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vi ^= readByte() << 14) >= 0) {
+            vi ^= ((~0 << 7) ^ (~0 << 14));
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = readByte()) & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vi ^= readByte() << 21) < 0) {
+            vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = readByte()) & 0x7FL) << 28;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        vl = vi;
+        if ((vl ^= (long) readByte() << 28) >= 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = readByte()) & 0x7FL) << 35;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) readByte() << 35) < 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = readByte()) & 0x7FL) << 42;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) readByte() << 42) >= 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = readByte()) & 0x7FL) << 49;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) readByte() << 49) < 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = readByte()) & 0x7FL) << 56;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) readByte() << 56) >= 0L) {
+            vl ^= ((~0L << 7)
+                    ^ (~0L << 14)
+                    ^ (~0L << 21)
+                    ^ (~0L << 28)
+                    ^ (~0L << 35)
+                    ^ (~0L << 42)
+                    ^ (~0L << 49)
+                    ^ (~0L << 56));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        b = readByte();
-        if ((b & 0x80) == 0) {
-            v |= (long) b << 63;
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((b = readByte()) < 0) {
+            throw new DataEncodingException("Malformed var int");
+        }
+        if ((vl ^= (long) b << 63) >= 0L) {
+            vl ^= ((~0L << 7)
+                    ^ (~0L << 14)
+                    ^ (~0L << 21)
+                    ^ (~0L << 28)
+                    ^ (~0L << 35)
+                    ^ (~0L << 42)
+                    ^ (~0L << 49)
+                    ^ (~0L << 56)
+                    ^ (~0L << 63));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
         throw new DataEncodingException("Malformed var int");

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
@@ -145,68 +145,165 @@ final class ByteArrayBufferedData extends BufferedData {
         checkOffset(offset, buffer.limit());
         offset += arrayOffset;
 
+        int vi;
+        long vl;
         final int limit = Math.min(arrayOffset + (int) length(), offset + 10);
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        byte b;
-        long v = (b = array[offset++]) & 0x7F;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        fastpath:
+        {
+            if (offset == limit) break fastpath;
+
+            if ((vi = array[offset++]) >= 0) {
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            } else if (offset + 9 == limit) {
+                // Fast path w/o any limit checks if we have 9 more array
+                if ((vi ^= array[offset++] << 7) < 0) {
+                    vi ^= (~0 << 7);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= array[offset++] << 14) >= 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= array[offset++] << 21) < 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                vl = vi;
+                if ((vl ^= (long) array[offset++] << 28) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 35) < 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 42) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 49) < 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 56) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if (array[offset++] < 0) break fastpath;
+                if ((vl ^= (long) array[offset - 1] << 63) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+            }
         }
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        v |= ((b = array[offset++]) & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+        slowpath:
+        {
+            // Slower path because this is an array/array, and we have less than 9 (or even 10) array ahead
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            // Since the above check is false, the offset was incremented in the fastpath above, and vi is actually
+            // assigned there. However, javac is unable to see this and throw an error. So we re-initialize it.
+            // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
+            vi = array[offset - 1];
+            if ((vi ^= array[offset++] << 7) < 0) {
+                vi ^= (~0 << 7);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vi ^= array[offset++] << 14) >= 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 28;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vi ^= array[offset++] << 21) < 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 35;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            vl = vi;
+            if ((vl ^= (long) array[offset++] << 28) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 42;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vl ^= (long) array[offset++] << 35) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 49;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vl ^= (long) array[offset++] << 42) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 56;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vl ^= (long) array[offset++] << 49) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        b = array[offset++];
-        if ((b & 0x80) == 0) {
-            v |= (long) b << 63;
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+            if ((vl ^= (long) array[offset++] << 56) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit || array[offset++] < 0) break slowpath;
+
+            if ((vl ^= (long) array[offset - 1] << 63) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56)
+                        ^ (~0L << 63));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
         }
 
         throw new DataEncodingException("Malformed var int");
@@ -299,81 +396,188 @@ final class ByteArrayBufferedData extends BufferedData {
         final int pos = buffer.position();
         int offset = arrayOffset + pos;
 
+        int vi;
+        long vl;
         final int limit = Math.min(offset + buffer.remaining(), offset + 10);
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        byte b;
-        long v = (b = array[offset++]) & 0x7F;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 1);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        fastpath:
+        {
+            if (offset == limit) break fastpath;
+
+            if ((vi = array[offset++]) >= 0) {
+                buffer.position(pos + 1);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            } else if (offset + 9 == limit) {
+                // Fast path w/o any limit checks if we have 9 more array
+                if ((vi ^= array[offset++] << 7) < 0) {
+                    vi ^= (~0 << 7);
+                    buffer.position(pos + 2);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= array[offset++] << 14) >= 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14));
+                    buffer.position(pos + 3);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= array[offset++] << 21) < 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                    buffer.position(pos + 4);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                vl = vi;
+                if ((vl ^= (long) array[offset++] << 28) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                    buffer.position(pos + 5);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 35) < 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                    buffer.position(pos + 6);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 42) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                    buffer.position(pos + 7);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 49) < 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
+                    buffer.position(pos + 8);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) array[offset++] << 56) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56));
+                    buffer.position(pos + 9);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                buffer.position(pos + 10);
+                if (array[offset++] < 0) throw new DataEncodingException("Malformed var int");
+                if ((vl ^= (long) array[offset - 1] << 63) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+            }
         }
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        v |= ((b = array[offset++]) & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 2);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+        slowpath:
+        {
+            // Slower path because this is an array/array, and we have less than 9 (or even 10) array ahead
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 3);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            // Since the above check is false, the offset was incremented in the fastpath above, and vi is actually
+            // assigned there. However, javac is unable to see this and throw an error. So we re-initialize it.
+            // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
+            vi = array[offset - 1];
+            if ((vi ^= array[offset++] << 7) < 0) {
+                vi ^= (~0 << 7);
+                buffer.position(pos + 2);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 4);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vi ^= array[offset++] << 14) >= 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14));
+                buffer.position(pos + 3);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 28;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 5);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vi ^= array[offset++] << 21) < 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                buffer.position(pos + 4);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 35;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 6);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            vl = vi;
+            if ((vl ^= (long) array[offset++] << 28) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                buffer.position(pos + 5);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 42;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 7);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vl ^= (long) array[offset++] << 35) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                buffer.position(pos + 6);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 49;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 8);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vl ^= (long) array[offset++] << 42) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                buffer.position(pos + 7);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = array[offset++]) & 0x7FL) << 56;
-        if ((b & 0x80) == 0) {
-            buffer.position(pos + 9);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
+            if ((vl ^= (long) array[offset++] << 49) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                buffer.position(pos + 8);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        b = array[offset++];
-        if ((b & 0x80) == 0) {
+            if ((vl ^= (long) array[offset++] << 56) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56));
+                buffer.position(pos + 9);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
             buffer.position(pos + 10);
-            v |= (long) b << 63;
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+            if (array[offset++] < 0) throw new DataEncodingException("Malformed var int");
+
+            if ((vl ^= (long) array[offset - 1] << 63) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56)
+                        ^ (~0L << 63));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
         }
 
-        throw new DataEncodingException("Malformed var int");
+        throw new BufferUnderflowException();
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
@@ -2,7 +2,6 @@
 package com.hedera.pbj.runtime.io.buffer;
 
 import com.hedera.pbj.runtime.io.DataEncodingException;
-import com.hedera.pbj.runtime.io.UnsafeUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
@@ -142,27 +141,75 @@ final class ByteArrayBufferedData extends BufferedData {
         return getVar(Math.toIntExact(offset), zigZag);
     }
 
-    private long getVar(final int offset, final boolean zigZag) {
+    private long getVar(int offset, final boolean zigZag) {
         checkOffset(offset, buffer.limit());
+        offset += arrayOffset;
 
-        final int readOffset = arrayOffset + offset;
-        int rem = buffer.limit() - offset;
-        if (rem > 10) {
-            rem = 10;
+        final int limit = Math.min(arrayOffset + (int) length(), offset + 10);
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        byte b;
+        long v = (b = array[offset++]) & 0x7F;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7F) << 7;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7F) << 14;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7F) << 21;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 28;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 35;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 42;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 49;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 56;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        b = array[offset++];
+        if ((b & 0x80) == 0) {
+            v |= (long) b << 63;
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
         }
 
-        long value = 0;
-
-        int i = 0;
-        while (i != rem) {
-            final byte b = UnsafeUtils.getArrayByteNoChecks(array, readOffset + i);
-            value |= (long) (b & 0x7F) << (i * 7);
-            i++;
-            if (b >= 0) {
-                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
-            }
-        }
-        throw (i == 10) ? new DataEncodingException("Malformed var int") : new BufferUnderflowException();
+        throw new DataEncodingException("Malformed var int");
     }
 
     /**
@@ -250,25 +297,83 @@ final class ByteArrayBufferedData extends BufferedData {
 
     private long readVar(final boolean zigZag) {
         final int pos = buffer.position();
-        final int offset = arrayOffset + pos;
-        int rem = buffer.remaining();
-        if (rem > 10) {
-            rem = 10;
+        int offset = arrayOffset + pos;
+
+        final int limit = Math.min(offset + buffer.remaining(), offset + 10);
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        byte b;
+        long v = (b = array[offset++]) & 0x7F;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 1);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7F) << 7;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 2);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7F) << 14;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 3);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7F) << 21;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 4);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 28;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 5);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 35;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 6);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 42;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 7);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 49;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 8);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = array[offset++]) & 0x7FL) << 56;
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 9);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        b = array[offset++];
+        if ((b & 0x80) == 0) {
+            buffer.position(pos + 10);
+            v |= (long) b << 63;
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
         }
 
-        long value = 0;
-
-        int i = 0;
-        while (i != rem) {
-            final byte b = UnsafeUtils.getArrayByteNoChecks(array, offset + i);
-            value |= (long) (b & 0x7F) << (i * 7);
-            i++;
-            if (b >= 0) {
-                buffer.position(pos + i);
-                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
-            }
-        }
-        throw (i == 10) ? new DataEncodingException("Malformed var int") : new BufferUnderflowException();
+        throw new DataEncodingException("Malformed var int");
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -865,68 +865,165 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
         }
         offset += start;
 
+        int vi;
+        long vl;
         final int limit = Math.min(start + length, offset + 10);
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
 
-        byte b;
-        long v = (b = buffer[offset++]) & 0x7F;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        fastpath:
+        {
+            if (offset == limit) break fastpath;
+
+            if ((vi = buffer[offset++]) >= 0) {
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            } else if (offset + 9 == limit) {
+                // Fast path w/o any limit checks if we have 9 more buffer
+                if ((vi ^= buffer[offset++] << 7) < 0) {
+                    vi ^= (~0 << 7);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= buffer[offset++] << 14) >= 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= buffer[offset++] << 21) < 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                vl = vi;
+                if ((vl ^= (long) buffer[offset++] << 28) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) buffer[offset++] << 35) < 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) buffer[offset++] << 42) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) buffer[offset++] << 49) < 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) buffer[offset++] << 56) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if (buffer[offset++] < 0) break fastpath;
+                if ((vl ^= (long) buffer[offset - 1] << 63) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+            }
         }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
 
-        v |= ((b = buffer[offset++]) & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+        slowpath:
+        {
+            // Slower path because this is an array/buffer, and we have less than 9 (or even 10) buffer ahead
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = buffer[offset++]) & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+            // Since the above check is false, the offset was incremented in the fastpath above, and vi is actually
+            // assigned there. However, javac is unable to see this and throw an error. So we re-initialize it.
+            // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
+            vi = buffer[offset - 1];
+            if ((vi ^= buffer[offset++] << 7) < 0) {
+                vi ^= (~0 << 7);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = buffer[offset++]) & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+            if ((vi ^= buffer[offset++] << 14) >= 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = buffer[offset++]) & 0x7FL) << 28;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+            if ((vi ^= buffer[offset++] << 21) < 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = buffer[offset++]) & 0x7FL) << 35;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+            vl = vi;
+            if ((vl ^= (long) buffer[offset++] << 28) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = buffer[offset++]) & 0x7FL) << 42;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+            if ((vl ^= (long) buffer[offset++] << 35) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = buffer[offset++]) & 0x7FL) << 49;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+            if ((vl ^= (long) buffer[offset++] << 42) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        v |= ((b = buffer[offset++]) & 0x7FL) << 56;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+            if ((vl ^= (long) buffer[offset++] << 49) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
 
-        b = buffer[offset++];
-        if ((b & 0x80) == 0) {
-            v |= (long) b << 63;
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+            if ((vl ^= (long) buffer[offset++] << 56) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit || buffer[offset++] < 0) break slowpath;
+
+            if ((vl ^= (long) buffer[offset - 1] << 63) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56)
+                        ^ (~0L << 63));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
         }
 
         throw new DataEncodingException("Malformed var int");

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -865,20 +865,70 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
         }
         offset += start;
 
-        int rem = (start + length) - offset;
-        if (rem > 10) {
-            rem = 10;
+        final int limit = Math.min(start + length, offset + 10);
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        byte b;
+        long v = (b = buffer[offset++]) & 0x7F;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7F) << 7;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7F) << 14;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7F) << 21;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7FL) << 28;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7FL) << 35;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7FL) << 42;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7FL) << 49;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        v |= ((b = buffer[offset++]) & 0x7FL) << 56;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new DataEncodingException("Malformed var int");
+
+        b = buffer[offset++];
+        if ((b & 0x80) == 0) {
+            v |= (long) b << 63;
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
         }
 
-        long value = 0;
-
-        for (int i = 0; i != rem; i++) {
-            final byte b = UnsafeUtils.getArrayByteNoChecks(buffer, offset + i);
-            value |= (long) (b & 0x7F) << (i * 7);
-            if (b >= 0) {
-                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
-            }
-        }
         throw new DataEncodingException("Malformed var int");
     }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedData.java
@@ -87,27 +87,74 @@ final class DirectBufferedData extends BufferedData {
         return getVar(Math.toIntExact(offset), zigZag);
     }
 
-    private long getVar(final int offset, final boolean zigZag) {
+    private long getVar(int offset, final boolean zigZag) {
         checkOffset(offset, length());
 
-        int rem = Math.toIntExact(buffer.limit() - offset);
-        if (rem > 10) {
-            rem = 10;
+        final int limit = Math.min(buffer.limit(), offset + 10);
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        byte b;
+        long v = (b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 7;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 14;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 21;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 28;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 35;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 42;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 49;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 56;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++);
+        if ((b & 0x80) == 0) {
+            v |= (long) b << 63;
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
         }
 
-        long value = 0;
-
-        int i = 0;
-        while (i != rem) {
-            final byte b = UnsafeUtils.getDirectBufferByte(buffer, offset + i);
-            value |= (long) (b & 0x7F) << (i * 7);
-            i++;
-            if (b >= 0) {
-                buffer.position(offset + i);
-                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
-            }
-        }
-        throw (i == 10) ? new DataEncodingException("Malformed var int") : new BufferUnderflowException();
+        throw new DataEncodingException("Malformed var int");
     }
 
     /**
@@ -185,25 +232,83 @@ final class DirectBufferedData extends BufferedData {
     }
 
     private long readVar(final boolean zigZag) {
-        final int pos = buffer.position();
-        int rem = buffer.remaining();
-        if (rem > 10) {
-            rem = 10;
+        int offset = buffer.position();
+
+        final int limit = Math.min(offset + buffer.remaining(), offset + 10);
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        byte b;
+        long v = (b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 7;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 14;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 21;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 28;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 35;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 42;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 49;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 56;
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+        if (offset >= limit) throw new BufferUnderflowException();
+
+        b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++);
+        if ((b & 0x80) == 0) {
+            buffer.position(offset);
+            v |= (long) b << 63;
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
         }
 
-        long value = 0;
-
-        int i = 0;
-        while (i != rem) {
-            final byte b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, pos + i);
-            value |= (long) (b & 0x7F) << (i * 7);
-            i++;
-            if (b >= 0) {
-                buffer.position(pos + i);
-                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
-            }
-        }
-        throw (i == 10) ? new DataEncodingException("") : new BufferUnderflowException();
+        throw new DataEncodingException("Malformed var int");
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/DirectBufferedData.java
@@ -90,71 +90,171 @@ final class DirectBufferedData extends BufferedData {
     private long getVar(int offset, final boolean zigZag) {
         checkOffset(offset, length());
 
+        int vi;
+        long vl;
         final int limit = Math.min(buffer.limit(), offset + 10);
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        byte b;
-        long v = (b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        fastpath:
+        {
+            if (offset == limit) break fastpath;
+
+            if ((vi = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) >= 0) {
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            } else if (offset + 9 == limit) {
+                // Fast path w/o any limit checks if we have 9 more array
+                if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 7) < 0) {
+                    vi ^= (~0 << 7);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 14) >= 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 21) < 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                vl = vi;
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 28) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 35) < 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 42) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 49) < 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 56) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if (UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) < 0)
+                    throw new DataEncodingException("Malformed var int");
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset - 1) << 63) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+            }
         }
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        slowpath:
+        {
+            // Slower path because this is an array/array, and we have less than 9 (or even 10) array ahead
+            if (offset >= limit) break slowpath;
+
+            // Since the above check is false, the offset was incremented in the fastpath above, and vi is actually
+            // assigned there. However, javac is unable to see this and throw an error. So we re-initialize it.
+            // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
+            vi = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset - 1);
+            if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 7) < 0) {
+                vi ^= (~0 << 7);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 14) >= 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 21) < 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
+
+            vl = vi;
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 28) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 35) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 42) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 49) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 56) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if (UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) < 0)
+                throw new DataEncodingException("Malformed var int");
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset - 1) << 63) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56)
+                        ^ (~0L << 63));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
         }
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 28;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 35;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 42;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 49;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 56;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++);
-        if ((b & 0x80) == 0) {
-            v |= (long) b << 63;
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-
-        throw new DataEncodingException("Malformed var int");
+        throw new BufferUnderflowException();
     }
 
     /**
@@ -234,81 +334,190 @@ final class DirectBufferedData extends BufferedData {
     private long readVar(final boolean zigZag) {
         int offset = buffer.position();
 
+        int vi;
+        long vl;
         final int limit = Math.min(offset + buffer.remaining(), offset + 10);
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        byte b;
-        long v = (b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        fastpath:
+        {
+            if (offset == limit) break fastpath;
+
+            if ((vi = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) >= 0) {
+                buffer.position(offset);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            } else if (offset + 9 == limit) {
+                // Fast path w/o any limit checks if we have 9 more array
+                if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 7) < 0) {
+                    vi ^= (~0 << 7);
+                    buffer.position(offset);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 14) >= 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14));
+                    buffer.position(offset);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 21) < 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                    buffer.position(offset);
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
+
+                vl = vi;
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 28) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                    buffer.position(offset);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 35) < 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                    buffer.position(offset);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 42) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                    buffer.position(offset);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 49) < 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
+                    buffer.position(offset);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 56) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56));
+                    buffer.position(offset);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+
+                if (UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) < 0)
+                    throw new DataEncodingException("Malformed var int");
+                if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset - 1) << 63) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63));
+                    buffer.position(offset);
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
+            }
         }
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        slowpath:
+        {
+            // Slower path because this is an array/array, and we have less than 9 (or even 10) array ahead
+            if (offset >= limit) break slowpath;
+
+            // Since the above check is false, the offset was incremented in the fastpath above, and vi is actually
+            // assigned there. However, javac is unable to see this and throw an error. So we re-initialize it.
+            // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
+            vi = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset - 1);
+            if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 7) < 0) {
+                vi ^= (~0 << 7);
+                buffer.position(offset);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 14) >= 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14));
+                buffer.position(offset);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vi ^= UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 21) < 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                buffer.position(offset);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+            if (offset >= limit) break slowpath;
+
+            vl = vi;
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 28) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                buffer.position(offset);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 35) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                buffer.position(offset);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 42) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                buffer.position(offset);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 49) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                buffer.position(offset);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) << 56) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56));
+                buffer.position(offset);
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+            if (offset >= limit) break slowpath;
+
+            buffer.position(offset + 1);
+            if (UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++) < 0)
+                throw new DataEncodingException("Malformed var int");
+            if ((vl ^= (long) UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset - 1) << 63) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56)
+                        ^ (~0L << 63));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
         }
-        if (offset >= limit) throw new BufferUnderflowException();
 
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 28;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 35;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 42;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 49;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        v |= ((b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++)) & 0x7FL) << 56;
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-        if (offset >= limit) throw new BufferUnderflowException();
-
-        b = UnsafeUtils.getDirectBufferByteNoChecks(buffer, offset++);
-        if ((b & 0x80) == 0) {
-            buffer.position(offset);
-            v |= (long) b << 63;
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
-        }
-
-        throw new DataEncodingException("Malformed var int");
+        throw new BufferUnderflowException();
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -430,56 +430,76 @@ public interface RandomAccessData {
      * @throws DataEncodingException if the var long is malformed
      */
     default long getVarLong(long offset, final boolean zigZag) {
-        byte b;
-        long v = (b = getByte(offset++)) & 0x7F;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        final byte b;
+        int vi;
+        long vl;
+
+        if ((vi = getByte(offset++)) >= 0) {
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vi ^= getByte(offset++) << 7) < 0) {
+            vi ^= (~0 << 7);
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vi ^= getByte(offset++) << 14) >= 0) {
+            vi ^= ((~0 << 7) ^ (~0 << 14));
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vi ^= getByte(offset++) << 21) < 0) {
+            vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7FL) << 28;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        vl = vi;
+        if ((vl ^= (long) getByte(offset++) << 28) >= 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7FL) << 35;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) getByte(offset++) << 35) < 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7FL) << 42;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) getByte(offset++) << 42) >= 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7FL) << 49;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) getByte(offset++) << 49) < 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        v |= ((b = getByte(offset++)) & 0x7FL) << 56;
-        if ((b & 0x80) == 0) {
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((vl ^= (long) getByte(offset++) << 56) >= 0L) {
+            vl ^= ((~0L << 7)
+                    ^ (~0L << 14)
+                    ^ (~0L << 21)
+                    ^ (~0L << 28)
+                    ^ (~0L << 35)
+                    ^ (~0L << 42)
+                    ^ (~0L << 49)
+                    ^ (~0L << 56));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
-        b = getByte(offset++);
-        if ((b & 0x80) == 0) {
-            v |= (long) b << 63;
-            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        if ((b = getByte(offset++)) < 0) {
+            throw new DataEncodingException("Malformed var int");
+        }
+        if ((vl ^= (long) b << 63) >= 0L) {
+            vl ^= ((~0L << 7)
+                    ^ (~0L << 14)
+                    ^ (~0L << 21)
+                    ^ (~0L << 28)
+                    ^ (~0L << 35)
+                    ^ (~0L << 42)
+                    ^ (~0L << 49)
+                    ^ (~0L << 56)
+                    ^ (~0L << 63));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
         throw new DataEncodingException("Malformed var int");

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -429,15 +429,59 @@ public interface RandomAccessData {
      *         or the end of the buffer is encountered before the last segment of the varlong
      * @throws DataEncodingException if the var long is malformed
      */
-    default long getVarLong(final long offset, final boolean zigZag) {
-        long value = 0;
-        for (int i = 0; i < 10; i++) {
-            final byte b = getByte(offset + i);
-            value |= (long) (b & 0x7F) << (i * 7);
-            if (b >= 0) {
-                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
-            }
+    default long getVarLong(long offset, final boolean zigZag) {
+        byte b;
+        long v = (b = getByte(offset++)) & 0x7F;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
         }
+
+        v |= ((b = getByte(offset++)) & 0x7F) << 7;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = getByte(offset++)) & 0x7F) << 14;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = getByte(offset++)) & 0x7F) << 21;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = getByte(offset++)) & 0x7FL) << 28;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = getByte(offset++)) & 0x7FL) << 35;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = getByte(offset++)) & 0x7FL) << 42;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = getByte(offset++)) & 0x7FL) << 49;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        v |= ((b = getByte(offset++)) & 0x7FL) << 56;
+        if ((b & 0x80) == 0) {
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
+        b = getByte(offset++);
+        if ((b & 0x80) == 0) {
+            v |= (long) b << 63;
+            return zigZag ? (v >>> 1) ^ -(v & 1) : v;
+        }
+
         throw new DataEncodingException("Malformed var int");
     }
 

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -445,7 +445,7 @@ public class VarIntByteArrayReadBench {
     }
 
     /// A vectorized LEB128, similar to the loopLess above, with some minor tweaks and supporting long varints.
-    @Benchmark
+    // @Benchmark // disabled because of improvements in versions below
     @OperationsPerInvocation(INVOCATIONS)
     public void vector_zigZag(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -521,6 +521,338 @@ public class VarIntByteArrayReadBench {
             if ((b & 0x80) == 0) {
                 v |= (long) b << 63;
                 state.sum += state.zigZag ? (v >>> 1) ^ -(v & 1) : v;
+                continue;
+            }
+
+            throw new DataEncodingException("Malformed var int");
+        }
+        blackhole.consume(state.sum);
+    }
+
+    /// A vectorized LEB128 version that:
+    /// * avoids limit checks if we have enough bytes ahead (or if we relied on an EOFException in case of streams)
+    /// * uses byte for 1 byte varint, int for a few bytes, and finally long for many bytes varint
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void vector_smartLimitByteIntLong(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
+        for (int invocation = 0, pos = 0; invocation < INVOCATIONS; invocation++) {
+            final int limit = Math.min(state.array.length, pos + 10);
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            byte b = state.array[pos++];
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (b >>> 1) ^ -(b & 1) : b;
+                continue;
+            }
+
+            int vi = b & 0x7F;
+
+            // Fast path w/o any limit checks if we have all 10 bytes, or if it was a stream b/c we'd get an EOF
+            if (pos + 9 == limit) {
+                vi |= ((b = state.array[pos++]) & 0x7F) << 7;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    continue;
+                }
+
+                vi |= ((b = state.array[pos++]) & 0x7F) << 14;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    continue;
+                }
+
+                vi |= ((b = state.array[pos++]) & 0x7F) << 21;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    continue;
+                }
+
+                long vl = vi | ((b = state.array[pos++]) & 0x7FL) << 28;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                vl |= ((b = state.array[pos++]) & 0x7FL) << 35;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                vl |= ((b = state.array[pos++]) & 0x7FL) << 42;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                vl |= ((b = state.array[pos++]) & 0x7FL) << 49;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                vl |= ((b = state.array[pos++]) & 0x7FL) << 56;
+                if ((b & 0x80) == 0) {
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                b = state.array[pos++];
+                if ((b & 0x80) == 0) {
+                    vl |= (long) b << 63;
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                throw new DataEncodingException("Malformed var int");
+            }
+
+            // Slower path because this is an array/buffer, and we have less than 9 bytes ahead
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            vi |= ((b = state.array[pos++]) & 0x7F) << 7;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            vi |= ((b = state.array[pos++]) & 0x7F) << 14;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            vi |= ((b = state.array[pos++]) & 0x7F) << 21;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            long vl = vi | ((b = state.array[pos++]) & 0x7FL) << 28;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            vl |= ((b = state.array[pos++]) & 0x7FL) << 35;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            vl |= ((b = state.array[pos++]) & 0x7FL) << 42;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            vl |= ((b = state.array[pos++]) & 0x7FL) << 49;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            vl |= ((b = state.array[pos++]) & 0x7FL) << 56;
+            if ((b & 0x80) == 0) {
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            b = state.array[pos++];
+            if ((b & 0x80) == 0) {
+                vl |= (long) b << 63;
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+
+            throw new DataEncodingException("Malformed var int");
+        }
+        blackhole.consume(state.sum);
+    }
+
+    /// A vectorized LEB128 similar to vector_smartLimitByteIntLong that also uses an XOR trick from Google impl.
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void vector_fastXOR(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
+        for (int invocation = 0, pos = 0; invocation < INVOCATIONS; invocation++) {
+            final int limit = Math.min(state.array.length, pos + 10);
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            int vi = state.array[pos++];
+            if (vi >= 0) {
+                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                continue;
+            }
+
+            // Fast path w/o any limit checks if we have all 10 bytes, or if it was a stream b/c we'd get an EOF
+            if (pos + 9 == limit) {
+                if ((vi ^= state.array[pos++] << 7) < 0) {
+                    vi ^= (~0 << 7);
+                    state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    continue;
+                }
+
+                if ((vi ^= state.array[pos++] << 14) >= 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14));
+                    state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    continue;
+                }
+
+                if ((vi ^= state.array[pos++] << 21) < 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                    state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    continue;
+                }
+
+                long vl = vi;
+                if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                if ((vl ^= (long) state.array[pos++] << 35) < 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                if ((vl ^= (long) state.array[pos++] << 56) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56));
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63));
+                    state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    continue;
+                }
+
+                throw new DataEncodingException("Malformed var int");
+            }
+
+            // Slower path because this is an array/buffer, and we have less than 9 bytes ahead
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vi ^= state.array[pos++] << 7) < 0) {
+                vi ^= (~0 << 7);
+                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vi ^= state.array[pos++] << 14) >= 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14));
+                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vi ^= state.array[pos++] << 21) < 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            long vl = vi;
+            if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vl ^= (long) state.array[pos++] << 35) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vl ^= (long) state.array[pos++] << 56) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56));
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                continue;
+            }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+            if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56)
+                        ^ (~0L << 63));
+                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                 continue;
             }
 

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -99,7 +99,7 @@ public class VarIntByteArrayReadBench {
     /// We use this algorithm everywhere in PBJ - in ReadableSequentialData , DirectBufferedData, RandomAccessData,
     /// ByteArrayBufferedData, and Bytes. It's known as "getVarLongRichard". The proper academic name is LEB128.
     /// It's also the Google slow-path algorithm as well.
-    // temp @Benchmark
+    @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void pbj(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -271,7 +271,7 @@ public class VarIntByteArrayReadBench {
     /// * zigZag is handled. Google's original readRawVarint64() doesn't handle zigZag directly.
     /// * limit checks are added. Google's original version relies on IOOBE. But PBJ can wrap array slices and still
     ///     must respect the length of the slice. So in PBJ we cannot rely on the IOOBE.
-    // temp @Benchmark
+    @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void google_zigZagAndLimit(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -820,7 +820,7 @@ public class VarIntByteArrayReadBench {
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
-                if (pos >= limit) throw new DataEncodingException("Malformed var int");
+                if (pos >= limit) break slowpath;
 
                 if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
                     vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -186,12 +186,12 @@ public class VarIntByteArrayReadBench {
     /// A slightly modified copy of Google implementation in CodecInputStream.
     /// PBJ used to use a very similar algorithm, just before https://github.com/hashgraph/pbj/pull/144
     /// where we switched to LEB128.
-    @Benchmark
+    // @Benchmark // disabled because PBJ requires zigZag handling and stricter limit checks
     @OperationsPerInvocation(INVOCATIONS)
     public void google(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
         for (int invocation = 0, pos = 0; invocation < INVOCATIONS; invocation++) {
-            final int limit = pos + 5;
+            final int limit = Math.min(state.array.length, pos + 10);
 
             fastpath:
             {
@@ -261,6 +261,92 @@ public class VarIntByteArrayReadBench {
                         break;
                     }
                 }
+            }
+        }
+        blackhole.consume(state.sum);
+    }
+
+    /// A modified version of the Google implementation adapted to PBJ.
+    /// Specifically:
+    /// * zigZag is handled. Google's original readRawVarint64() doesn't handle zigZag directly.
+    /// * limit checks are added. Google's original version relies on IOOBE. But PBJ can wrap array slices and still
+    ///     must respect the length of the slice. So in PBJ we cannot rely on the IOOBE.
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void google_zigZagAndLimit(final BenchState state, final Blackhole blackhole) {
+        state.sum = 0;
+        for (int invocation = 0, pos = 0; invocation < INVOCATIONS; invocation++) {
+            final int limit = Math.min(state.array.length, pos + 10);
+
+            fastpath:
+            {
+                int tempPos = pos;
+
+                if (limit == tempPos) {
+                    break fastpath;
+                }
+
+                long x;
+                int y;
+                if ((y = state.array[tempPos++]) >= 0) {
+                    pos = tempPos;
+                    state.sum += state.zigZag ? (y >>> 1) ^ -(y & 1) : y;
+                    continue;
+                } else if (limit - tempPos < 9) {
+                    break fastpath;
+                } else if ((y ^= (state.array[tempPos++] << 7)) < 0) {
+                    x = y ^ (~0 << 7);
+                } else if ((y ^= (state.array[tempPos++] << 14)) >= 0) {
+                    x = y ^ ((~0 << 7) ^ (~0 << 14));
+                } else if ((y ^= (state.array[tempPos++] << 21)) < 0) {
+                    x = y ^ ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                } else if ((x = y ^ (state.array[tempPos++] << 28)) >= 0L) {
+                    x ^= (~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28);
+                } else if ((x ^= (state.array[tempPos++] << 35)) < 0L) {
+                    x ^= (~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35);
+                } else if ((x ^= (state.array[tempPos++] << 42)) >= 0L) {
+                    x ^= (~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42);
+                } else if ((x ^= (state.array[tempPos++] << 49)) < 0L) {
+                    x ^= (~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49);
+                } else if ((x ^= (state.array[tempPos++] << 56)) >= 0L) {
+                    x ^= (~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56);
+                } else if ((x ^= (state.array[tempPos++] << 63)) >= 0L) {
+                    x ^= (~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63);
+                } else {
+                    break fastpath; // Will throw malformedVarint()
+                }
+                pos = tempPos;
+                state.sum += state.zigZag ? (x >>> 1) ^ -(x & 1) : x;
+                continue;
+            }
+
+            slowpath:
+            {
+                int result = 0;
+                for (int shift = 0; pos < limit && shift < 64; shift += 7) {
+                    final byte b = state.array[pos++];
+                    result |= (b & 0x7F) << shift;
+                    if ((b & 0x80) == 0) {
+                        state.sum += state.zigZag ? (result >>> 1) ^ -(result & 1) : result;
+                        break slowpath;
+                    }
+                }
+                throw new DataEncodingException("Malformed var int");
             }
         }
         blackhole.consume(state.sum);

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -532,7 +532,7 @@ public class VarIntByteArrayReadBench {
     /// A vectorized LEB128 version that:
     /// * avoids limit checks if we have enough bytes ahead (or if we relied on an EOFException in case of streams)
     /// * uses byte for 1 byte varint, int for a few bytes, and finally long for many bytes varint
-    @Benchmark
+    // @Benchmark // disabled because there's a faster version below
     @OperationsPerInvocation(INVOCATIONS)
     public void vector_smartLimitByteIntLong(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -685,11 +685,13 @@ public class VarIntByteArrayReadBench {
     public void vector_fastXOR(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
         for (int invocation = 0, pos = 0; invocation < INVOCATIONS; invocation++) {
-            final int limit = Math.min(state.array.length, pos + 10);
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+            final int limit;
+            if (pos >= (limit = Math.min(state.array.length, pos + 10))) {
+                throw new DataEncodingException("Malformed var int");
+            }
 
-            int vi = state.array[pos++];
-            if (vi >= 0) {
+            int vi;
+            if ((vi = state.array[pos++]) >= 0) {
                 state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
                 continue;
             }

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -99,7 +99,7 @@ public class VarIntByteArrayReadBench {
     /// We use this algorithm everywhere in PBJ - in ReadableSequentialData , DirectBufferedData, RandomAccessData,
     /// ByteArrayBufferedData, and Bytes. It's known as "getVarLongRichard". The proper academic name is LEB128.
     /// It's also the Google slow-path algorithm as well.
-    @Benchmark
+    // temp @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void pbj(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -271,7 +271,7 @@ public class VarIntByteArrayReadBench {
     /// * zigZag is handled. Google's original readRawVarint64() doesn't handle zigZag directly.
     /// * limit checks are added. Google's original version relies on IOOBE. But PBJ can wrap array slices and still
     ///     must respect the length of the slice. So in PBJ we cannot rely on the IOOBE.
-    @Benchmark
+    // temp @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void google_zigZagAndLimit(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -685,36 +685,124 @@ public class VarIntByteArrayReadBench {
     public void vector_fastXOR(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
         for (int invocation = 0, pos = 0; invocation < INVOCATIONS; invocation++) {
-            final int limit;
-            if (pos >= (limit = Math.min(state.array.length, pos + 10))) {
-                throw new DataEncodingException("Malformed var int");
+            final int limit = Math.min(state.array.length, pos + 10);
+
+            fastpath:
+            {
+                if (pos < limit) {
+                    int vi;
+                    if ((vi = state.array[pos++]) >= 0) {
+                        state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                        continue;
+                    } else if (pos + 9 == limit) {
+                        // Fast path w/o any limit checks if we have 9 more bytes
+                        if ((vi ^= state.array[pos++] << 7) < 0) {
+                            vi ^= (~0 << 7);
+                            state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                            continue;
+                        }
+
+                        if ((vi ^= state.array[pos++] << 14) >= 0) {
+                            vi ^= ((~0 << 7) ^ (~0 << 14));
+                            state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                            continue;
+                        }
+
+                        if ((vi ^= state.array[pos++] << 21) < 0) {
+                            vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                            state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                            continue;
+                        }
+
+                        long vl = vi;
+                        if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
+                            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                            continue;
+                        }
+
+                        if ((vl ^= (long) state.array[pos++] << 35) < 0L) {
+                            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                            continue;
+                        }
+
+                        if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
+                            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                            continue;
+                        }
+
+                        if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
+                            vl ^= ((~0L << 7)
+                                    ^ (~0L << 14)
+                                    ^ (~0L << 21)
+                                    ^ (~0L << 28)
+                                    ^ (~0L << 35)
+                                    ^ (~0L << 42)
+                                    ^ (~0L << 49));
+                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                            continue;
+                        }
+
+                        if ((vl ^= (long) state.array[pos++] << 56) >= 0L) {
+                            vl ^= ((~0L << 7)
+                                    ^ (~0L << 14)
+                                    ^ (~0L << 21)
+                                    ^ (~0L << 28)
+                                    ^ (~0L << 35)
+                                    ^ (~0L << 42)
+                                    ^ (~0L << 49)
+                                    ^ (~0L << 56));
+                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                            continue;
+                        }
+
+                        if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
+                            vl ^= ((~0L << 7)
+                                    ^ (~0L << 14)
+                                    ^ (~0L << 21)
+                                    ^ (~0L << 28)
+                                    ^ (~0L << 35)
+                                    ^ (~0L << 42)
+                                    ^ (~0L << 49)
+                                    ^ (~0L << 56)
+                                    ^ (~0L << 63));
+                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                            continue;
+                        }
+                    }
+                }
             }
 
-            int vi;
-            if ((vi = state.array[pos++]) >= 0) {
-                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                continue;
-            }
+            slowpath:
+            {
+                // Slower path because this is an array/buffer, and we have less than 9 (or even 10) bytes ahead
+                if (pos >= limit) break slowpath;
 
-            // Fast path w/o any limit checks if we have all 10 bytes, or if it was a stream b/c we'd get an EOF
-            if (pos + 9 == limit) {
+                // Since the above check is false, the pos was incremented in the fastpath above.
+                // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
+                int vi = state.array[pos - 1];
                 if ((vi ^= state.array[pos++] << 7) < 0) {
                     vi ^= (~0 << 7);
                     state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
                     continue;
                 }
+                if (pos >= limit) break slowpath;
 
                 if ((vi ^= state.array[pos++] << 14) >= 0) {
                     vi ^= ((~0 << 7) ^ (~0 << 14));
                     state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
                     continue;
                 }
+                if (pos >= limit) break slowpath;
 
                 if ((vi ^= state.array[pos++] << 21) < 0) {
                     vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
                     state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
                     continue;
                 }
+                if (pos >= limit) break slowpath;
 
                 long vl = vi;
                 if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
@@ -722,30 +810,28 @@ public class VarIntByteArrayReadBench {
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
+                if (pos >= limit) break slowpath;
 
                 if ((vl ^= (long) state.array[pos++] << 35) < 0L) {
                     vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
+                if (pos >= limit) throw new DataEncodingException("Malformed var int");
 
                 if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
                     vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
+                if (pos >= limit) break slowpath;
 
                 if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
-                    vl ^= ((~0L << 7)
-                            ^ (~0L << 14)
-                            ^ (~0L << 21)
-                            ^ (~0L << 28)
-                            ^ (~0L << 35)
-                            ^ (~0L << 42)
-                            ^ (~0L << 49));
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
+                if (pos >= limit) break slowpath;
 
                 if ((vl ^= (long) state.array[pos++] << 56) >= 0L) {
                     vl ^= ((~0L << 7)
@@ -759,6 +845,7 @@ public class VarIntByteArrayReadBench {
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
+                if (pos >= limit) break slowpath;
 
                 if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
                     vl ^= ((~0L << 7)
@@ -773,89 +860,6 @@ public class VarIntByteArrayReadBench {
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
-
-                throw new DataEncodingException("Malformed var int");
-            }
-
-            // Slower path because this is an array/buffer, and we have less than 9 bytes ahead
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vi ^= state.array[pos++] << 7) < 0) {
-                vi ^= (~0 << 7);
-                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vi ^= state.array[pos++] << 14) >= 0) {
-                vi ^= ((~0 << 7) ^ (~0 << 14));
-                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vi ^= state.array[pos++] << 21) < 0) {
-                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
-                state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            long vl = vi;
-            if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
-                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
-                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vl ^= (long) state.array[pos++] << 35) < 0L) {
-                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
-                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
-                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
-                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
-                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
-                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vl ^= (long) state.array[pos++] << 56) >= 0L) {
-                vl ^= ((~0L << 7)
-                        ^ (~0L << 14)
-                        ^ (~0L << 21)
-                        ^ (~0L << 28)
-                        ^ (~0L << 35)
-                        ^ (~0L << 42)
-                        ^ (~0L << 49)
-                        ^ (~0L << 56));
-                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                continue;
-            }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-            if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
-                vl ^= ((~0L << 7)
-                        ^ (~0L << 14)
-                        ^ (~0L << 21)
-                        ^ (~0L << 28)
-                        ^ (~0L << 35)
-                        ^ (~0L << 42)
-                        ^ (~0L << 49)
-                        ^ (~0L << 56)
-                        ^ (~0L << 63));
-                state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                continue;
             }
 
             throw new DataEncodingException("Malformed var int");

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -99,7 +99,7 @@ public class VarIntByteArrayReadBench {
     /// We use this algorithm everywhere in PBJ - in ReadableSequentialData , DirectBufferedData, RandomAccessData,
     /// ByteArrayBufferedData, and Bytes. It's known as "getVarLongRichard". The proper academic name is LEB128.
     /// It's also the Google slow-path algorithm as well.
-    // temp @Benchmark
+    @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void pbj(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -271,7 +271,7 @@ public class VarIntByteArrayReadBench {
     /// * zigZag is handled. Google's original readRawVarint64() doesn't handle zigZag directly.
     /// * limit checks are added. Google's original version relies on IOOBE. But PBJ can wrap array slices and still
     ///     must respect the length of the slice. So in PBJ we cannot rely on the IOOBE.
-    // temp @Benchmark
+    @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void google_zigZagAndLimit(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -685,92 +685,93 @@ public class VarIntByteArrayReadBench {
     public void vector_fastXOR(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
         for (int invocation = 0, pos = 0; invocation < INVOCATIONS; invocation++) {
+            int vi;
+            long vl;
             final int limit = Math.min(state.array.length, pos + 10);
 
             fastpath:
             {
-                if (pos < limit) {
-                    int vi;
-                    if ((vi = state.array[pos++]) >= 0) {
+                if (pos == limit) break fastpath;
+
+                if ((vi = state.array[pos++]) >= 0) {
+                    state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    continue;
+                } else if (pos + 9 == limit) {
+                    // Fast path w/o any limit checks if we have 9 more bytes
+                    if ((vi ^= state.array[pos++] << 7) < 0) {
+                        vi ^= (~0 << 7);
                         state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
                         continue;
-                    } else if (pos + 9 == limit) {
-                        // Fast path w/o any limit checks if we have 9 more bytes
-                        if ((vi ^= state.array[pos++] << 7) < 0) {
-                            vi ^= (~0 << 7);
-                            state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                            continue;
-                        }
+                    }
 
-                        if ((vi ^= state.array[pos++] << 14) >= 0) {
-                            vi ^= ((~0 << 7) ^ (~0 << 14));
-                            state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                            continue;
-                        }
+                    if ((vi ^= state.array[pos++] << 14) >= 0) {
+                        vi ^= ((~0 << 7) ^ (~0 << 14));
+                        state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                        continue;
+                    }
 
-                        if ((vi ^= state.array[pos++] << 21) < 0) {
-                            vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
-                            state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                            continue;
-                        }
+                    if ((vi ^= state.array[pos++] << 21) < 0) {
+                        vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                        state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                        continue;
+                    }
 
-                        long vl = vi;
-                        if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
-                            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
-                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                            continue;
-                        }
+                    vl = vi;
+                    if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
+                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                        state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                        continue;
+                    }
 
-                        if ((vl ^= (long) state.array[pos++] << 35) < 0L) {
-                            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
-                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                            continue;
-                        }
+                    if ((vl ^= (long) state.array[pos++] << 35) < 0L) {
+                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                        state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                        continue;
+                    }
 
-                        if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
-                            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
-                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                            continue;
-                        }
+                    if ((vl ^= (long) state.array[pos++] << 42) >= 0L) {
+                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                        state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                        continue;
+                    }
 
-                        if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
-                            vl ^= ((~0L << 7)
-                                    ^ (~0L << 14)
-                                    ^ (~0L << 21)
-                                    ^ (~0L << 28)
-                                    ^ (~0L << 35)
-                                    ^ (~0L << 42)
-                                    ^ (~0L << 49));
-                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                            continue;
-                        }
+                    if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
+                        vl ^= ((~0L << 7)
+                                ^ (~0L << 14)
+                                ^ (~0L << 21)
+                                ^ (~0L << 28)
+                                ^ (~0L << 35)
+                                ^ (~0L << 42)
+                                ^ (~0L << 49));
+                        state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                        continue;
+                    }
 
-                        if ((vl ^= (long) state.array[pos++] << 56) >= 0L) {
-                            vl ^= ((~0L << 7)
-                                    ^ (~0L << 14)
-                                    ^ (~0L << 21)
-                                    ^ (~0L << 28)
-                                    ^ (~0L << 35)
-                                    ^ (~0L << 42)
-                                    ^ (~0L << 49)
-                                    ^ (~0L << 56));
-                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                            continue;
-                        }
+                    if ((vl ^= (long) state.array[pos++] << 56) >= 0L) {
+                        vl ^= ((~0L << 7)
+                                ^ (~0L << 14)
+                                ^ (~0L << 21)
+                                ^ (~0L << 28)
+                                ^ (~0L << 35)
+                                ^ (~0L << 42)
+                                ^ (~0L << 49)
+                                ^ (~0L << 56));
+                        state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                        continue;
+                    }
 
-                        if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
-                            vl ^= ((~0L << 7)
-                                    ^ (~0L << 14)
-                                    ^ (~0L << 21)
-                                    ^ (~0L << 28)
-                                    ^ (~0L << 35)
-                                    ^ (~0L << 42)
-                                    ^ (~0L << 49)
-                                    ^ (~0L << 56)
-                                    ^ (~0L << 63));
-                            state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                            continue;
-                        }
+                    if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
+                        vl ^= ((~0L << 7)
+                                ^ (~0L << 14)
+                                ^ (~0L << 21)
+                                ^ (~0L << 28)
+                                ^ (~0L << 35)
+                                ^ (~0L << 42)
+                                ^ (~0L << 49)
+                                ^ (~0L << 56)
+                                ^ (~0L << 63));
+                        state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                        continue;
                     }
                 }
             }
@@ -780,9 +781,10 @@ public class VarIntByteArrayReadBench {
                 // Slower path because this is an array/buffer, and we have less than 9 (or even 10) bytes ahead
                 if (pos >= limit) break slowpath;
 
-                // Since the above check is false, the pos was incremented in the fastpath above.
+                // Since the above check is false, the pos was incremented in the fastpath above, and vi is actually
+                // assigned there. However, javac is unable to see this and throw an error. So we re-initialize it.
                 // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
-                int vi = state.array[pos - 1];
+                vi = state.array[pos - 1];
                 if ((vi ^= state.array[pos++] << 7) < 0) {
                     vi ^= (~0 << 7);
                     state.sum += state.zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
@@ -804,7 +806,7 @@ public class VarIntByteArrayReadBench {
                 }
                 if (pos >= limit) break slowpath;
 
-                long vl = vi;
+                vl = vi;
                 if ((vl ^= (long) state.array[pos++] << 28) >= 0L) {
                     vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
@@ -827,7 +829,13 @@ public class VarIntByteArrayReadBench {
                 if (pos >= limit) break slowpath;
 
                 if ((vl ^= (long) state.array[pos++] << 49) < 0L) {
-                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -99,7 +99,7 @@ public class VarIntByteArrayReadBench {
     /// We use this algorithm everywhere in PBJ - in ReadableSequentialData , DirectBufferedData, RandomAccessData,
     /// ByteArrayBufferedData, and Bytes. It's known as "getVarLongRichard". The proper academic name is LEB128.
     /// It's also the Google slow-path algorithm as well.
-    @Benchmark
+    // temp @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void pbj(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -271,7 +271,7 @@ public class VarIntByteArrayReadBench {
     /// * zigZag is handled. Google's original readRawVarint64() doesn't handle zigZag directly.
     /// * limit checks are added. Google's original version relies on IOOBE. But PBJ can wrap array slices and still
     ///     must respect the length of the slice. So in PBJ we cannot rely on the IOOBE.
-    @Benchmark
+    // temp @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void google_zigZagAndLimit(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -760,7 +760,8 @@ public class VarIntByteArrayReadBench {
                         continue;
                     }
 
-                    if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
+                    if (state.array[pos++] < 0) break fastpath;
+                    if ((vl ^= (long) state.array[pos - 1] << 63) >= 0L) {
                         vl ^= ((~0L << 7)
                                 ^ (~0L << 14)
                                 ^ (~0L << 21)
@@ -853,9 +854,9 @@ public class VarIntByteArrayReadBench {
                     state.sum += state.zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                     continue;
                 }
-                if (pos >= limit) break slowpath;
+                if (pos >= limit || state.array[pos++] < 0) break slowpath;
 
-                if ((vl ^= (long) state.array[pos++] << 63) >= 0L) {
+                if ((vl ^= (long) state.array[pos - 1] << 63) >= 0L) {
                     vl ^= ((~0L << 7)
                             ^ (~0L << 14)
                             ^ (~0L << 21)

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/varint/read/VarIntByteArrayReadBench.java
@@ -186,8 +186,7 @@ public class VarIntByteArrayReadBench {
     /// A slightly modified copy of Google implementation in CodecInputStream.
     /// PBJ used to use a very similar algorithm, just before https://github.com/hashgraph/pbj/pull/144
     /// where we switched to LEB128.
-    @SuppressWarnings("lossy-conversions") // the impl is able to support longs, but we ignore that here and use ints.
-    // @Benchmark // disabled because it performs worse than the standard pbj implementation
+    @Benchmark
     @OperationsPerInvocation(INVOCATIONS)
     public void google(final BenchState state, final Blackhole blackhole) {
         state.sum = 0;
@@ -202,7 +201,7 @@ public class VarIntByteArrayReadBench {
                     break fastpath;
                 }
 
-                int x;
+                long x;
                 int y;
                 if ((y = state.array[tempPos++]) >= 0) {
                     pos = tempPos;

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
@@ -102,53 +102,136 @@ public class VectorVarIntTest {
 
     /// A refactored copy from VarIntByteArrayReadBench.vector_fastXOR.
     private long readVarInt_fastXOR(byte[] bytes, int pos, boolean zigZag) {
-        final int limit;
-        if (pos >= (limit = Math.min(bytes.length, pos + 10))) {
-            throw new DataEncodingException("Malformed var int");
+        final int limit = Math.min(bytes.length, pos + 10);
+
+        fastpath:
+        {
+            if (pos < limit) {
+                int vi;
+                if ((vi = bytes[pos++]) >= 0) {
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                } else if (pos + 9 == limit) {
+                    // Fast path w/o any limit checks if we have 9 more bytes
+                    if ((vi ^= bytes[pos++] << 7) < 0) {
+                        vi ^= (~0 << 7);
+                        return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    }
+
+                    if ((vi ^= bytes[pos++] << 14) >= 0) {
+                        vi ^= ((~0 << 7) ^ (~0 << 14));
+                        return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    }
+
+                    if ((vi ^= bytes[pos++] << 21) < 0) {
+                        vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                        return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                    }
+
+                    long vl = vi;
+                    if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
+                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    }
+
+                    if ((vl ^= (long) bytes[pos++] << 35) < 0L) {
+                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    }
+
+                    if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
+                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    }
+
+                    if ((vl ^= (long) bytes[pos++] << 49) < 0L) {
+                        vl ^= ((~0L << 7)
+                                ^ (~0L << 14)
+                                ^ (~0L << 21)
+                                ^ (~0L << 28)
+                                ^ (~0L << 35)
+                                ^ (~0L << 42)
+                                ^ (~0L << 49));
+                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    }
+
+                    if ((vl ^= (long) bytes[pos++] << 56) >= 0L) {
+                        vl ^= ((~0L << 7)
+                                ^ (~0L << 14)
+                                ^ (~0L << 21)
+                                ^ (~0L << 28)
+                                ^ (~0L << 35)
+                                ^ (~0L << 42)
+                                ^ (~0L << 49)
+                                ^ (~0L << 56));
+                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    }
+
+                    if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
+                        vl ^= ((~0L << 7)
+                                ^ (~0L << 14)
+                                ^ (~0L << 21)
+                                ^ (~0L << 28)
+                                ^ (~0L << 35)
+                                ^ (~0L << 42)
+                                ^ (~0L << 49)
+                                ^ (~0L << 56)
+                                ^ (~0L << 63));
+                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                    }
+                }
+            }
         }
 
-        int vi;
-        if ((vi = bytes[pos++]) >= 0) {
-            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-        }
+        slowpath:
+        {
+            // Slower path because this is an array/buffer, and we have less than 9 (or even 10) bytes ahead
+            if (pos >= limit) break slowpath;
 
-        // Fast path w/o any limit checks if we have all 10 bytes, or if it was a stream b/c we'd get an EOF
-        if (pos + 9 == limit) {
+            // Since the above check is false, the pos was incremented in the fastpath above.
+            // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
+            int vi = bytes[pos - 1];
             if ((vi ^= bytes[pos++] << 7) < 0) {
                 vi ^= (~0 << 7);
                 return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
             }
+            if (pos >= limit) break slowpath;
 
             if ((vi ^= bytes[pos++] << 14) >= 0) {
                 vi ^= ((~0 << 7) ^ (~0 << 14));
                 return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
             }
+            if (pos >= limit) break slowpath;
 
             if ((vi ^= bytes[pos++] << 21) < 0) {
                 vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
                 return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
             }
+            if (pos >= limit) break slowpath;
 
             long vl = vi;
             if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
                 vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
             }
+            if (pos >= limit) break slowpath;
 
             if ((vl ^= (long) bytes[pos++] << 35) < 0L) {
                 vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
             }
+            if (pos >= limit) throw new DataEncodingException("Malformed var int");
 
             if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
                 vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
             }
+            if (pos >= limit) break slowpath;
 
             if ((vl ^= (long) bytes[pos++] << 49) < 0L) {
                 vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
             }
+            if (pos >= limit) break slowpath;
 
             if ((vl ^= (long) bytes[pos++] << 56) >= 0L) {
                 vl ^= ((~0L << 7)
@@ -161,6 +244,7 @@ public class VectorVarIntTest {
                         ^ (~0L << 56));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
             }
+            if (pos >= limit) break slowpath;
 
             if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
                 vl ^= ((~0L << 7)
@@ -174,80 +258,6 @@ public class VectorVarIntTest {
                         ^ (~0L << 63));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
             }
-
-            throw new DataEncodingException("Malformed var int");
-        }
-
-        // Slower path because this is an array/buffer, and we have less than 9 bytes ahead
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vi ^= bytes[pos++] << 7) < 0) {
-            vi ^= (~0 << 7);
-            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vi ^= bytes[pos++] << 14) >= 0) {
-            vi ^= ((~0 << 7) ^ (~0 << 14));
-            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vi ^= bytes[pos++] << 21) < 0) {
-            vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
-            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        long vl = vi;
-        if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
-            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
-            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vl ^= (long) bytes[pos++] << 35) < 0L) {
-            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
-            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
-            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
-            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vl ^= (long) bytes[pos++] << 49) < 0L) {
-            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
-            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vl ^= (long) bytes[pos++] << 56) >= 0L) {
-            vl ^= ((~0L << 7)
-                    ^ (~0L << 14)
-                    ^ (~0L << 21)
-                    ^ (~0L << 28)
-                    ^ (~0L << 35)
-                    ^ (~0L << 42)
-                    ^ (~0L << 49)
-                    ^ (~0L << 56));
-            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-        }
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
-
-        if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
-            vl ^= ((~0L << 7)
-                    ^ (~0L << 14)
-                    ^ (~0L << 21)
-                    ^ (~0L << 28)
-                    ^ (~0L << 35)
-                    ^ (~0L << 42)
-                    ^ (~0L << 49)
-                    ^ (~0L << 56)
-                    ^ (~0L << 63));
-            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
         }
 
         throw new DataEncodingException("Malformed var int");

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
@@ -102,11 +102,13 @@ public class VectorVarIntTest {
 
     /// A refactored copy from VarIntByteArrayReadBench.vector_fastXOR.
     private long readVarInt_fastXOR(byte[] bytes, int pos, boolean zigZag) {
-        final int limit = Math.min(bytes.length, pos + 10);
-        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+        final int limit;
+        if (pos >= (limit = Math.min(bytes.length, pos + 10))) {
+            throw new DataEncodingException("Malformed var int");
+        }
 
-        int vi = bytes[pos++];
-        if (vi >= 0) {
+        int vi;
+        if ((vi = bytes[pos++]) >= 0) {
             return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
         }
 

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
@@ -102,82 +102,83 @@ public class VectorVarIntTest {
 
     /// A refactored copy from VarIntByteArrayReadBench.vector_fastXOR.
     private long readVarInt_fastXOR(byte[] bytes, int pos, boolean zigZag) {
+        int vi;
+        long vl;
         final int limit = Math.min(bytes.length, pos + 10);
 
         fastpath:
         {
-            if (pos < limit) {
-                int vi;
-                if ((vi = bytes[pos++]) >= 0) {
+            if (pos == limit) break fastpath;
+
+            if ((vi = bytes[pos++]) >= 0) {
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            } else if (pos + 9 == limit) {
+                // Fast path w/o any limit checks if we have 9 more bytes
+                if ((vi ^= bytes[pos++] << 7) < 0) {
+                    vi ^= (~0 << 7);
                     return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                } else if (pos + 9 == limit) {
-                    // Fast path w/o any limit checks if we have 9 more bytes
-                    if ((vi ^= bytes[pos++] << 7) < 0) {
-                        vi ^= (~0 << 7);
-                        return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                    }
+                }
 
-                    if ((vi ^= bytes[pos++] << 14) >= 0) {
-                        vi ^= ((~0 << 7) ^ (~0 << 14));
-                        return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                    }
+                if ((vi ^= bytes[pos++] << 14) >= 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
 
-                    if ((vi ^= bytes[pos++] << 21) < 0) {
-                        vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
-                        return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
-                    }
+                if ((vi ^= bytes[pos++] << 21) < 0) {
+                    vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                    return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+                }
 
-                    long vl = vi;
-                    if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
-                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
-                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                    }
+                vl = vi;
+                if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
 
-                    if ((vl ^= (long) bytes[pos++] << 35) < 0L) {
-                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
-                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                    }
+                if ((vl ^= (long) bytes[pos++] << 35) < 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
 
-                    if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
-                        vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
-                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                    }
+                if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
+                    vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
 
-                    if ((vl ^= (long) bytes[pos++] << 49) < 0L) {
-                        vl ^= ((~0L << 7)
-                                ^ (~0L << 14)
-                                ^ (~0L << 21)
-                                ^ (~0L << 28)
-                                ^ (~0L << 35)
-                                ^ (~0L << 42)
-                                ^ (~0L << 49));
-                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                    }
+                if ((vl ^= (long) bytes[pos++] << 49) < 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
 
-                    if ((vl ^= (long) bytes[pos++] << 56) >= 0L) {
-                        vl ^= ((~0L << 7)
-                                ^ (~0L << 14)
-                                ^ (~0L << 21)
-                                ^ (~0L << 28)
-                                ^ (~0L << 35)
-                                ^ (~0L << 42)
-                                ^ (~0L << 49)
-                                ^ (~0L << 56));
-                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                    }
+                if ((vl ^= (long) bytes[pos++] << 56) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+                }
 
-                    if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
-                        vl ^= ((~0L << 7)
-                                ^ (~0L << 14)
-                                ^ (~0L << 21)
-                                ^ (~0L << 28)
-                                ^ (~0L << 35)
-                                ^ (~0L << 42)
-                                ^ (~0L << 49)
-                                ^ (~0L << 56)
-                                ^ (~0L << 63));
-                        return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
-                    }
+                if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
+                    vl ^= ((~0L << 7)
+                            ^ (~0L << 14)
+                            ^ (~0L << 21)
+                            ^ (~0L << 28)
+                            ^ (~0L << 35)
+                            ^ (~0L << 42)
+                            ^ (~0L << 49)
+                            ^ (~0L << 56)
+                            ^ (~0L << 63));
+                    return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                 }
             }
         }
@@ -187,9 +188,10 @@ public class VectorVarIntTest {
             // Slower path because this is an array/buffer, and we have less than 9 (or even 10) bytes ahead
             if (pos >= limit) break slowpath;
 
-            // Since the above check is false, the pos was incremented in the fastpath above.
+            // Since the above check is false, the pos was incremented in the fastpath above, and vi is actually
+            // assigned there. However, javac is unable to see this and throw an error. So we re-initialize it.
             // This byte is in CPU L1 cache, so this should be fast. Also, this is a slowpath anyway.
-            int vi = bytes[pos - 1];
+            vi = bytes[pos - 1];
             if ((vi ^= bytes[pos++] << 7) < 0) {
                 vi ^= (~0 << 7);
                 return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
@@ -208,7 +210,7 @@ public class VectorVarIntTest {
             }
             if (pos >= limit) break slowpath;
 
-            long vl = vi;
+            vl = vi;
             if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
                 vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
@@ -99,4 +99,173 @@ public class VectorVarIntTest {
             bd.reset();
         }
     }
+
+    /// A refactored copy from VarIntByteArrayReadBench.vector_fastXOR.
+    private long readVarInt_fastXOR(byte[] bytes, int pos, boolean zigZag) {
+        final int limit = Math.min(bytes.length, pos + 10);
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        int vi = bytes[pos++];
+        if (vi >= 0) {
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+        }
+
+        // Fast path w/o any limit checks if we have all 10 bytes, or if it was a stream b/c we'd get an EOF
+        if (pos + 9 == limit) {
+            if ((vi ^= bytes[pos++] << 7) < 0) {
+                vi ^= (~0 << 7);
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+
+            if ((vi ^= bytes[pos++] << 14) >= 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+
+            if ((vi ^= bytes[pos++] << 21) < 0) {
+                vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+                return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+            }
+
+            long vl = vi;
+            if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+
+            if ((vl ^= (long) bytes[pos++] << 35) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+
+            if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+
+            if ((vl ^= (long) bytes[pos++] << 49) < 0L) {
+                vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+
+            if ((vl ^= (long) bytes[pos++] << 56) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+
+            if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
+                vl ^= ((~0L << 7)
+                        ^ (~0L << 14)
+                        ^ (~0L << 21)
+                        ^ (~0L << 28)
+                        ^ (~0L << 35)
+                        ^ (~0L << 42)
+                        ^ (~0L << 49)
+                        ^ (~0L << 56)
+                        ^ (~0L << 63));
+                return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+            }
+
+            throw new DataEncodingException("Malformed var int");
+        }
+
+        // Slower path because this is an array/buffer, and we have less than 9 bytes ahead
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vi ^= bytes[pos++] << 7) < 0) {
+            vi ^= (~0 << 7);
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vi ^= bytes[pos++] << 14) >= 0) {
+            vi ^= ((~0 << 7) ^ (~0 << 14));
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vi ^= bytes[pos++] << 21) < 0) {
+            vi ^= ((~0 << 7) ^ (~0 << 14) ^ (~0 << 21));
+            return zigZag ? (vi >>> 1) ^ -(vi & 1) : vi;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        long vl = vi;
+        if ((vl ^= (long) bytes[pos++] << 28) >= 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vl ^= (long) bytes[pos++] << 35) < 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vl ^= (long) bytes[pos++] << 49) < 0L) {
+            vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42) ^ (~0L << 49));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vl ^= (long) bytes[pos++] << 56) >= 0L) {
+            vl ^= ((~0L << 7)
+                    ^ (~0L << 14)
+                    ^ (~0L << 21)
+                    ^ (~0L << 28)
+                    ^ (~0L << 35)
+                    ^ (~0L << 42)
+                    ^ (~0L << 49)
+                    ^ (~0L << 56));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+        }
+        if (pos >= limit) throw new DataEncodingException("Malformed var int");
+
+        if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
+            vl ^= ((~0L << 7)
+                    ^ (~0L << 14)
+                    ^ (~0L << 21)
+                    ^ (~0L << 28)
+                    ^ (~0L << 35)
+                    ^ (~0L << 42)
+                    ^ (~0L << 49)
+                    ^ (~0L << 56)
+                    ^ (~0L << 63));
+            return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
+        }
+
+        throw new DataEncodingException("Malformed var int");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testVectorVarInt_fastXOR(boolean zigZag) {
+        final byte[] bytes = new byte[64];
+        final BufferedData bd = BufferedData.wrap(bytes);
+        final Random random = new Random(457639854);
+
+        for (int i = 0; i < 10 * 1024 * 1024; i++) {
+            final int val = random.nextInt();
+            Arrays.fill(bytes, (byte) 0);
+            bd.writeVarInt(val, zigZag);
+
+            assertEquals(val, readVarInt_fastXOR(bytes, 0, zigZag));
+
+            bd.reset();
+        }
+    }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/VectorVarIntTest.java
@@ -168,7 +168,8 @@ public class VectorVarIntTest {
                     return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
                 }
 
-                if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
+                if (bytes[pos++] < 0) break fastpath;
+                if ((vl ^= (long) bytes[pos - 1] << 63) >= 0L) {
                     vl ^= ((~0L << 7)
                             ^ (~0L << 14)
                             ^ (~0L << 21)
@@ -221,7 +222,7 @@ public class VectorVarIntTest {
                 vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35));
                 return zigZag ? (vl >>> 1) ^ -(vl & 1) : vl;
             }
-            if (pos >= limit) throw new DataEncodingException("Malformed var int");
+            if (pos >= limit) break slowpath;
 
             if ((vl ^= (long) bytes[pos++] << 42) >= 0L) {
                 vl ^= ((~0L << 7) ^ (~0L << 14) ^ (~0L << 21) ^ (~0L << 28) ^ (~0L << 35) ^ (~0L << 42));
@@ -248,7 +249,8 @@ public class VectorVarIntTest {
             }
             if (pos >= limit) break slowpath;
 
-            if ((vl ^= (long) bytes[pos++] << 63) >= 0L) {
+            if (bytes[pos++] < 0) break slowpath;
+            if ((vl ^= (long) bytes[pos - 1] << 63) >= 0L) {
                 vl ^= ((~0L << 7)
                         ^ (~0L << 14)
                         ^ (~0L << 21)


### PR DESCRIPTION
**Description**:
Updating the varint parsing implementation by:
* unrolling loops
* first using an `int`, and then switching to a `long` accumulator to reduce the cost of bitwise operations
* adopting the Google XOR trick where OR is replaced with XOR w/o clearing the sign bits when adding bytes, and only clearing them all at once with one final XOR on the accumulator.
* adding fast/slow paths, with the fast path bypassing limit checks (which is possible when we parse an array or a buffer where the limit is known upfront)
* fixing a bug still present in the Google implementation in the current benchmark (as well as in Google's actual code) that happily accepts 10 `-1` bytes and interprets them as a varint with value `-1`, even though this is a malformed representation that must throw an exception.
* eliminating the Google's "tempPos" local variable, and ensuring all local variables are allocated on the stack just once to avoid extending the local stack frame in the middle of the method execution dynamically.

A unit test is added to verify the correctness of the new algorithm. All the PBJ implementations are updated: ReadableSequentialData , DirectBufferedData, RandomAccessData, ByteArrayBufferedData, and Bytes. The benchmark is updated as well.

**Performance testing**:

The benchmark was run on a real Linux AMD hardware: https://github.com/hashgraph/pbj/actions/runs/25944398410/job/76269270691

The current PBJ implementation appears to be slower than Google. Please note that previously, this wasn't the case on Linux AMD, as can be seen at https://github.com/hashgraph/pbj/pull/797#issuecomment-4356425712 . I'm unsure what caused the discrepancy, but Google implementation is currently consistently faster than the current PBJ implementation. Our new implementation introduced in this fix is even superior to Google:
* 1 byte - same performance
* 2 byte - 10% faster
* longer varints - ~1% faster

The performance improvements are reproducible consistently after multiple re-runs (can be seen at https://github.com/hashgraph/pbj/actions/workflows/performance-PBJ-JMH.yml ).

```
Benchmark                                       (range)   Mode  Cnt     Score    Error   Units
VarIntByteArrayReadBench.google_zigZagAndLimit        1  thrpt   15  1707.264 ±  0.714  ops/us
VarIntByteArrayReadBench.google_zigZagAndLimit        2  thrpt   15   924.932 ±  1.002  ops/us
VarIntByteArrayReadBench.google_zigZagAndLimit        3  thrpt   15   755.884 ±  9.184  ops/us
VarIntByteArrayReadBench.google_zigZagAndLimit        4  thrpt   15   639.781 ±  0.721  ops/us
VarIntByteArrayReadBench.google_zigZagAndLimit        5  thrpt   15   360.415 ±  0.140  ops/us
VarIntByteArrayReadBench.pbj                          1  thrpt   15  1242.653 ±  2.002  ops/us
VarIntByteArrayReadBench.pbj                          2  thrpt   15   258.054 ±  0.237  ops/us
VarIntByteArrayReadBench.pbj                          3  thrpt   15   242.877 ±  0.095  ops/us
VarIntByteArrayReadBench.pbj                          4  thrpt   15   187.489 ±  0.156  ops/us
VarIntByteArrayReadBench.pbj                          5  thrpt   15   187.103 ± 15.050  ops/us
VarIntByteArrayReadBench.vector_fastXOR               1  thrpt   15  1708.714 ±  1.432  ops/us
VarIntByteArrayReadBench.vector_fastXOR               2  thrpt   15  1025.616 ±  1.081  ops/us
VarIntByteArrayReadBench.vector_fastXOR               3  thrpt   15   782.612 ±  0.535  ops/us
VarIntByteArrayReadBench.vector_fastXOR               4  thrpt   15   687.230 ±  0.584  ops/us
VarIntByteArrayReadBench.vector_fastXOR               5  thrpt   15   365.028 ± 55.450  ops/us
```

**Related issue(s)**:

Fixes #798 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
