### PR TITLE
perf: cache Bytes.toMemorySegment()

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -78,6 +78,9 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
      */
     private int hashCode = 0;
 
+    /// Cached read-only MemorySegment backed by this Bytes instance.
+    private MemorySegment memorySegment = null;
+
     /**
      * Create a new ByteOverByteBuffer over given byte array. This does not copy data it just wraps so
      * any changes to arrays contents will be effected here.
@@ -513,7 +516,12 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
      * @return a read-only on-heap MemorySegment mapping this Bytes' content
      */
     public MemorySegment toMemorySegment() {
-        return MemorySegment.ofArray(buffer).asSlice(start, length).asReadOnly();
+        // No synchronization for performance reasons. Rely on eventual consistency.
+        if (memorySegment != null) {
+            return memorySegment;
+        }
+        return memorySegment =
+                MemorySegment.ofArray(buffer).asSlice(start, length).asReadOnly();
     }
 
     /**


### PR DESCRIPTION
**Description**:
Per https://github.com/hiero-ledger/hiero-cryptography/pull/631#issuecomment-4804728309 , it appears that caching MemorySegments could ever-so-slightly reduce preassure on Java GC. So in this fix I'm caching the result returned by the `Bytes.toMemorySegment()`

**Related issue(s)**:

Fixes #869 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
