### PR TITLE
fix: Allow JSON parsing of snake_case field names

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -77,7 +77,7 @@ class JsonCodecParseMethodGenerator {
                         // -- EXTRACT VALUES FROM PARSE TREE ---------------------------------------------
 
                         for (JSONParser.PairContext kvPair : root.pair()) {
-                            switch (kvPair.STRING().getText()) {
+                            switch (toJsonFieldName(kvPair.STRING().getText())) {
                                 $caseStatements
                                 default: {
                                     if (strictMode) {

--- a/pbj-integration-tests/src/main/proto/bytesAndString.proto
+++ b/pbj-integration-tests/src/main/proto/bytesAndString.proto
@@ -13,5 +13,5 @@ option java_multiple_files = true;
  */
 message MessageWithBytesAndString {
   bytes bytesField = 1;
-  string stringField = 2;
+  string string_field = 2;
 }

--- a/pbj-integration-tests/src/main/proto/bytesAndString.proto
+++ b/pbj-integration-tests/src/main/proto/bytesAndString.proto
@@ -13,5 +13,5 @@ option java_multiple_files = true;
  */
 message MessageWithBytesAndString {
   bytes bytesField = 1;
-  string string_field = 2;
+  string stringField = 2;
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/JsonCodecTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/JsonCodecTest.java
@@ -136,4 +136,17 @@ public class JsonCodecTest {
         assertNotEquals(0, bytesAndString.bytesField().length());
         assertTrue(bytesAndString.stringField().isEmpty());
     }
+
+    @Test
+    public void SnakeCaseStringTest() throws Exception {
+        final String json = """
+                {
+                  "bytesField": "308201a2300d06092a86",
+                  "string_field": "snake_case"
+                }
+                """;
+        MessageWithBytesAndString bytesAndString = MessageWithBytesAndString.JSON.parse(Bytes.wrap(json));
+        assertNotEquals(0, bytesAndString.bytesField().length());
+        assertEquals("snake_case", bytesAndString.stringField());
+    }
 }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/JsonCodecTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/JsonCodecTest.java
@@ -125,7 +125,7 @@ public class JsonCodecTest {
     }
 
     @Test
-    public void NullStringTest() throws Exception {
+    public void nullStringTest() throws Exception {
         final String json = """
                 {
                   "bytesField": "308201a2300d06092a86",
@@ -138,7 +138,7 @@ public class JsonCodecTest {
     }
 
     @Test
-    public void SnakeCaseStringTest() throws Exception {
+    public void snakeCaseStringTest() throws Exception {
         final String json = """
                 {
                   "bytesField": "308201a2300d06092a86",


### PR DESCRIPTION
____________________________________________________________________

**Description**:
- convert json field name to camelCase before matching to protobuf object field name

**Related issue(s)**:
Fixes #831

**Notes for reviewer**:
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
