### PR TITLE
fix: deadline calculation in PbjProtocolHandler

### DIFF
--- a/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
+++ b/pbj-core/pbj-grpc-helidon/src/main/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandler.java
@@ -527,7 +527,7 @@ final class PbjProtocolHandler implements Http2SubProtocolSelector.SubProtocolHa
             final var num = Integer.parseInt(matcher.group(1));
             final var unit = matcher.group(2);
             final var deadline = System.nanoTime()
-                    * TimeUnit.NANOSECONDS.convert(
+                    + TimeUnit.NANOSECONDS.convert(
                             num,
                             switch (unit) {
                                 case "H" -> TimeUnit.HOURS;

--- a/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
+++ b/pbj-core/pbj-grpc-helidon/src/test/java/com/hedera/pbj/grpc/helidon/PbjProtocolHandlerTest.java
@@ -522,6 +522,35 @@ class PbjProtocolHandlerTest {
         assertThat(handler.streamState()).isEqualTo(Http2StreamState.CLOSED);
     }
 
+    /**
+     * Verifies that {@code scheduleDeadline} computation is correct
+     */
+    @Test
+    void scheduleDeadlinePassesPositiveFutureNanosToDetector() {
+        final long timeoutNanos = TimeUnit.SECONDS.toNanos(30);
+        headers = Http2Headers.create(WritableHeaders.create()
+                .add(HeaderNames.CONTENT_TYPE, "application/grpc+proto")
+                .add(HeaderNames.create("grpc-timeout"), "30S"));
+
+        final long beforeNanos = System.nanoTime();
+        final var handler = new PbjProtocolHandler(
+                headers,
+                streamWriter,
+                streamId,
+                flowControl,
+                currentStreamState,
+                config,
+                route,
+                deadlineDetector,
+                connectionContext);
+        handler.init();
+        final long afterNanos = System.nanoTime();
+
+        assertThat(deadlineDetector.capturedDeadlineNanos).isPositive();
+        assertThat(deadlineDetector.capturedDeadlineNanos).isGreaterThanOrEqualTo(beforeNanos + timeoutNanos);
+        assertThat(deadlineDetector.capturedDeadlineNanos).isLessThanOrEqualTo(afterNanos + timeoutNanos);
+    }
+
     @Test
     void errorThrownForOnNextWhenStreamIsClosed() {
         // Use a custom streamWriter that will throw an exception when "streamClosed" is set to true, and it is
@@ -690,9 +719,12 @@ class PbjProtocolHandlerTest {
     }
 
     private static final class DeadlineDetectorStub implements DeadlineDetector {
+        long capturedDeadlineNanos = Long.MIN_VALUE;
+
         @NonNull
         @Override
         public ScheduledFuture<?> scheduleDeadline(long deadlineNanos, @NonNull Runnable onDeadlineExceeded) {
+            capturedDeadlineNanos = deadlineNanos;
             return new ScheduledFuture<>() {
                 @Override
                 public long getDelay(@NonNull TimeUnit unit) {


### PR DESCRIPTION
**Description**:

Fix `PbjProtocolHandler.scheduleDeadline` to compute the server-side deadline as `System.nanoTime() + durationNanos ` instead of `System.nanoTime() * durationNanos, preventing immediate DEADLINE_EXCEEDED` on all timed inbound gRPC calls.

* Fix multiplication operator (*) to addition (+) in scheduleDeadline deadline computation
* Add capturedDeadlineNanos field to DeadlineDetectorStub to record the value passed by scheduleDeadline
* Add test scheduleDeadlinePassesPositiveFutureNanosToDetector asserting the deadline is positive and falls within the expected [nanoTime + timeout] window

**Related issue(s)**:

Fixes #839 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
