### PR TITLE
perf: improve ByteArrayBufferedData.writeVarLong

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/ByteArrayBufferedData.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime.io.buffer;
 
+import com.hedera.pbj.runtime.ProtoArrayWriterTools;
+import com.hedera.pbj.runtime.ProtoWriterTools;
 import com.hedera.pbj.runtime.io.DataEncodingException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -712,6 +714,24 @@ final class ByteArrayBufferedData extends BufferedData {
             return totalBytesRead;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void writeVarLong(long value, boolean zigZag) {
+        if (zigZag) {
+            value = (value << 1) ^ (value >> 63);
+        }
+
+        final int position = buffer.position();
+        try {
+            final int length = ProtoWriterTools.sizeOfVarInt64(value);
+            // Tests expect the position to advance even if the operation overflows in the end:
+            buffer.position(Math.min(position + length, position + Math.toIntExact(remaining())));
+            checkOffsetToWrite(position, length(), length);
+            ProtoArrayWriterTools.writeUnsignedVarInt(array, arrayOffset + position, value);
+        } catch (IndexOutOfBoundsException e) {
+            throw new BufferOverflowException();
         }
     }
 }


### PR DESCRIPTION
**Description**:
Implementing `ByteArrayBufferedData.writeVarLong()` to speed up varint writing and make it faster than Google's similar implementation. Performance testing:

**BEFORE:** https://github.com/hashgraph/pbj/actions/runs/26786674935/job/78963964610
```
Benchmark                                      (numOfBytes)  Mode  Cnt   Score   Error  Units
VarIntWriterBench.googleCodedByteArray                    4  avgt    5   3.649 ± 0.031  ns/op
VarIntWriterBench.googleCodedByteBufferDirect             4  avgt    5   4.161 ± 0.018  ns/op
VarIntWriterBench.googleCodedOutputStream                 4  avgt    5   3.682 ± 0.005  ns/op
VarIntWriterBench.kafkaByteBuffer                         4  avgt    5   4.018 ± 0.056  ns/op
VarIntWriterBench.pbjBufferedData                         4  avgt    5   4.632 ± 0.071  ns/op
VarIntWriterBench.pbjBufferedDataDirect                   4  avgt    5   4.121 ± 0.039  ns/op
VarIntWriterBench.pbjWritableStreamingData                4  avgt    5  20.439 ± 0.113  ns/op
VarIntWriterBench.richardStartinByteArray                 4  avgt    5   1.464 ± 0.003  ns/op
```

**AFTER:** https://github.com/hashgraph/pbj/actions/runs/26843686890/job/79157361053
```
Benchmark                                      (numOfBytes)  Mode  Cnt   Score   Error  Units
VarIntWriterBench.googleCodedByteArray                    4  avgt    5   3.639 ± 0.016  ns/op
VarIntWriterBench.googleCodedByteBufferDirect             4  avgt    5   4.164 ± 0.023  ns/op
VarIntWriterBench.googleCodedOutputStream                 4  avgt    5   4.978 ± 0.072  ns/op
VarIntWriterBench.kafkaByteBuffer                         4  avgt    5   3.987 ± 0.024  ns/op
VarIntWriterBench.pbjBufferedData                         4  avgt    5   3.255 ± 0.009  ns/op
VarIntWriterBench.pbjBufferedDataDirect                   4  avgt    5   4.144 ± 0.036  ns/op
VarIntWriterBench.pbjWritableStreamingData                4  avgt    5  20.436 ± 0.037  ns/op
VarIntWriterBench.richardStartinByteArray                 4  avgt    5   1.462 ± 0.004  ns/op
```

Note the diff in the `pbjBufferedData` test.

The `pbjBufferedDataDirect` is already faster than Google, and its performance is bounded by the direct buffer access which we cannot improve easily.

I tried tweaking `pbjWritableStreamingData`, but it's limited by the stream nature of the destination.

As of today, the `pbjBufferedData` does in fact use the Richard Startin algo same as in `richardStartinByteArray`. However, this benchmark implementation of this algorithm is way simpler than our buffers, and in particular it lacks any bounds checks and similar. It's for this reason that it's showing as the fastest in the benchmark run. Since we already use this same algo, we cannot really improve our performance any further. But we're already faster than Google, so we're good.

**Related issue(s)**:

Fixes #846

**Notes for reviewer**:
The `writeVarLong` is very well covered by existing BufferedData unit tests already. So this new overridden implementation is being tested properly by the existing tests.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
