### PR TITLE
feat: RandomAccessData.put methods

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/BufferedData.java
@@ -361,6 +361,13 @@ public sealed class BufferedData
         return buffer.get(Math.toIntExact(offset));
     }
 
+    @Override
+    public int putByte(final long offset, final byte b) {
+        checkOffsetToWrite(offset, length(), 1);
+        buffer.put(Math.toIntExact(offset), b);
+        return 1;
+    }
+
     /** {@inheritDoc} */
     @Override
     public long getBytes(final long offset, @NonNull final byte[] dst, final int dstOffset, final int maxLength) {
@@ -371,6 +378,22 @@ public sealed class BufferedData
         // FUTURE: why offset + length is checked for this object, but not for dst?
         final var len = Math.min(maxLength, length() - offset);
         buffer.get(Math.toIntExact(offset), dst, dstOffset, Math.toIntExact(len));
+        return len;
+    }
+
+    @Override
+    public int putBytes(final long offset, @NonNull final byte[] src, final int srcOffset, final int len) {
+        if (len < 0 || offset < 0 || srcOffset < 0) {
+            throw new IllegalArgumentException("Negative length or offsets not allowed");
+        }
+        if (len > src.length - srcOffset) {
+            throw new BufferUnderflowException();
+        }
+        if (len > length() - offset) {
+            throw new BufferOverflowException();
+        }
+
+        buffer.put(Math.toIntExact(offset), src, srcOffset, len);
         return len;
     }
 
@@ -439,6 +462,13 @@ public sealed class BufferedData
     public long getLong(final long offset) {
         checkUnderflow(offset, 8);
         return buffer.getLong(Math.toIntExact(offset));
+    }
+
+    @Override
+    public int putLong(final long offset, final long value) {
+        checkOffsetToWrite(offset, length(), 8);
+        buffer.putLong(Math.toIntExact(offset), value);
+        return 8;
     }
 
     /** {@inheritDoc} */

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -75,6 +76,13 @@ final class ByteArrayBufferedData extends BufferedData {
         return array[Math.toIntExact(arrayOffset + offset)];
     }
 
+    @Override
+    public int putByte(final long offset, final byte b) {
+        checkOffsetToWrite(offset, length(), 1);
+        array[Math.toIntExact(arrayOffset + offset)] = b;
+        return 1;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -88,6 +96,22 @@ final class ByteArrayBufferedData extends BufferedData {
             return 0;
         }
         System.arraycopy(array, Math.toIntExact(arrayOffset + offset), dst, dstOffset, Math.toIntExact(len));
+        return len;
+    }
+
+    @Override
+    public int putBytes(final long offset, @NonNull final byte[] src, final int srcOffset, final int len) {
+        if (len < 0 || offset < 0 || srcOffset < 0) {
+            throw new IllegalArgumentException("Negative length or offsets not allowed");
+        }
+        if (len > src.length - srcOffset) {
+            throw new BufferUnderflowException();
+        }
+        if (len > length() - offset) {
+            throw new BufferOverflowException();
+        }
+
+        System.arraycopy(src, srcOffset, array, Math.toIntExact(arrayOffset + offset), len);
         return len;
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/MemoryData.java
@@ -578,6 +578,13 @@ public final class MemoryData
     }
 
     @Override
+    public int putByte(final long offset, final byte b) {
+        checkOffsetToWrite(offset, length(), 1);
+        segment.set(ValueLayout.JAVA_BYTE, offset, b);
+        return 1;
+    }
+
+    @Override
     public long getBytes(final long offset, @NonNull final byte[] dst, final int dstOffset, final int maxLength) {
         if (maxLength < 0) {
             throw new IllegalArgumentException("Negative maxLength not allowed");
@@ -590,6 +597,27 @@ public final class MemoryData
             System.arraycopy(array, Math.toIntExact(segment.address() + offset), dst, dstOffset, Math.toIntExact(len));
         } else {
             MemorySegment.copy(segment, offset, MemorySegment.ofArray(dst).asSlice(dstOffset, len), 0, len);
+        }
+        return len;
+    }
+
+    @Override
+    public int putBytes(final long offset, @NonNull final byte[] src, final int srcOffset, final int len) {
+        if (len < 0 || offset < 0 || srcOffset < 0) {
+            throw new IllegalArgumentException("Negative length or offsets not allowed");
+        }
+        if (len > src.length - srcOffset) {
+            throw new BufferUnderflowException();
+        }
+        if (len > length() - offset) {
+            throw new BufferOverflowException();
+        }
+
+        final Optional<Object> heapBaseOptional = segment.heapBase();
+        if (heapBaseOptional.isPresent() && heapBaseOptional.get() instanceof byte[] array) {
+            System.arraycopy(src, srcOffset, array, Math.toIntExact(segment.address() + offset), len);
+        } else {
+            MemorySegment.copy(MemorySegment.ofArray(src), srcOffset, segment, offset, len);
         }
         return len;
     }
@@ -670,6 +698,13 @@ public final class MemoryData
             throw new BufferUnderflowException();
         }
         return segment.get(determineLongLayout(ByteOrder.BIG_ENDIAN, offset), offset);
+    }
+
+    @Override
+    public int putLong(final long offset, final long value) {
+        checkOffsetToWrite(offset, length(), 8);
+        segment.set(determineLongLayout(ByteOrder.BIG_ENDIAN, offset), offset, value);
+        return 8;
     }
 
     @Override

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -355,10 +355,7 @@ public interface RandomAccessData {
     /// Puts a given long `value` as a big-endian 8 bytes at a given `offset`.
     /// @return the number of bytes written
     default int putLong(final long offset, final long value) {
-        checkOffset(offset, length());
-        if ((length() - offset) < Long.BYTES) {
-            throw new BufferOverflowException();
-        }
+        checkOffsetToWrite(offset, length(), Long.BYTES);
         putByte(offset, (byte) ((value >>> 56) & 0xFF));
         putByte(offset + 1, (byte) ((value >>> 48) & 0xFF));
         putByte(offset + 2, (byte) ((value >>> 40) & 0xFF));

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/RandomAccessData.java
@@ -17,6 +17,11 @@ import java.security.MessageDigest;
  * this interface is only backed by a buffer of some kind: an array, a {@link ByteBuffer}, a memory-mapped file, etc.
  * Unlike {@link BufferedSequentialData}, it does not define any kind of "position" cursor, just a "length" representing
  * the valid range of indexes and methods for reading data at any of those indexes.
+ * <p>
+ * In addition to "get" methods for reading data, this interface also defines a few "put" methods for writing data.
+ * By default, the "put" methods throw the `UnsupportedOperationException` and must be overridden in concrete classes
+ * to implement the write operations. If a backing datastore such as a `MemorySegment` in the `MemoryData` class
+ * is readonly, then calling a "put" method would still throw an exception because the store is immutable.
  */
 @SuppressWarnings("unused")
 public interface RandomAccessData {
@@ -36,6 +41,12 @@ public interface RandomAccessData {
      * @throws IndexOutOfBoundsException If the given {@code offset} is negative or not less than {@link #length()}
      */
     byte getByte(final long offset);
+
+    /// Puts a given signed byte at a given `offset` if this object is mutable, or throws an exception otherwise.
+    /// @return the number of bytes written
+    default int putByte(final long offset, final byte b) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Gets the unsigned byte at given {@code offset}.
@@ -95,6 +106,34 @@ public interface RandomAccessData {
             dst[dstOffset + i] = getByte(offset + i);
         }
         return len;
+    }
+
+    /// Puts `len` bytes from `src` starting at `srcOffset` into this object at a given `offset`, or throw an exception
+    /// if the source or the destination don't have enough bytes, or the operation is unsupported.
+    /// @return the number of bytes written
+    default int putBytes(final long offset, @NonNull final byte[] src, final int srcOffset, final int len) {
+        if (len < 0 || offset < 0 || srcOffset < 0) {
+            throw new IllegalArgumentException("Negative length or offsets not allowed");
+        }
+        if (len > src.length - srcOffset) {
+            throw new BufferUnderflowException();
+        }
+        if (len > length() - offset) {
+            throw new BufferOverflowException();
+        }
+
+        for (int i = 0; i < len; i++) {
+            putByte(offset + i, src[srcOffset + i]);
+        }
+
+        return len;
+    }
+
+    /// A convenience version of the `putBytes(long, byte[], int, int)` to put an entire `src` array at a given
+    /// `offset`.
+    /// @return the number of bytes written
+    default int putBytes(final long offset, @NonNull final byte[] src) {
+        return putBytes(offset, src, 0, src.length);
     }
 
     /**
@@ -313,6 +352,24 @@ public interface RandomAccessData {
                 + (b8 & 255));
     }
 
+    /// Puts a given long `value` as a big-endian 8 bytes at a given `offset`.
+    /// @return the number of bytes written
+    default int putLong(final long offset, final long value) {
+        checkOffset(offset, length());
+        if ((length() - offset) < Long.BYTES) {
+            throw new BufferOverflowException();
+        }
+        putByte(offset, (byte) ((value >>> 56) & 0xFF));
+        putByte(offset + 1, (byte) ((value >>> 48) & 0xFF));
+        putByte(offset + 2, (byte) ((value >>> 40) & 0xFF));
+        putByte(offset + 3, (byte) ((value >>> 32) & 0xFF));
+        putByte(offset + 4, (byte) ((value >>> 24) & 0xFF));
+        putByte(offset + 5, (byte) ((value >>> 16) & 0xFF));
+        putByte(offset + 6, (byte) ((value >>> 8) & 0xFF));
+        putByte(offset + 7, (byte) (value & 0xFF));
+        return 8;
+    }
+
     /**
      * Gets eight bytes at the given {@code offset}, composing them into a long value according to specified byte
      * order.
@@ -503,6 +560,21 @@ public interface RandomAccessData {
         }
 
         throw new DataEncodingException("Malformed var int");
+    }
+
+    /// Puts a given long `value` as a no-zigZag varint at a given `offset`.
+    /// @return the number of bytes written
+    default int putVarLong(final long offset, long value) {
+        long pos = offset;
+        while (true) {
+            if ((value & ~0x7FL) == 0) {
+                putByte(pos++, (byte) value);
+                return (int) (pos - offset);
+            } else {
+                putByte(pos++, (byte) (((int) value & 0x7F) | 0x80));
+                value >>>= 7;
+            }
+        }
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BufferedDataTestBase.java
@@ -5,19 +5,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.hedera.pbj.runtime.ProtoWriterTools;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.ReadableSequentialTestBase;
 import com.hedera.pbj.runtime.io.ReadableTestBase;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.WritableTestBase;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /// A base test class for BufferedData-like objects of type T.
@@ -222,43 +228,46 @@ abstract class BufferedDataTestBase<
         assertEquals(afterPos, buf.position());
     }
 
+    private static Stream<Arguments> provideLongs() {
+        return Stream.of(
+                        0,
+                        1,
+                        7,
+                        8,
+                        9,
+                        127,
+                        128,
+                        129,
+                        1023,
+                        1024,
+                        1025,
+                        65534,
+                        65535,
+                        65536,
+                        0xFFFFFFFFL,
+                        0x100000000L,
+                        0x100000001L,
+                        0xFFFFFFFFFFFFL,
+                        0x1000000000000L,
+                        0x1000000000001L,
+                        -1,
+                        -7,
+                        -8,
+                        -9,
+                        -127,
+                        -128,
+                        -129,
+                        -65534,
+                        -65535,
+                        -65536,
+                        -0xFFFFFFFFL,
+                        -0x100000000L,
+                        -0x100000001L)
+                .map(Arguments::of);
+    }
+
     @ParameterizedTest
-    @ValueSource(
-            longs = {
-                0,
-                1,
-                7,
-                8,
-                9,
-                127,
-                128,
-                129,
-                1023,
-                1024,
-                1025,
-                65534,
-                65535,
-                65536,
-                0xFFFFFFFFL,
-                0x100000000L,
-                0x100000001L,
-                0xFFFFFFFFFFFFL,
-                0x1000000000000L,
-                0x1000000000001L,
-                -1,
-                -7,
-                -8,
-                -9,
-                -127,
-                -128,
-                -129,
-                -65534,
-                -65535,
-                -65536,
-                -0xFFFFFFFFL,
-                -0x100000000L,
-                -0x100000001L
-            })
+    @MethodSource("provideLongs")
     @DisplayName("readVarLong() works with views")
     void sliceThenReadVarLong(final long num) {
         final var buf = allocate(256);
@@ -272,6 +281,101 @@ abstract class BufferedDataTestBase<
         final long readback = slicedBuf.readVarLong(false);
         assertEquals(num + 1, readback);
         assertEquals(afterSecondIntPos - afterFirstIntPos, slicedBuf.position());
+    }
+
+    @Test
+    @DisplayName("putByte() works")
+    void putByte() {
+        final int SIZE = 100;
+        final var buf = allocate(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(1, buf.putByte(i, (byte) (SIZE - i)));
+        }
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals((byte) (SIZE - i), buf.getByte(i));
+        }
+    }
+
+    @Test
+    @DisplayName("putBytes(long, byte[], int, int) works")
+    void putBytes() {
+        final int LENGTH = 200;
+        final byte[] array = new byte[LENGTH];
+        for (int i = 0; i < LENGTH; i++) {
+            array[i] = (byte) i;
+        }
+        final int SIZE = 100;
+        // ASSUME: the buffer is initialized with all zeros
+        final var buf = allocate(SIZE);
+        final int OFFSET_SRC = 55;
+        final int OFFSET_DST = 5;
+        final int LEN = 15;
+        assertEquals(LEN, buf.putBytes(OFFSET_DST, array, OFFSET_SRC, LEN));
+        for (int i = 0; i < OFFSET_DST; i++) {
+            assertEquals(0, buf.getByte(i));
+        }
+        for (int i = 0; i < LEN; i++) {
+            assertEquals(array[OFFSET_SRC + i], buf.getByte(OFFSET_DST + i));
+        }
+        for (int i = 0; i < SIZE - LEN - OFFSET_DST; i++) {
+            assertEquals(0, buf.getByte(OFFSET_DST + LEN + i));
+        }
+    }
+
+    @Test
+    @DisplayName("putBytes(long, byte[]) works")
+    void putBytesSimple() {
+        final int LENGTH = 20;
+        final byte[] array = new byte[LENGTH];
+        for (int i = 0; i < LENGTH; i++) {
+            array[i] = (byte) i;
+        }
+        final int SIZE = 100;
+        // ASSUME: the buffer is initialized with all zeros
+        final var buf = allocate(SIZE);
+        final int OFFSET_DST = 5;
+        assertEquals(array.length, buf.putBytes(OFFSET_DST, array));
+        for (int i = 0; i < OFFSET_DST; i++) {
+            assertEquals(0, buf.getByte(i));
+        }
+        for (int i = 0; i < array.length; i++) {
+            assertEquals(array[i], buf.getByte(OFFSET_DST + i));
+        }
+        for (int i = 0; i < SIZE - array.length - OFFSET_DST; i++) {
+            assertEquals(0, buf.getByte(OFFSET_DST + array.length + i));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideLongs")
+    @DisplayName("putLong() works")
+    void putLong(final long num) {
+        final int SIZE = 8;
+        final var buf = allocate(SIZE);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.putLong(-1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.putLong(8, 0));
+        assertThrows(BufferOverflowException.class, () -> buf.putLong(1, 0));
+
+        assertEquals(8, buf.putLong(0, num));
+        assertEquals(num, buf.getLong(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideLongs")
+    @DisplayName("putVarLong() works")
+    void putVarLong(final long num) {
+        final int SIZE = 10;
+        final var buf = allocate(SIZE);
+
+        final int numSize = ProtoWriterTools.sizeOfVarInt64(num);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.putVarLong(-1, num));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.putVarLong(SIZE, num));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.putVarLong(SIZE - numSize + 1, num));
+
+        assertEquals(numSize, buf.putVarLong(SIZE - numSize, num));
+        assertEquals(num, buf.getVarLong(SIZE - numSize, false));
     }
 
     @Test

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/BytesTest.java
@@ -78,6 +78,24 @@ final class BytesTest {
     }
 
     @Test
+    @DisplayName("RandomAccessData.put*() methods must throw exceptions because Bytes is read-only")
+    void putDoesNotWork() {
+        final String str = "1234567890";
+        final Bytes bytes = Bytes.wrap(str);
+
+        assertThrows(UnsupportedOperationException.class, () -> bytes.putByte(0, (byte) 0));
+        assertEquals(str, bytes.asUtf8String());
+        assertThrows(UnsupportedOperationException.class, () -> bytes.putBytes(0, new byte[] {4, 5, 6}));
+        assertEquals(str, bytes.asUtf8String());
+        assertThrows(UnsupportedOperationException.class, () -> bytes.putBytes(0, new byte[] {4, 5, 6}, 1, 1));
+        assertEquals(str, bytes.asUtf8String());
+        assertThrows(UnsupportedOperationException.class, () -> bytes.putLong(0, 111L));
+        assertEquals(str, bytes.asUtf8String());
+        assertThrows(UnsupportedOperationException.class, () -> bytes.putVarLong(0, 111L));
+        assertEquals(str, bytes.asUtf8String());
+    }
+
+    @Test
     void testReplicate() {
         byte[] arr = new byte[] {0, 1, 2};
 
@@ -762,9 +780,7 @@ final class BytesTest {
     }
 
     @ParameterizedTest
-    @CsvSource(
-            textBlock =
-                    """
+    @CsvSource(textBlock = """
             "", "", 0
             "a", "", 1
             "", "a", -1

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/MemoryDataTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/MemoryDataTest.java
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime.io.buffer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 /// Test for heap MemoryData
 final class MemoryDataTest extends BufferedDataTestBase<MemoryData> {
@@ -22,5 +29,25 @@ final class MemoryDataTest extends BufferedDataTestBase<MemoryData> {
     @Override
     protected MemoryData wrap(final byte[] arr, final int offset, final int len) {
         return MemoryData.wrap(arr, offset, len);
+    }
+
+    @Test
+    @DisplayName("RandomAccessData.put*() methods must throw exceptions on read-only MemoryData")
+    void putDoesNotWork() {
+        final String str = "1234567890";
+        final MemorySegment readOnlySegment =
+                MemorySegment.ofArray(str.getBytes(StandardCharsets.UTF_8)).asReadOnly();
+        final MemoryData data = MemoryData.wrap(readOnlySegment);
+
+        assertThrows(IllegalArgumentException.class, () -> data.putByte(0, (byte) 0));
+        assertEquals(str, data.asUtf8String());
+        assertThrows(IllegalArgumentException.class, () -> data.putBytes(0, new byte[] {4, 5, 6}));
+        assertEquals(str, data.asUtf8String());
+        assertThrows(IllegalArgumentException.class, () -> data.putBytes(0, new byte[] {4, 5, 6}, 1, 1));
+        assertEquals(str, data.asUtf8String());
+        assertThrows(IllegalArgumentException.class, () -> data.putLong(0, 111L));
+        assertEquals(str, data.asUtf8String());
+        assertThrows(IllegalArgumentException.class, () -> data.putVarLong(0, 111L));
+        assertEquals(str, data.asUtf8String());
     }
 }


### PR DESCRIPTION
**Description**:
Introducing new `RandomAccessData.put*()` methods for absolute writes into RandomAccessData objects. By default the methods throw an exception, and this works perfectly for the immutable `Bytes` which implements this interface. Other implementations, such as `BufferedData` and `MemoryData` have overrides that implement actual put operations.

The methods are: `putByte(long, byte)`, `putBytes(long, byte[])`, `putBytes(long, byte[], int, int)`, `putLong(long, long)`, and `putVarLong(long, long)` which is the minimum set of methods that could be immediately useful in the MerkleDB implementation in the Consensus Node. If necessary, we can add methods for other types (float, String, and whatnot) in the future.

Unit tests are updated to verify all the new methods.

**Related issue(s)**:

Fixes #790 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
