### PR TITLE
perf: default stmt to func

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -126,6 +126,8 @@ public final class CodecGenerator implements Generator {
         writer.addImport("static com.hedera.pbj.runtime.ProtoConstants.*");
         writer.addImport("static com.hedera.pbj.runtime.Utf8Tools.*");
 
+        var sbFunc = new StringBuilder();
+
         // spotless:off
         writer.append("""
                 /**
@@ -164,7 +166,7 @@ public final class CodecGenerator implements Generator {
                 .replace("$codecClass", codecClassName)
                 .replace("$cacheableSupport", cacheableSupport)
                 .replace("$unsetOneOfConstants", CodecParseMethodGenerator.generateUnsetOneOfConstants(fields))
-                .replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(modelClassName, schemaClassName, fields, !cacheableSupport.isBlank()))
+                .replace("$parseMethod", CodecParseMethodGenerator.generateParseMethod(sbFunc, modelClassName, schemaClassName, fields, !cacheableSupport.isBlank()))
                 .replace("$writeMethod", writeMethod)
                 .replace("$writeByteArrayMethod", writeByteArrayMethod)
                 .replace("$measureDataMethod", CodecMeasureDataMethodGenerator.generateMeasureMethod(modelClassName, fields))
@@ -172,6 +174,7 @@ public final class CodecGenerator implements Generator {
                 .replace("$fastEqualsMethod", CodecFastEqualsMethodGenerator.generateFastEqualsMethod(modelClassName, fields))
                 .replace("$getDefaultInstanceMethod", generateGetDefaultInstanceMethod(modelClassName))
         );
+        writer.append(sbFunc.toString());
         // spotless:on
 
         for (final var item : msgDef.messageBody().messageElement()) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -48,12 +48,14 @@ class CodecParseMethodGenerator {
     }
 
     static String generateParseMethod(
+            StringBuilder sbFuncMain,
             final String modelClassName,
             final String schemaClassName,
             final List<Field> fields,
             final boolean isCacheable) {
 
-        var parseLoopLs = generateParseLoop(generateCaseStatements(fields, schemaClassName), "", schemaClassName);
+        var parseLoopLs =
+                generateParseLoop(generateCaseStatements(sbFuncMain, fields, schemaClassName), "", schemaClassName);
         // spotless:off
         var retString = """
                 /**
@@ -263,20 +265,20 @@ if ($prefixf == null) {
      * @param fields list of all fields in record
      * @return string of case statement code
      */
-    private static String generateCaseStatements(final List<Field> fields, final String schemaClassName) {
+    private static String generateCaseStatements(StringBuilder sbFunc, List<Field> fields, String schemaClassName) {
         StringBuilder sb = new StringBuilder();
         for (Field field : fields) {
             if (field instanceof final OneOfField oneOfField) {
                 for (final Field subField : oneOfField.fields()) {
-                    generateFieldCaseStatement(sb, subField, schemaClassName);
+                    generateFieldCaseStatement(sb, sbFunc, subField, schemaClassName);
                 }
             } else if (field.repeated() && field.type().wireType() != Common.TYPE_LENGTH_DELIMITED) {
                 // for repeated fields that are not length encoded there are 2 forms they can be stored in file.
                 // "packed" and repeated primitive fields
-                generateFieldCaseStatement(sb, field, schemaClassName);
-                generateFieldCaseStatementPacked(sb, field);
+                generateFieldCaseStatement(sb, sbFunc, field, schemaClassName);
+                generateFieldCaseStatementPacked(sb, sbFunc, field);
             } else {
-                generateFieldCaseStatement(sb, field, schemaClassName);
+                generateFieldCaseStatement(sb, sbFunc, field, schemaClassName);
             }
         }
         return sb.toString().indent(DEFAULT_INDENT * 4);
@@ -286,16 +288,24 @@ if ($prefixf == null) {
      * Generate switch case statement for a repeated numeric value type in packed encoding.
      *
      * @param field field to generate case statement for
-     * @param sb StringBuilder to append code to
+     * @param sbCase code written in case statement
+     * @param sbFunc code written in class scope, used to create functions
      */
     @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-    private static void generateFieldCaseStatementPacked(final StringBuilder sb, final Field field) {
+    private static void generateFieldCaseStatementPacked(
+            StringBuilder sbCase, StringBuilder sbFunc, final Field field) {
         final int wireType = Common.TYPE_LENGTH_DELIMITED;
         final int fieldNum = field.fieldNumber();
         final int tag = Common.getTag(wireType, fieldNum);
+        var fieldType =
+                field.type() == Field.FieldType.ENUM ? field.repeated() ? "List" : "Object" : field.javaFieldType();
+        var tempFieldName = "temp_" + field.name();
         // spotless:off
-        sb.append("case %d /* type=%d [%s] packed-repeated field=%d [%s] */ -> {%n"
+        sbCase.append("case %d /* type=%d [%s] packed-repeated field=%d [%s] */ -> {%n"
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
+        sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
+        sbFunc.append("""
+%s case%d(ReadableSequentialData input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         if (field.type() == Field.FieldType.ENUM) {
             // spotless:off
@@ -314,7 +324,7 @@ if ($prefixf == null) {
         } else {
             preRead = "";
         }
-        sb.append("""
+        sbFunc.append("""
                 // Read the length of packed repeated field data
                 final long length = input.readVarInt(false);
                 if (length > $maxSize) {
@@ -332,13 +342,14 @@ if ($prefixf == null) {
                 input.limit(beforeLimit);
                 if (input.position() != beforePosition + length) {
                     throw new BufferUnderflowException();
-                }""".replace("$tempFieldName", "temp_" + field.name())
+                }""".replace("$tempFieldName", tempFieldName)
                 .replace("$preRead", preRead)
                 .replace("$readMethod", field.type() == Field.FieldType.ENUM ? "value" : readMethod(field))
                 .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                 .replace("$fieldName", field.name())
                 .indent(DEFAULT_INDENT));
-        sb.append("\n}\n");
+        sbCase.append("\n}\n");
+        sbFunc.append("    return %s;\n    }\n".formatted(tempFieldName));
         // spotless:on
     }
 
@@ -346,20 +357,21 @@ if ($prefixf == null) {
      * Generate switch case statement for a field.
      *
      * @param field field to generate case statement for
-     * @param sb StringBuilder to append code to
+     * @param sbCase code written in case statement
+     * @param sbFunc code written in class scope, used to create functions
      */
     private static void generateFieldCaseStatement(
-            final StringBuilder sb, final Field field, final String schemaClassName) {
+            StringBuilder sbCase, StringBuilder sbFunc, final Field field, final String schemaClassName) {
         final int wireType = field.optionalValueType()
                 ? Common.TYPE_LENGTH_DELIMITED
                 : field.type().wireType();
         final int fieldNum = field.fieldNumber();
         final int tag = Common.getTag(wireType, fieldNum);
         // spotless:off
-        sb.append("case %d /* type=%d [%s] field=%d [%s] */ -> {%n"
+        sbCase.append("case %d /* type=%d [%s] field=%d [%s] */ -> {%n"
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         if (field.optionalValueType()) {
-            sb.append("""
+            sbCase.append("""
                             // Read the message size, it is not needed
                             final var valueTypeMessageSize = input.readVarInt(false);
                             final $fieldType value;
@@ -401,11 +413,11 @@ if ($prefixf == null) {
                             }))
                     .indent(DEFAULT_INDENT)
             );
-            sb.append('\n');
+            sbCase.append('\n');
             // spotless:on
         } else if (field.type() == Field.FieldType.MESSAGE) {
             // spotless:off
-            sb.append("""
+            sbCase.append("""
                         final var messageLength = input.readVarInt(false);
                         final $fieldType value;
                         if (messageLength == 0) {
@@ -448,9 +460,9 @@ if ($prefixf == null) {
             final MapField mapField = (MapField) field;
             final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
             var parseLoopLs = generateParseLoop(
-                    generateCaseStatements(mapEntryFields, schemaClassName), "map_entry_", schemaClassName);
+                    generateCaseStatements(sbFunc, mapEntryFields, schemaClassName), "map_entry_", schemaClassName);
             // spotless:off
-            sb.append("""
+            sbCase.append("""
                         final var __map_messageLength = input.readVarInt(false);
                         
                         $fieldDefs
@@ -490,7 +502,7 @@ if ($prefixf == null) {
             // spotless:on
         } else if (field.type() == Field.FieldType.ENUM) {
             // spotless:off
-            sb.append("""
+            sbCase.append("""
                         final int enumOrdinal = readEnum(input);
                         final var value = $enumName.fromProtobufOrdinal(enumOrdinal);
                         """
@@ -500,20 +512,20 @@ if ($prefixf == null) {
             );
             // spotless:on
         } else {
-            sb.append(("final var value = " + readMethod(field) + ";\n").indent(DEFAULT_INDENT));
+            sbCase.append(("final var value = " + readMethod(field) + ";\n").indent(DEFAULT_INDENT));
         }
         // set value to temp var
         // spotless:off
-        sb.append(Common.FIELD_INDENT);
+        sbCase.append(Common.FIELD_INDENT);
         if (field.parent() != null && field.repeated()) {
             throw new PbjCompilerException("Fields can not be oneof and repeated ["+field+"]");
         } else if (field.parent() != null) {
             final var oneOfField = field.parent();
-            sb.append("temp_%s =  new %s<>(%s.%s, value);%n"
+            sbCase.append("temp_%s =  new %s<>(%s.%s, value);%n"
                     .formatted(oneOfField.name(), oneOfField.className(), oneOfField.getEnumClassRef(),
                             Common.camelToUpperSnake(field.name())));
         } else if (field.repeated()) {
-            sb.append(
+            sbCase.append(
                 """
                 if (temp_%s.size() >= %s) {
                     throw new ParseException("%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
@@ -522,7 +534,7 @@ if ($prefixf == null) {
                 """.formatted(field.name(), field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize"));
         } else if (field.type() == Field.FieldType.MAP) {
             final MapField mapField = (MapField) field;
-            sb.append(
+            sbCase.append(
                 """
                 if (__map_messageLength != 0) {
                     if (temp_%s.size() >= %s) {
@@ -534,7 +546,7 @@ if ($prefixf == null) {
                         mapField.keyField().name(), mapField.valueField().name()));
         } else if (field.type() == Field.FieldType.ENUM) {
             // spotless:off
-            sb.append("""
+            sbCase.append("""
                         temp_$fieldName = value != $enumName.UNRECOGNIZED ? value : Integer.valueOf(enumOrdinal);
                         """
                     .replace("$enumName", Common.snakeToCamel(field.messageType(), true))
@@ -543,9 +555,9 @@ if ($prefixf == null) {
             );
             // spotless:on
         } else {
-            sb.append("temp_%s = value;\n".formatted(field.name()));
+            sbCase.append("temp_%s = value;\n".formatted(field.name()));
         }
-        sb.append("}\n");
+        sbCase.append("}\n");
         // spotless:on
     }
 

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -10,6 +10,7 @@ import com.hedera.pbj.compiler.impl.OneOfField;
 import com.hedera.pbj.compiler.impl.PbjCompilerException;
 import com.hedera.pbj.compiler.impl.generators.ModelGenerator;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -51,8 +52,10 @@ class CodecParseMethodGenerator {
             final String schemaClassName,
             final List<Field> fields,
             final boolean isCacheable) {
+
+        var parseLoopLs = generateParseLoop(generateCaseStatements(fields, schemaClassName), "", schemaClassName);
         // spotless:off
-        return """
+        var retString = """
                 /**
                  * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
                  * <p>
@@ -105,6 +108,10 @@ class CodecParseMethodGenerator {
                         throw new ParseException(anyException);
                     }
                 }
+                List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, ReadableSequentialData input, int maxSize) throws ParseException, IOException {
+                    $defaultCaseBody
+                    return $unknownFields;
+                }
                 """
         .replace("$cacheableSupport", isCacheable ? generateCacheableSupport(modelClassName, fields) : "return new $modelClassName($fieldsList);")
         .replace("$modelClassName",modelClassName)
@@ -117,7 +124,8 @@ class CodecParseMethodGenerator {
                 fields.stream().map(field -> "temp_"+field.name()).collect(Collectors.joining(", "))
                 + (fields.isEmpty() ? "" : ", ") + "$unknownFields"
         )
-        .replace("$parseLoop", generateParseLoop(generateCaseStatements(fields, schemaClassName), "", schemaClassName))
+        .replace("$parseLoop", parseLoopLs.get(0))
+        .replace("$defaultCaseBody", parseLoopLs.get(1))
         .replace("$listFieldsWriteProtection", fields.stream()
                 .filter(Field::repeated)
                 .map(field -> "if (temp_" + field.name() + " instanceof UnmodifiableArrayList ual) ual.makeReadOnly();")
@@ -125,6 +133,7 @@ class CodecParseMethodGenerator {
                 .indent(DEFAULT_INDENT * 2))
         .indent(DEFAULT_INDENT);
         // spotless:on
+        return retString;
     }
 
     static String generateCacheableSupport(String modelClassName, final List<Field> fields) {
@@ -160,10 +169,12 @@ class CodecParseMethodGenerator {
     }
 
     // prefix is pre-pended to variable names to support a nested parsing loop.
-    static String generateParseLoop(
+    // The list returned is [$parseLoop, $defaultCaseBody]
+    static List<String> generateParseLoop(
             final String caseStatements, @NonNull final String prefix, @NonNull final String schemaClassName) {
         // spotless:off
-        return """
+        List<String> list = new ArrayList<>();
+        list.add("""
                         // -- PARSE LOOP ---------------------------------------------
                         // Continue to parse bytes out of the input stream until we get to the end.
                         while (input.hasRemaining()) {
@@ -191,54 +202,58 @@ class CodecParseMethodGenerator {
                             // Given the wire type and the field type, parse the field
                             switch ($prefixtag) {
                 $caseStatements
-                                default -> {
-                                    // The wire type is the bottom 3 bits of the byte. Read that off
-                                    final int wireType = $prefixtag & TAG_WIRE_TYPE_MASK;
-                                    // handle error cases here, so we do not do if statements in normal loop
-                                    // Validate the field number is valid (must be > 0)
-                                    if ($prefixfield == 0) {
-                                        throw new IOException("Bad protobuf encoding. We read a field value of "
-                                            + $prefixfield);
-                                    }
-                                    // Validate the wire type is valid (must be >=0 && <= 5).
-                                    // Otherwise we cannot parse this.
-                                    // Note: it is always >= 0 at this point (see code above where it is defined).
-                                    if (wireType > 5) {
-                                        throw new IOException("Cannot understand wire_type of " + wireType);
-                                    }
-                                    // It may be that the parser subclass doesn't know about this field
-                                    if ($prefixf == null) {
-                                        if (strictMode) {
-                                            // Since we are parsing is strict mode, this is an exceptional condition.
-                                            throw new UnknownFieldException($prefixfield);
-                                        } else if (parseUnknownFields) {
-                                            if ($unknownFields == null) {
-                                                $unknownFields = new ArrayList<>($initialSizeOfUnknownFieldsArray);
-                                            }
-                                            $unknownFields.add(new UnknownField(
-                                                    field,
-                                                    ProtoConstants.get(wireType),
-                                                    extractField(input, ProtoConstants.get(wireType), $skipMaxSize)
-                                            ));
-                                        } else {
-                                            // We just need to read off the bytes for this field to skip it
-                                            // and move on to the next one.
-                                            skipField(input, ProtoConstants.get(wireType), $skipMaxSize);
-                                        }
-                                    } else {
-                                        throw new IOException("Bad tag [" + $prefixtag + "], field [" + $prefixfield
-                                                + "] wireType [" + wireType + "]");
-                                    }
-                                }
+                                default -> $unknownFields = defaultCase(tag, field, f, strictMode, parseUnknownFields, $unknownFields, input, maxSize);
                             }
                         }
-                """
-                .replace("$caseStatements",caseStatements)
-                .replace("$prefix",prefix)
-                .replace("$schemaClassName",schemaClassName)
+""");
+        list.add("""
+// The wire type is the bottom 3 bits of the byte. Read that off
+final int wireType = $prefixtag & TAG_WIRE_TYPE_MASK;
+// handle error cases here, so we do not do if statements in normal loop
+// Validate the field number is valid (must be > 0)
+if ($prefixfield == 0) {
+    throw new IOException("Bad protobuf encoding. We read a field value of "
+        + $prefixfield);
+}
+// Validate the wire type is valid (must be >=0 && <= 5).
+// Otherwise we cannot parse this.
+// Note: it is always >= 0 at this point (see code above where it is defined).
+if (wireType > 5) {
+    throw new IOException("Cannot understand wire_type of " + wireType);
+}
+// It may be that the parser subclass doesn't know about this field
+if ($prefixf == null) {
+    if (strictMode) {
+        // Since we are parsing is strict mode, this is an exceptional condition.
+        throw new UnknownFieldException($prefixfield);
+    } else if (parseUnknownFields) {
+        if ($unknownFields == null) {
+            $unknownFields = new ArrayList<>($initialSizeOfUnknownFieldsArray);
+        }
+        $unknownFields.add(new UnknownField(
+                field,
+                ProtoConstants.get(wireType),
+                extractField(input, ProtoConstants.get(wireType), $skipMaxSize)
+        ));
+    } else {
+        // We just need to read off the bytes for this field to skip it
+        // and move on to the next one.
+        skipField(input, ProtoConstants.get(wireType), $skipMaxSize);
+    }
+} else {
+    throw new IOException("Bad tag [" + $prefixtag + "], field [" + $prefixfield
+            + "] wireType [" + wireType + "]");
+}""");
+        for (int i = 0; i < list.size(); i++) {
+            list.set(i, list.get(i)
+                .replace("$caseStatements", caseStatements)
+                .replace("$prefix", prefix)
+                .replace("$schemaClassName", schemaClassName)
                 .replace("$skipMaxSize", "maxSize")
-                .indent(DEFAULT_INDENT);
+                .indent(DEFAULT_INDENT));
+        }
         // spotless:on
+        return list;
     }
 
     /**
@@ -432,6 +447,8 @@ class CodecParseMethodGenerator {
             // However(!), we read the key and value fields explicitly to avoid creating temporary entry objects.
             final MapField mapField = (MapField) field;
             final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
+            var parseLoopLs = generateParseLoop(
+                    generateCaseStatements(mapEntryFields, schemaClassName), "map_entry_", schemaClassName);
             // spotless:off
             sb.append("""
                         final var __map_messageLength = input.readVarInt(false);
@@ -466,7 +483,7 @@ class CodecParseMethodGenerator {
                     .replace("$fieldDefs",mapEntryFields.stream().map(mapEntryField ->
                             "%s temp_%s = %s;".formatted(mapEntryField.javaFieldType(),
                             mapEntryField.name(), mapEntryField.javaDefault())).collect(Collectors.joining("\n")))
-                    .replace("$mapParseLoop", generateParseLoop(generateCaseStatements(mapEntryFields, schemaClassName), "map_entry_", schemaClassName)
+                    .replace("$mapParseLoop", parseLoopLs.get(0)
                             .indent(-DEFAULT_INDENT))
                     .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
             );

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -48,16 +48,16 @@ class CodecParseMethodGenerator {
     }
 
     static String generateParseMethod(
-            StringBuilder sbFuncMain,
+            StringBuilder sbFunc,
             final String modelClassName,
             final String schemaClassName,
             final List<Field> fields,
             final boolean isCacheable) {
 
-        var parseLoopLs =
-                generateParseLoop(generateCaseStatements(sbFuncMain, fields, schemaClassName), "", schemaClassName);
+        ParseAndDefaultBody parseAndDefaultBodyPair =
+                generateParseLoop(generateCaseStatements(sbFunc, fields, schemaClassName), "", schemaClassName);
         // spotless:off
-        var retString = """
+        return """
                 /**
                  * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
                  * <p>
@@ -110,7 +110,8 @@ class CodecParseMethodGenerator {
                         throw new ParseException(anyException);
                     }
                 }
-                List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, ReadableSequentialData input, int maxSize) throws ParseException, IOException {
+                
+                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, ReadableSequentialData input, int maxSize) throws ParseException, IOException {
                     $defaultCaseBody
                     return $unknownFields;
                 }
@@ -126,8 +127,8 @@ class CodecParseMethodGenerator {
                 fields.stream().map(field -> "temp_"+field.name()).collect(Collectors.joining(", "))
                 + (fields.isEmpty() ? "" : ", ") + "$unknownFields"
         )
-        .replace("$parseLoop", parseLoopLs.get(0))
-        .replace("$defaultCaseBody", parseLoopLs.get(1))
+        .replace("$parseLoop", parseAndDefaultBodyPair.parseBody())
+        .replace("$defaultCaseBody", parseAndDefaultBodyPair.defaultBody())
         .replace("$listFieldsWriteProtection", fields.stream()
                 .filter(Field::repeated)
                 .map(field -> "if (temp_" + field.name() + " instanceof UnmodifiableArrayList ual) ual.makeReadOnly();")
@@ -135,7 +136,6 @@ class CodecParseMethodGenerator {
                 .indent(DEFAULT_INDENT * 2))
         .indent(DEFAULT_INDENT);
         // spotless:on
-        return retString;
     }
 
     static String generateCacheableSupport(String modelClassName, final List<Field> fields) {
@@ -170,9 +170,11 @@ class CodecParseMethodGenerator {
                 .indent(DEFAULT_INDENT * 2);
     }
 
+    public record ParseAndDefaultBody(String parseBody, String defaultBody) {}
+
     // prefix is pre-pended to variable names to support a nested parsing loop.
     // The list returned is [$parseLoop, $defaultCaseBody]
-    static List<String> generateParseLoop(
+    static ParseAndDefaultBody generateParseLoop(
             final String caseStatements, @NonNull final String prefix, @NonNull final String schemaClassName) {
         // spotless:off
         List<String> list = new ArrayList<>();
@@ -209,43 +211,43 @@ class CodecParseMethodGenerator {
                         }
 """);
         list.add("""
-// The wire type is the bottom 3 bits of the byte. Read that off
-final int wireType = $prefixtag & TAG_WIRE_TYPE_MASK;
-// handle error cases here, so we do not do if statements in normal loop
-// Validate the field number is valid (must be > 0)
-if ($prefixfield == 0) {
-    throw new IOException("Bad protobuf encoding. We read a field value of "
-        + $prefixfield);
-}
-// Validate the wire type is valid (must be >=0 && <= 5).
-// Otherwise we cannot parse this.
-// Note: it is always >= 0 at this point (see code above where it is defined).
-if (wireType > 5) {
-    throw new IOException("Cannot understand wire_type of " + wireType);
-}
-// It may be that the parser subclass doesn't know about this field
-if ($prefixf == null) {
-    if (strictMode) {
-        // Since we are parsing is strict mode, this is an exceptional condition.
-        throw new UnknownFieldException($prefixfield);
-    } else if (parseUnknownFields) {
-        if ($unknownFields == null) {
-            $unknownFields = new ArrayList<>($initialSizeOfUnknownFieldsArray);
-        }
-        $unknownFields.add(new UnknownField(
-                field,
-                ProtoConstants.get(wireType),
-                extractField(input, ProtoConstants.get(wireType), $skipMaxSize)
-        ));
-    } else {
-        // We just need to read off the bytes for this field to skip it
-        // and move on to the next one.
-        skipField(input, ProtoConstants.get(wireType), $skipMaxSize);
-    }
-} else {
-    throw new IOException("Bad tag [" + $prefixtag + "], field [" + $prefixfield
-            + "] wireType [" + wireType + "]");
-}""");
+                        // The wire type is the bottom 3 bits of the byte. Read that off
+                        final int wireType = $prefixtag & TAG_WIRE_TYPE_MASK;
+                        // handle error cases here, so we do not do if statements in normal loop
+                        // Validate the field number is valid (must be > 0)
+                        if ($prefixfield == 0) {
+                            throw new IOException("Bad protobuf encoding. We read a field value of "
+                                + $prefixfield);
+                        }
+                        // Validate the wire type is valid (must be >=0 && <= 5).
+                        // Otherwise we cannot parse this.
+                        // Note: it is always >= 0 at this point (see code above where it is defined).
+                        if (wireType > 5) {
+                            throw new IOException("Cannot understand wire_type of " + wireType);
+                        }
+                        // It may be that the parser subclass doesn't know about this field
+                        if ($prefixf == null) {
+                            if (strictMode) {
+                                // Since we are parsing is strict mode, this is an exceptional condition.
+                                throw new UnknownFieldException($prefixfield);
+                            } else if (parseUnknownFields) {
+                                if ($unknownFields == null) {
+                                    $unknownFields = new ArrayList<>($initialSizeOfUnknownFieldsArray);
+                                }
+                                $unknownFields.add(new UnknownField(
+                                        field,
+                                        ProtoConstants.get(wireType),
+                                        extractField(input, ProtoConstants.get(wireType), $skipMaxSize)
+                                ));
+                            } else {
+                                // We just need to read off the bytes for this field to skip it
+                                // and move on to the next one.
+                                skipField(input, ProtoConstants.get(wireType), $skipMaxSize);
+                            }
+                        } else {
+                            throw new IOException("Bad tag [" + $prefixtag + "], field [" + $prefixfield
+                                    + "] wireType [" + wireType + "]");
+                        }""");
         for (int i = 0; i < list.size(); i++) {
             list.set(i, list.get(i)
                 .replace("$caseStatements", caseStatements)
@@ -255,16 +257,9 @@ if ($prefixf == null) {
                 .indent(DEFAULT_INDENT));
         }
         // spotless:on
-        return list;
+        return new ParseAndDefaultBody(list.get(0), list.get(1));
     }
 
-    /**
-     * Generate switch case statements for each tag (field & wire type pair). For repeated numeric value types we
-     * generate 2 case statements for packed and unpacked encoding.
-     *
-     * @param fields list of all fields in record
-     * @return string of case statement code
-     */
     private static String generateCaseStatements(StringBuilder sbFunc, List<Field> fields, String schemaClassName) {
         StringBuilder sb = new StringBuilder();
         for (Field field : fields) {
@@ -459,7 +454,7 @@ if ($prefixf == null) {
             // However(!), we read the key and value fields explicitly to avoid creating temporary entry objects.
             final MapField mapField = (MapField) field;
             final List<Field> mapEntryFields = List.of(mapField.keyField(), mapField.valueField());
-            var parseLoopLs = generateParseLoop(
+            ParseAndDefaultBody parseAndDefaultBodyPair = generateParseLoop(
                     generateCaseStatements(sbFunc, mapEntryFields, schemaClassName), "map_entry_", schemaClassName);
             // spotless:off
             sbCase.append("""
@@ -495,7 +490,7 @@ if ($prefixf == null) {
                     .replace("$fieldDefs",mapEntryFields.stream().map(mapEntryField ->
                             "%s temp_%s = %s;".formatted(mapEntryField.javaFieldType(),
                             mapEntryField.name(), mapEntryField.javaDefault())).collect(Collectors.joining("\n")))
-                    .replace("$mapParseLoop", parseLoopLs.get(0)
+                    .replace("$mapParseLoop", parseAndDefaultBodyPair.parseBody()
                             .indent(-DEFAULT_INDENT))
                     .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
             );

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GenericParserQuickBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GenericParserQuickBench.java
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.integration.jmh;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.test.proto.pbj.CacheableAccountID;
+import com.hedera.pbj.test.proto.pbj.NotCacheableAccountID;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@SuppressWarnings("unused")
+@State(Scope.Benchmark)
+@Fork(3)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class GenericParserQuickBench {
+    private static final int INVOCATIONS = 1 * 1024;
+
+    @State(Scope.Thread)
+    public static class BenchState {
+        record Model<T>(int maxSize, Function<Random, T> factory, Codec<T> codec) {}
+
+        public enum Type {
+            NotCacheableAccountIDType(new Model<NotCacheableAccountID>(
+                    256,
+                    random -> {
+                        final NotCacheableAccountID.Builder builder = NotCacheableAccountID.newBuilder()
+                                .shardNum(random.nextLong())
+                                .realmNum(random.nextLong());
+                        if (random.nextBoolean()) {
+                            builder.accountNum(random.nextLong());
+                        } else {
+                            byte[] arr = new byte[32];
+                            random.nextBytes(arr);
+                            builder.alias(Bytes.wrap(arr));
+                        }
+                        return builder.build();
+                    },
+                    NotCacheableAccountID.PROTOBUF));
+
+            private final Model model;
+
+            Type(Model model) {
+                this.model = model;
+            }
+        }
+
+        @Param
+        Type type;
+
+        Model model;
+        byte[] array;
+        BufferedData bd;
+
+        @Setup(Level.Trial)
+        public void setup() throws IOException {
+            model = type.model;
+
+            array = new byte[INVOCATIONS * model.maxSize];
+            // For determinism:
+            final Random random = new Random(723049435);
+            bd = BufferedData.wrap(array);
+            for (int i = 0, j = 0; i < INVOCATIONS; i++) {
+                    model.codec.write(model.factory.apply(random), bd);
+            }
+            bd.flip();
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {}
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void bench(final BenchState state, final Blackhole blackhole) throws ParseException {
+        for (int invocation = 0; invocation < INVOCATIONS; invocation++) {
+            blackhole.consume(state.model.codec.parse(state.bd));
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(GenericParserQuickBench.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GenericParserQuickBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GenericParserQuickBench.java
@@ -5,7 +5,6 @@ import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.test.proto.pbj.CacheableAccountID;
 import com.hedera.pbj.test.proto.pbj.NotCacheableAccountID;
 import java.io.IOException;
 import java.util.Random;
@@ -85,7 +84,7 @@ public class GenericParserQuickBench {
             final Random random = new Random(723049435);
             bd = BufferedData.wrap(array);
             for (int i = 0, j = 0; i < INVOCATIONS; i++) {
-                    model.codec.write(model.factory.apply(random), bd);
+                model.codec.write(model.factory.apply(random), bd);
             }
             bd.flip();
         }


### PR DESCRIPTION
**Description**:

Moves default case into its own function so optimizer can choose what to inline

Prev bench numbers

Benchmark (type) Mode Cnt Score Error Units
GenericParserQuickBench.bench NotCacheableAccountIDType thrpt 15 292.432 ± 14.627 ops/us
https://github.com/hashgraph/pbj/actions/runs/25826669514/job/75881464290

New

Default Case Commit

Benchmark                                         (type)   Mode  Cnt    Score   Error   Units
GenericParserQuickBench.bench  NotCacheableAccountIDType  thrpt   15  446.331 ± 7.801  ops/us
https://github.com/hashgraph/pbj/actions/runs/25863069512/job/75997769734

Some additional cases as func from generateFieldCaseStatementPacked

Benchmark                                         (type)   Mode  Cnt    Score   Error   Units
GenericParserQuickBench.bench  NotCacheableAccountIDType  thrpt   15  450.417 ± 2.910  ops/us
https://github.com/hashgraph/pbj/actions/runs/25867304244/job/76012761470  
  
  
NOTE: Hash is different because I ran this before applying spotlight

Benchmark                                         (type)   Mode  Cnt    Score   Error   Units
GenericParserQuickBench.bench  NotCacheableAccountIDType  thrpt   15  451.509 ± 5.192  ops/us
https://github.com/hashgraph/pbj/actions/runs/25921616637/job/76191842411

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
