### PR TITLE
perf: Remove interface

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
@@ -28,11 +28,9 @@ class CodecFastEqualsMethodGenerator {
                  * @return true if the bytes represent the item, false otherwise.
                  * @throws ParseException If parsing fails
                  */
-                public boolean fastEquals(@NonNull $modelClass item, @NonNull final ReadableSequentialData input) throws ParseException {
+                public boolean fastEquals(@NonNull $modelClass item, @NonNull final SlimBuffer input) throws ParseException {
                     return item.equals(parse(input));
                 }
-                """
-                .replace("$modelClass", modelClassName)
-                .indent(DEFAULT_INDENT);
+                """.replace("$modelClass", modelClassName).indent(DEFAULT_INDENT);
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
@@ -24,13 +24,12 @@ class CodecMeasureDataMethodGenerator {
                  * @return The length of the data item in the input
                  * @throws ParseException If parsing fails
                  */
-                public int measure(@NonNull final ReadableSequentialData input) throws ParseException {
+                public int measure(@NonNull final SlimBuffer input) throws ParseException {
                     final var start = input.position();
                     parse(input);
                     final var end = input.position();
                     return (int)(end - start);
                 }
-                """
-                .indent(DEFAULT_INDENT);
+                """.indent(DEFAULT_INDENT);
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -59,7 +59,7 @@ class CodecParseMethodGenerator {
         // spotless:off
         return """
                 /**
-                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
+                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link SlimBuffer}. Throws if in strict mode ONLY.
                  * <p>
                  * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
                  * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
@@ -83,7 +83,7 @@ class CodecParseMethodGenerator {
                  * @throws ParseException If parsing fails
                  */
                 public @NonNull $modelClassName parse(
-                        @NonNull final ReadableSequentialData input,
+                        @NonNull final SlimBuffer input,
                         final boolean strictMode,
                         final boolean parseUnknownFields,
                         final int maxDepth,
@@ -111,7 +111,7 @@ class CodecParseMethodGenerator {
                     }
                 }
                 
-                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, ReadableSequentialData input, int maxSize) throws ParseException, IOException {
+                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, SlimBuffer input, int maxSize) throws ParseException, IOException {
                     $defaultCaseBody
                     return $unknownFields;
                 }
@@ -300,7 +300,7 @@ class CodecParseMethodGenerator {
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
         sbFunc.append("""
-%s case%d(ReadableSequentialData input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
+            %s case%d(SlimBuffer input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         if (field.type() == Field.FieldType.ENUM) {
             // spotless:off

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -181,8 +181,8 @@ class CodecParseMethodGenerator {
         list.add("""
                         // -- PARSE LOOP ---------------------------------------------
                         // Continue to parse bytes out of the input stream until we get to the end.
-                        while (input.hasRemaining()) {
-                            // Note: ReadableStreamingData.hasRemaining() won't flip to false
+                        while (input.hasMore()) {
+                            // Note: ReadableStreamingData.hasMore() won't flip to false
                             // until the end of stream is actually hit with a read operation.
                             // So we catch this exception here and **only** here, because an EOFException
                             // anywhere else suggests that we're processing malformed data and so
@@ -321,17 +321,15 @@ class CodecParseMethodGenerator {
         }
         sbFunc.append("""
                 // Read the length of packed repeated field data
-                final long length = input.readVarInt(false);
+                final int length = input.readVarInt(false);
                 if (length > $maxSize) {
                     throw new ParseException("$fieldName size " + length + " is greater than max " + $maxSize);
                 }
-                if (input.remaining() < length) {
-                    throw new BufferUnderflowException();
-                }
+                input.ensure(length);
                 final var beforeLimit = input.limit();
                 final long beforePosition = input.position();
                 input.limit(input.position() + length);
-                while (input.hasRemaining()) {
+                while (input.hasMore()) {
                     $preRead$tempFieldName = addToList($tempFieldName,$readMethod);
                 }
                 input.limit(beforeLimit);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -268,7 +268,11 @@ public interface Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    int measure(@NonNull SlimBuffer input) throws ParseException;
+    default int measure(@NonNull SlimBuffer input) throws ParseException {
+        final long startPosition = input.position();
+        parse(input);
+        return (int) (input.position() - startPosition);
+    }
 
     default int measure(@NonNull ReadableSequentialData input) throws ParseException {
         return measure(new SlimBuffer(input));

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -2,6 +2,7 @@
 package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.SlimBuffer;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -65,13 +66,18 @@ public interface Codec<T> {
      * @return The parsed object. It must not return null.
      * @throws ParseException If parsing fails
      */
-    @NonNull
-    T parse(
+    default @NonNull T parse(
             @NonNull ReadableSequentialData input,
             boolean strictMode,
             boolean parseUnknownFields,
             int maxDepth,
             int maxSize)
+            throws ParseException {
+        return parse(new SlimBuffer(input), strictMode, parseUnknownFields, maxDepth, maxSize);
+    }
+
+    @NonNull
+    T parse(@NonNull SlimBuffer input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException;
 
     /**
@@ -99,6 +105,11 @@ public interface Codec<T> {
     @NonNull
     default T parse(@NonNull ReadableSequentialData input, boolean strictMode, boolean parseUnknownFields, int maxDepth)
             throws ParseException {
+        return parse(new SlimBuffer(input), strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
+    }
+
+    default T parse(@NonNull SlimBuffer input, boolean strictMode, boolean parseUnknownFields, int maxDepth)
+            throws ParseException {
         return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
     }
     /**
@@ -122,6 +133,11 @@ public interface Codec<T> {
     @NonNull
     default T parse(@NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
             throws ParseException {
+        return parse(input, strictMode, false, maxDepth);
+    }
+
+    @NonNull
+    default T parse(@NonNull SlimBuffer input, final boolean strictMode, final int maxDepth) throws ParseException {
         return parse(input, strictMode, false, maxDepth);
     }
 
@@ -149,14 +165,19 @@ public interface Codec<T> {
     }
 
     /**
-     * Parses an object from the {@link ReadableSequentialData} and returns it.
+     * Parses an object from the {@link SlimBuffer} and returns it.
      *
-     * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
+     * @param input The {@link SlimBuffer} from which to read the data to construct an object
      * @return The parsed object. It must not return null.
      * @throws ParseException If parsing fails
      */
     @NonNull
     default T parse(@NonNull ReadableSequentialData input) throws ParseException {
+        return parse(new SlimBuffer(input));
+    }
+
+    @NonNull
+    default T parse(@NonNull SlimBuffer input) throws ParseException {
         return parse(input, false, DEFAULT_MAX_DEPTH);
     }
 
@@ -185,9 +206,13 @@ public interface Codec<T> {
      */
     @NonNull
     default T parseStrict(@NonNull ReadableSequentialData input) throws ParseException {
-        return parse(input, true, DEFAULT_MAX_DEPTH);
+        return parse(new SlimBuffer(input), true, DEFAULT_MAX_DEPTH);
     }
 
+    @NonNull
+    default T parseStrict(@NonNull SlimBuffer input) throws ParseException {
+        return parse(input, true, DEFAULT_MAX_DEPTH);
+    }
     /**
      * Parses an object from the {@link Bytes} and returns it. Throws an exception if fields
      * have been defined on the encoded object that are not supported by the parser. This
@@ -201,7 +226,7 @@ public interface Codec<T> {
      */
     @NonNull
     default T parseStrict(@NonNull Bytes bytes) throws ParseException {
-        return parseStrict(bytes.toReadableSequentialData());
+        return parseStrict(new SlimBuffer(bytes.toReadableSequentialData()));
     }
 
     /**
@@ -243,8 +268,11 @@ public interface Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    int measure(@NonNull ReadableSequentialData input) throws ParseException;
+    int measure(@NonNull SlimBuffer input) throws ParseException;
 
+    default int measure(@NonNull ReadableSequentialData input) throws ParseException {
+        return measure(new SlimBuffer(input));
+    }
     /**
      * Compute number of bytes that would be written when calling {@code write()} method.
      *
@@ -265,8 +293,11 @@ public interface Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException;
+    boolean fastEquals(@NonNull T item, @NonNull SlimBuffer input) throws ParseException;
 
+    default boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+        return fastEquals(item, new SlimBuffer(input));
+    }
     /**
      * Converts a Record into a Bytes object
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.SlimBuffer;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
@@ -20,7 +20,7 @@ public interface JsonCodec<T> extends Codec<T> {
 
     /** {@inheritDoc} */
     default @NonNull T parse(
-            @NonNull ReadableSequentialData input,
+            @NonNull SlimBuffer input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -95,7 +95,7 @@ public interface JsonCodec<T> extends Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    default int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    default int measure(@NonNull SlimBuffer input) throws ParseException {
         final long startPosition = input.position();
         parse(input);
         return (int) (input.position() - startPosition);
@@ -134,7 +134,7 @@ public interface JsonCodec<T> extends Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    default boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    default boolean fastEquals(@NonNull T item, @NonNull SlimBuffer input) throws ParseException {
         return Objects.equals(item, parse(input));
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.SlimBuffer;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.jsonparser.JSONLexer;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
@@ -94,7 +94,7 @@ public final class JsonTools {
      * @return the Antlr JSON context object
      * @throws IOException if there was a problem parsing the JSON
      */
-    public static JSONParser.ObjContext parseJson(@NonNull final ReadableSequentialData input) throws IOException {
+    public static JSONParser.ObjContext parseJson(@NonNull final SlimBuffer input) throws IOException {
         final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
         final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
         final JSONParser.JsonContext jsonContext = parser.json();

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -2,6 +2,7 @@
 package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.SlimBuffer;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -81,6 +82,10 @@ public final class ProtoParserTools {
         return input.readVarInt(false);
     }
 
+    public static int readInt32(SlimBuffer input) {
+        return input.readVarInt(false);
+    }
+
     /**
      * Read a protobuf int64(long) from input
      *
@@ -88,6 +93,10 @@ public final class ProtoParserTools {
      * @return the read long
      */
     public static long readInt64(final ReadableSequentialData input) {
+        return input.readVarLong(false);
+    }
+
+    public static long readInt64(SlimBuffer input) {
         return input.readVarLong(false);
     }
 
@@ -101,6 +110,10 @@ public final class ProtoParserTools {
         return input.readVarInt(false);
     }
 
+    public static int readUint32(SlimBuffer input) {
+        return input.readVarInt(false);
+    }
+
     /**
      * Read a protobuf uint64 from input
      *
@@ -111,6 +124,9 @@ public final class ProtoParserTools {
         return input.readVarLong(false);
     }
 
+    public static long readUint64(SlimBuffer input) {
+        return input.readVarLong(false);
+    }
     /**
      * Read a protobuf bool from input
      *
@@ -119,6 +135,14 @@ public final class ProtoParserTools {
      * @throws IOException If a I/O error occurs
      */
     public static boolean readBool(final ReadableSequentialData input) throws IOException {
+        final var i = input.readVarInt(false);
+        if (i != 1 && i != 0) {
+            throw new IOException("Bad protobuf encoding. Boolean was not 0 or 1");
+        }
+        return i == 1;
+    }
+
+    public static boolean readBool(SlimBuffer input) throws IOException {
         final var i = input.readVarInt(false);
         if (i != 1 && i != 0) {
             throw new IOException("Bad protobuf encoding. Boolean was not 0 or 1");
@@ -136,6 +160,9 @@ public final class ProtoParserTools {
         return input.readVarInt(false);
     }
 
+    public static int readEnum(SlimBuffer input) {
+        return input.readVarInt(false);
+    }
     /**
      * Read a protobuf sint32 from input
      *
@@ -143,6 +170,10 @@ public final class ProtoParserTools {
      * @return the read int
      */
     public static int readSignedInt32(final ReadableSequentialData input) {
+        return input.readVarInt(true);
+    }
+
+    public static int readSignedInt32(SlimBuffer input) {
         return input.readVarInt(true);
     }
 
@@ -156,6 +187,10 @@ public final class ProtoParserTools {
         return input.readVarLong(true);
     }
 
+    public static long readSignedInt64(SlimBuffer input) {
+        return input.readVarLong(true);
+    }
+
     /**
      * Read a protobuf sfixed32 from input
      *
@@ -163,6 +198,10 @@ public final class ProtoParserTools {
      * @return the read int
      */
     public static int readSignedFixed32(final ReadableSequentialData input) {
+        return input.readInt(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    public static int readSignedFixed32(SlimBuffer input) {
         return input.readInt(ByteOrder.LITTLE_ENDIAN);
     }
 
@@ -176,6 +215,10 @@ public final class ProtoParserTools {
         return input.readInt(ByteOrder.LITTLE_ENDIAN);
     }
 
+    public static int readFixed32(SlimBuffer input) {
+        return input.readInt(ByteOrder.LITTLE_ENDIAN);
+    }
+
     /**
      * Read a protobuf float from input
      *
@@ -183,6 +226,10 @@ public final class ProtoParserTools {
      * @return the read float
      */
     public static float readFloat(final ReadableSequentialData input) {
+        return input.readFloat(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    public static float readFloat(SlimBuffer input) {
         return input.readFloat(ByteOrder.LITTLE_ENDIAN);
     }
 
@@ -196,6 +243,10 @@ public final class ProtoParserTools {
         return input.readLong(ByteOrder.LITTLE_ENDIAN);
     }
 
+    public static long readSignedFixed64(final SlimBuffer input) {
+        return input.readLong(ByteOrder.LITTLE_ENDIAN);
+    }
+
     /**
      * Read a fixed 64, which is a fixed size encoded long
      *
@@ -206,6 +257,10 @@ public final class ProtoParserTools {
         return input.readLong(ByteOrder.LITTLE_ENDIAN);
     }
 
+    public static long readFixed64(SlimBuffer input) {
+        return input.readLong(ByteOrder.LITTLE_ENDIAN);
+    }
+
     /**
      * Read a double from input data
      *
@@ -213,6 +268,10 @@ public final class ProtoParserTools {
      * @return read double
      */
     public static double readDouble(final ReadableSequentialData input) {
+        return input.readDouble(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    public static double readDouble(SlimBuffer input) {
         return input.readDouble(ByteOrder.LITTLE_ENDIAN);
     }
 
@@ -230,6 +289,14 @@ public final class ProtoParserTools {
         }
     }
 
+    public static String readString(final SlimBuffer input) throws IOException {
+        try {
+            return readString(input, Long.MAX_VALUE);
+        } catch (ParseException ex) {
+            throw new UncheckedParseException(ex);
+        }
+    }
+
     /**
      * Read a String field from data input
      *
@@ -240,6 +307,34 @@ public final class ProtoParserTools {
      */
     public static String readString(final ReadableSequentialData input, final long maxSize)
             throws IOException, ParseException {
+        final int length = input.readVarInt(false);
+        if (length > maxSize) {
+            throw new ParseException("size " + length + " is greater than max " + maxSize);
+        }
+        if (input.remaining() < length) {
+            throw new BufferUnderflowException();
+        }
+        final ByteBuffer bb = ByteBuffer.allocate(length);
+        final long bytesRead = input.readBytes(bb);
+        if (bytesRead != length) {
+            throw new BufferUnderflowException();
+        }
+        bb.rewind();
+
+        try {
+            // Shouldn't use `new String()` because we want to error out on malformed UTF-8 bytes.
+            return StandardCharsets.UTF_8
+                    .newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(bb)
+                    .toString();
+        } catch (CharacterCodingException e) {
+            throw new MalformedProtobufException("Malformed UTF-8 string encountered", e);
+        }
+    }
+
+    public static String readString(SlimBuffer input, final long maxSize) throws IOException, ParseException {
         final int length = input.readVarInt(false);
         if (length > maxSize) {
             throw new ParseException("size " + length + " is greater than max " + maxSize);
@@ -293,6 +388,21 @@ public final class ProtoParserTools {
      * @throws ParseException if the length is greater than maxSize
      */
     public static Bytes readBytes(final ReadableSequentialData input, final long maxSize) throws ParseException {
+        final int length = input.readVarInt(false);
+        if (length > maxSize) {
+            throw new ParseException("size " + length + " is greater than max " + maxSize);
+        }
+        if (input.remaining() < length) {
+            throw new BufferUnderflowException();
+        }
+        Bytes bytes = input.readBytes(length);
+        if (bytes.length() != length) {
+            throw new BufferUnderflowException();
+        }
+        return bytes;
+    }
+
+    public static Bytes readBytes(SlimBuffer input, final long maxSize) throws ParseException {
         final int length = input.readVarInt(false);
         if (length > maxSize) {
             throw new ParseException("size " + length + " is greater than max " + maxSize);
@@ -402,6 +512,32 @@ public final class ProtoParserTools {
         };
     }
 
+    public static Bytes extractField(SlimBuffer input, final ProtoConstants wireType, final long maxSize)
+            throws IOException, ParseException {
+        return switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.readBytes(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.readBytes(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLongBytes();
+            case WIRE_TYPE_DELIMITED -> {
+                final Bytes lenBytes = input.readVarLongBytes();
+                final int length = lenBytes.getVarInt(0, false);
+                if (length < 0) {
+                    throw new IOException("Encountered a field with negative length " + length);
+                }
+                if (length > maxSize) {
+                    throw new ParseException("size " + length + " is greater than max " + maxSize);
+                }
+                yield Bytes.merge(lenBytes, input.readBytes(length));
+            }
+            case WIRE_TYPE_GROUP_START -> throw new IOException("Wire type 'Group Start' is unsupported");
+            case WIRE_TYPE_GROUP_END -> throw new IOException("Wire type 'Group End' is unsupported");
+            default -> throw new IOException("Unhandled wire type while trying to skip a field " + wireType);
+        };
+    }
+
     /**
      * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
      *
@@ -427,6 +563,31 @@ public final class ProtoParserTools {
      * @throws ParseException if the length of a repeated/length-encoded field is greater than maxSize
      */
     public static void skipField(final ReadableSequentialData input, final ProtoConstants wireType, final long maxSize)
+            throws IOException, ParseException {
+        switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.skip(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.skip(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLong(false);
+            case WIRE_TYPE_DELIMITED -> {
+                final int length = input.readVarInt(false);
+                if (length < 0) {
+                    throw new IOException("Encountered a field with negative length " + length);
+                }
+                if (length > maxSize) {
+                    throw new ParseException("size " + length + " is greater than max " + maxSize);
+                }
+                input.skip(length);
+            }
+            case WIRE_TYPE_GROUP_START -> throw new IOException("Wire type 'Group Start' is unsupported");
+            case WIRE_TYPE_GROUP_END -> throw new IOException("Wire type 'Group End' is unsupported");
+            default -> throw new IOException("Unhandled wire type while trying to skip a field " + wireType);
+        }
+    }
+
+    public static void skipField(SlimBuffer input, final ProtoConstants wireType, final long maxSize)
             throws IOException, ParseException {
         switch (wireType) {
             case WIRE_TYPE_FIXED_64_BIT -> input.skip(8);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -202,7 +202,7 @@ public final class ProtoParserTools {
     }
 
     public static int readSignedFixed32(SlimBuffer input) {
-        return input.readInt(ByteOrder.LITTLE_ENDIAN);
+        return input.readInt();
     }
 
     /**
@@ -216,7 +216,7 @@ public final class ProtoParserTools {
     }
 
     public static int readFixed32(SlimBuffer input) {
-        return input.readInt(ByteOrder.LITTLE_ENDIAN);
+        return input.readInt();
     }
 
     /**
@@ -230,7 +230,7 @@ public final class ProtoParserTools {
     }
 
     public static float readFloat(SlimBuffer input) {
-        return input.readFloat(ByteOrder.LITTLE_ENDIAN);
+        return input.readFloat();
     }
 
     /**
@@ -244,7 +244,7 @@ public final class ProtoParserTools {
     }
 
     public static long readSignedFixed64(final SlimBuffer input) {
-        return input.readLong(ByteOrder.LITTLE_ENDIAN);
+        return input.readLong();
     }
 
     /**
@@ -258,7 +258,7 @@ public final class ProtoParserTools {
     }
 
     public static long readFixed64(SlimBuffer input) {
-        return input.readLong(ByteOrder.LITTLE_ENDIAN);
+        return input.readLong();
     }
 
     /**
@@ -272,7 +272,7 @@ public final class ProtoParserTools {
     }
 
     public static double readDouble(SlimBuffer input) {
-        return input.readDouble(ByteOrder.LITTLE_ENDIAN);
+        return input.readDouble();
     }
 
     /**
@@ -339,9 +339,7 @@ public final class ProtoParserTools {
         if (length > maxSize) {
             throw new ParseException("size " + length + " is greater than max " + maxSize);
         }
-        if (input.remaining() < length) {
-            throw new BufferUnderflowException();
-        }
+        input.ensure(length);
         final ByteBuffer bb = ByteBuffer.allocate(length);
         final long bytesRead = input.readBytes(bb);
         if (bytesRead != length) {
@@ -407,9 +405,7 @@ public final class ProtoParserTools {
         if (length > maxSize) {
             throw new ParseException("size " + length + " is greater than max " + maxSize);
         }
-        if (input.remaining() < length) {
-            throw new BufferUnderflowException();
-        }
+        input.ensure(length);
         Bytes bytes = input.readBytes(length);
         if (bytes.length() != length) {
             throw new BufferUnderflowException();

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SlimBuffer.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SlimBuffer.java
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class SlimBuffer {
+    ReadableSequentialData input;
+
+    public SlimBuffer(ReadableSequentialData input) {
+        this.input = input;
+    }
+
+    public boolean hasRemaining() {
+        return input.hasRemaining();
+    }
+
+    public long remaining() {
+        return input.remaining();
+    }
+
+    public long limit() {
+        return input.limit();
+    }
+
+    public void limit(long limit) {
+        input.limit(limit);
+    }
+
+    public long position() {
+        return input.position();
+    }
+
+    public void skip(long count) throws UncheckedIOException {
+        input.skip(count);
+    }
+
+    public int readVarInt(final boolean zigZag) {
+        return input.readVarInt(zigZag);
+    }
+
+    public long readVarLong(final boolean zigZag) throws BufferUnderflowException, UncheckedIOException {
+        return input.readVarLong(zigZag);
+    }
+
+    public Bytes readVarLongBytes() throws BufferUnderflowException, UncheckedIOException {
+        return input.readVarLongBytes();
+    }
+
+    public long readBytes(@NonNull final byte[] dst) throws UncheckedIOException {
+        return input.readBytes(dst);
+    }
+
+    public @NonNull Bytes readBytes(final int length) throws BufferUnderflowException, UncheckedIOException {
+        return input.readBytes(length);
+    }
+
+    public long readBytes(@NonNull final ByteBuffer dst) throws UncheckedIOException {
+        return input.readBytes(dst);
+    }
+
+    public int readInt() throws BufferUnderflowException, UncheckedIOException {
+        return input.readInt();
+    }
+
+    public int readInt(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
+        return input.readInt(byteOrder);
+    }
+
+    public long readLong() throws BufferUnderflowException, UncheckedIOException {
+        return input.readLong();
+    }
+
+    public long readLong(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
+        return input.readLong(byteOrder);
+    }
+
+    public float readFloat() throws BufferUnderflowException, UncheckedIOException {
+        return input.readFloat();
+    }
+
+    public float readFloat(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
+        return input.readFloat(byteOrder);
+    }
+
+    public double readDouble() throws BufferUnderflowException, UncheckedIOException {
+        return input.readDouble();
+    }
+
+    public double readDouble(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
+        return input.readDouble(byteOrder);
+    }
+
+    public InputStream asInputStream() {
+        return input.asInputStream();
+    }
+
+    public void test() {
+        input.readDouble();
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SlimBuffer.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SlimBuffer.java
@@ -20,6 +20,14 @@ public class SlimBuffer {
         this.input = input;
     }
 
+    public SlimBuffer(byte[] buf) {
+        this.buf = buf;
+        end = buf.length;
+        relLimit = buf.length;
+        absoluteLimit = buf.length;
+        seenEOF = true;
+    }
+
     private void grow(int minCap) {
         int newCap = Math.max(buf.length * 2, 1 << 63 - Long.numberOfLeadingZeros((minCap << 1) - 1));
         byte[] newCopy = new byte[newCap];

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SlimBuffer.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/SlimBuffer.java
@@ -7,100 +7,221 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 public class SlimBuffer {
-    ReadableSequentialData input;
+    byte[] buf = new byte[16 << 10];
+    int pos, end;
+    int relLimit;
+    long absoluteLimit, offset;
+    boolean seenEOF;
+    private ReadableSequentialData input;
 
     public SlimBuffer(ReadableSequentialData input) {
         this.input = input;
     }
 
-    public boolean hasRemaining() {
-        return input.hasRemaining();
+    private void grow(int minCap) {
+        int newCap = Math.max(buf.length * 2, 1 << 63 - Long.numberOfLeadingZeros((minCap << 1) - 1));
+        byte[] newCopy = new byte[newCap];
+        System.arraycopy(buf, 0, newCopy, 0, end);
+        buf = newCopy;
     }
 
-    public long remaining() {
-        return input.remaining();
+    private void bufferMore() {
+        bufferMore(1);
+    }
+
+    private void bufferMore(int relAmount) {
+        if (relAmount <= 0) {
+            relAmount = 1;
+        }
+        offset += pos;
+        relLimit = (int) (absoluteLimit - offset);
+        if (pos < end && pos != 0) {
+            int moveLen = end - pos;
+            System.arraycopy(buf, pos, buf, 0, end - pos);
+            end = moveLen;
+        } else if (pos == end) {
+            end = 0;
+        }
+        pos = 0;
+        int remLen = buf.length - end;
+        if (remLen < relAmount) {
+            grow(relAmount);
+            remLen = buf.length - end;
+        }
+        try {
+            int rdlen = (int) input.readBytes(buf, end, remLen);
+            end += rdlen;
+            absoluteLimit = offset + end;
+            relLimit = (int) (absoluteLimit - offset);
+            if (rdlen == 0) {
+                seenEOF = true;
+                return;
+            }
+            if (rdlen <= 0) {
+                int q = 1;
+            }
+        } catch (UncheckedIOException e) {
+            throw e;
+        }
+    }
+
+    public boolean hasMore() {
+        if (!seenEOF && pos == end) {
+            bufferMore();
+        }
+        while (true) {
+            if (pos < relLimit) return true;
+            if (seenEOF || relLimit < end) return false;
+            bufferMore();
+        }
+    }
+
+    public void ensure(int amount) throws BufferUnderflowException {
+        if (amount < 0) {
+            throw new IllegalArgumentException();
+        }
+        if (pos + amount <= relLimit) return;
+        if (seenEOF) throw new BufferUnderflowException();
+        bufferMore(amount);
+        if (pos + amount <= relLimit) return;
+        throw new BufferUnderflowException();
     }
 
     public long limit() {
-        return input.limit();
+        if (!seenEOF) {
+            for (int i = 0; !seenEOF && i < 32; i++) {
+                bufferMore();
+            }
+            if (seenEOF == false) {
+                throw new RuntimeException(); // logic error
+            }
+        }
+        return absoluteLimit;
     }
 
     public void limit(long limit) {
-        input.limit(limit);
+        absoluteLimit = Math.max(offset + pos, Math.min(limit, offset + end));
+        relLimit = (int) (absoluteLimit - offset);
     }
 
     public long position() {
-        return input.position();
+        return pos + offset;
     }
 
     public void skip(long count) throws UncheckedIOException {
-        input.skip(count);
+        ensure((int) count);
+        pos += (int) count;
     }
 
     public int readVarInt(final boolean zigZag) {
-        return input.readVarInt(zigZag);
+        return (int) readVarLong(zigZag);
     }
 
     public long readVarLong(final boolean zigZag) throws BufferUnderflowException, UncheckedIOException {
-        return input.readVarLong(zigZag);
+        long value = 0;
+        for (int i = 0; i < 10; i++) {
+            final byte b = readByte();
+            value |= (long) (b & 0x7F) << (i * 7);
+            if (b >= 0) {
+                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
+            }
+        }
+        throw new DataEncodingException("Malformed var int");
     }
 
     public Bytes readVarLongBytes() throws BufferUnderflowException, UncheckedIOException {
-        return input.readVarLongBytes();
+        final byte[] bytes = new byte[10];
+        for (int i = 0; i < 10; i++) {
+            bytes[i] = readByte();
+            if (bytes[i] >= 0) {
+                return Bytes.wrap(bytes, 0, i + 1);
+            }
+        }
+        throw new DataEncodingException("Malformed var int");
     }
 
     public long readBytes(@NonNull final byte[] dst) throws UncheckedIOException {
-        return input.readBytes(dst);
+        ensure(dst.length);
+        System.arraycopy(buf, pos, dst, 0, dst.length);
+        pos += dst.length;
+        return dst.length;
     }
 
     public @NonNull Bytes readBytes(final int length) throws BufferUnderflowException, UncheckedIOException {
-        return input.readBytes(length);
+        if (length < 0) {
+            throw new IllegalArgumentException();
+        }
+        ensure(length);
+        final var bytes = new byte[length];
+        readBytes(bytes);
+        return Bytes.wrap(bytes);
     }
 
     public long readBytes(@NonNull final ByteBuffer dst) throws UncheckedIOException {
-        return input.readBytes(dst);
+        int len = dst.remaining();
+        if (len == 0) return 0;
+        if (relLimit - pos < len) {
+            throw new BufferUnderflowException();
+        }
+        System.arraycopy(buf, pos, dst.array(), dst.arrayOffset() + dst.position(), len);
+        dst.position(dst.position() + len);
+        pos += len;
+        return len;
     }
 
     public int readInt() throws BufferUnderflowException, UncheckedIOException {
-        return input.readInt();
-    }
-
-    public int readInt(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
-        return input.readInt(byteOrder);
+        ensure(4);
+        final int b0 = readByte() & 255;
+        final int b1 = readByte() & 255;
+        final int b2 = readByte() & 255;
+        final int b3 = readByte() & 255;
+        return (b3 << 24) | (b2 << 16) | (b1 << 8) | b0;
     }
 
     public long readLong() throws BufferUnderflowException, UncheckedIOException {
-        return input.readLong();
-    }
-
-    public long readLong(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
-        return input.readLong(byteOrder);
+        ensure(8);
+        final byte b8 = readByte();
+        final byte b7 = readByte();
+        final byte b6 = readByte();
+        final byte b5 = readByte();
+        final byte b4 = readByte();
+        final byte b3 = readByte();
+        final byte b2 = readByte();
+        final byte b1 = readByte();
+        return (((long) b1 << 56)
+                + ((long) (b2 & 255) << 48)
+                + ((long) (b3 & 255) << 40)
+                + ((long) (b4 & 255) << 32)
+                + ((long) (b5 & 255) << 24)
+                + ((b6 & 255) << 16)
+                + ((b7 & 255) << 8)
+                + (b8 & 255));
     }
 
     public float readFloat() throws BufferUnderflowException, UncheckedIOException {
-        return input.readFloat();
-    }
-
-    public float readFloat(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
-        return input.readFloat(byteOrder);
+        return Float.intBitsToFloat(readInt());
     }
 
     public double readDouble() throws BufferUnderflowException, UncheckedIOException {
-        return input.readDouble();
-    }
-
-    public double readDouble(@NonNull final ByteOrder byteOrder) throws BufferUnderflowException, UncheckedIOException {
-        return input.readDouble(byteOrder);
+        return Double.longBitsToDouble(readLong());
     }
 
     public InputStream asInputStream() {
-        return input.asInputStream();
+        if (end == 0) return input.asInputStream();
+        throw new UnsupportedOperationException();
     }
 
-    public void test() {
-        input.readDouble();
+    private byte readByte() {
+        if (pos == relLimit) {
+            if (relLimit == end) {
+                bufferMore();
+            }
+            if (pos == relLimit) {
+                throw new BufferUnderflowException();
+            }
+        }
+        return buf[pos++];
     }
 }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.SlimBuffer;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -24,12 +24,7 @@ class CodecWrapper<T> implements Codec<T> {
 
     @NonNull
     @Override
-    public T parse(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+    public T parse(@NonNull SlimBuffer input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         throw new UnsupportedOperationException();
     }
@@ -40,7 +35,7 @@ class CodecWrapper<T> implements Codec<T> {
     }
 
     @Override
-    public int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    public int measure(@NonNull SlimBuffer input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 
@@ -50,7 +45,7 @@ class CodecWrapper<T> implements Codec<T> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    public boolean fastEquals(@NonNull T item, @NonNull SlimBuffer input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -549,8 +549,17 @@ class ProtoParserToolsTest {
                 final int maxDepth,
                 final int maxSize)
                 throws ParseException {
+            return parse(new SlimBuffer(in), strictMode, parseUnknownFields, maxDepth, maxSize);
+        }
+        public TestMessage parse(
+                @NonNull final SlimBuffer in,
+                final boolean strictMode,
+                final boolean parseUnknownFields,
+                final int maxDepth,
+                final int maxSize)
+                throws ParseException {
             String value = null;
-            while (in.hasRemaining()) {
+            while (in.hasMore()) {
                 final int tag = in.readVarInt(false);
                 final int fieldNum = tag >> ProtoParserTools.TAG_FIELD_OFFSET;
                 final int wireType = tag & TAG_WIRE_TYPE_MASK;

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.SlimBuffer;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -592,8 +593,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public boolean fastEquals(@NonNull TestMessage item, @NonNull ReadableSequentialData input)
-                throws ParseException {
+        public boolean fastEquals(@NonNull TestMessage item, @NonNull SlimBuffer input) throws ParseException {
             throw new UnsupportedOperationException();
         }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -551,6 +551,7 @@ class ProtoParserToolsTest {
                 throws ParseException {
             return parse(new SlimBuffer(in), strictMode, parseUnknownFields, maxDepth, maxSize);
         }
+
         public TestMessage parse(
                 @NonNull final SlimBuffer in,
                 final boolean strictMode,

--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GenericParserQuickBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/GenericParserQuickBench.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.integration.jmh;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.SlimBuffer;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.test.proto.pbj.NotCacheableAccountID;
@@ -74,6 +75,7 @@ public class GenericParserQuickBench {
         Model model;
         byte[] array;
         BufferedData bd;
+        SlimBuffer slimBuffer;
 
         @Setup(Level.Trial)
         public void setup() throws IOException {
@@ -87,6 +89,8 @@ public class GenericParserQuickBench {
                 model.codec.write(model.factory.apply(random), bd);
             }
             bd.flip();
+            slimBuffer = new SlimBuffer(array);
+            slimBuffer.limit(bd.limit());
         }
 
         @TearDown(Level.Trial)
@@ -97,7 +101,7 @@ public class GenericParserQuickBench {
     @OperationsPerInvocation(INVOCATIONS)
     public void bench(final BenchState state, final Blackhole blackhole) throws ParseException {
         for (int invocation = 0; invocation < INVOCATIONS; invocation++) {
-            blackhole.consume(state.model.codec.parse(state.bd));
+            blackhole.consume(state.model.codec.parse(state.slimBuffer));
         }
     }
 


### PR DESCRIPTION
**Description**:

The first commit is easier to go through, touches a lot of signature. The rest can be squashed

Bench:

Current:

Benchmark                                         (type)   Mode  Cnt    Score   Error   Units
GenericParserQuickBench.bench  NotCacheableAccountIDType  thrpt   15  458.108 ± 2.490  ops/us
https://github.com/hashgraph/pbj/actions/runs/26190721867/job/77058132411

main:

Benchmark                                         (type)   Mode  Cnt    Score   Error   Units
GenericParserQuickBench.bench  NotCacheableAccountIDType  thrpt   15  458.108 ± 2.490  ops/us
https://github.com/hashgraph/pbj/actions/runs/26180014678/job/77020208498

**Checklist**

- [x ] Documented (Code comments, README, etc.)
- [x ] Tested (unit, integration, etc.)
