### PR TITLE
Add main to ProtobufObjectBench

### DIFF
--- a/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/ProtobufObjectBench.java
+++ b/pbj-integration-tests/src/jmh/java/com/hedera/pbj/integration/jmh/ProtobufObjectBench.java
@@ -32,6 +32,9 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @SuppressWarnings("unused")
 @Fork(1)
@@ -319,5 +322,12 @@ public abstract class ProtobufObjectBench<P, G extends GeneratedMessage> {
                     GetAccountDetailsResponse.AccountDetails::parseFrom,
                     GetAccountDetailsResponse.AccountDetails::parseFrom);
         }
+    }
+    static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(EverythingBench.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
     }
 }


### PR DESCRIPTION
**Description**:

Adds main to ProtobufObjectBench, to run actions using com.hedera.pbj.integration.jmh.ProtobufObjectBench

Example result:

https://github.com/hashgraph/pbj/actions/runs/26979231408/job/79613976276

`Benchmark                                                        Mode  Cnt       Score      Error  Units
JsonBench.EverythingBench.parsePbj                               avgt    5  724808.315 ± 3938.258  ns/op
JsonBench.EverythingBench.parseProtoC                            avgt    5  154841.062 ± 2530.080  ns/op
JsonBench.EverythingBench.writeProtoC                            avgt    5  128727.369 ± 6846.019  ns/op
ProtobufObjectBench.EverythingBench.parsePbjByteArray            avgt    7   38302.416 ±  251.353  ns/op
ProtobufObjectBench.EverythingBench.parsePbjByteBuffer           avgt    7   37975.583 ±  171.749  ns/op
ProtobufObjectBench.EverythingBench.parsePbjByteBufferDirect     avgt    7   54718.479 ±  237.438  ns/op
ProtobufObjectBench.EverythingBench.parsePbjInputStream          avgt    7   42724.794 ±  245.429  ns/op
ProtobufObjectBench.EverythingBench.parseProtoCByteArray         avgt    7   18673.640 ±  122.797  ns/op
ProtobufObjectBench.EverythingBench.parseProtoCByteBuffer        avgt    7   18561.728 ±   96.832  ns/op
ProtobufObjectBench.EverythingBench.parseProtoCByteBufferDirect  avgt    7   19004.189 ±  244.949  ns/op
ProtobufObjectBench.EverythingBench.parseProtoCInputStream       avgt    7   19004.539 ±  212.926  ns/op
ProtobufObjectBench.EverythingBench.writePbjByteArray            avgt    7   14435.173 ±  250.567  ns/op
ProtobufObjectBench.EverythingBench.writePbjByteBuffer           avgt    7   14453.549 ±  334.121  ns/op
ProtobufObjectBench.EverythingBench.writePbjByteDirect           avgt    7   10273.071 ±   60.202  ns/op
ProtobufObjectBench.EverythingBench.writePbjOutputStream         avgt    7   15834.433 ±   84.341  ns/op
ProtobufObjectBench.EverythingBench.writeProtoCByteArray         avgt    7   10161.016 ±   54.200  ns/op
ProtobufObjectBench.EverythingBench.writeProtoCByteBuffer        avgt    7    9655.258 ±   47.309  ns/op
ProtobufObjectBench.EverythingBench.writeProtoCByteBufferDirect  avgt    7   13428.888 ±   97.163  ns/op
ProtobufObjectBench.EverythingBench.writeProtoCOutputStream      avgt    7   14106.541 ±   79.359  ns/op`