### PR TITLE
Codec Interface to Abstract class, made all paths call parseImpl/writeImpl

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecGenerator.java
@@ -78,7 +78,7 @@ public final class JsonCodecGenerator implements Generator {
                 /**
                  * JSON Codec for $modelClass model object. Generated based on protobuf schema.
                  */
-                public final$staticModifier class $codecClass implements JsonCodec<$modelClass> {
+                public final$staticModifier class $codecClass extends JsonCodec<$modelClass> {
 
                     /**
                      * Empty constructor

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -62,7 +62,7 @@ class JsonCodecParseMethodGenerator {
                  * @return Parsed HashObject model object or null if data input was null or empty
                  * @throws ParseException If parsing fails
                  */
-                public @NonNull $modelClassName parse(
+                protected final @NonNull $modelClassName parseImpl(
                         @Nullable final JSONParser.ObjContext root,
                         final boolean strictMode,
                         final int maxDepth,

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecWriteMethodGenerator.java
@@ -33,7 +33,7 @@ final class JsonCodecWriteMethodGenerator {
                         field, modelClassName, "data.%s()".formatted(field.nameCamelFirstLower())))
                 .collect(Collectors.joining("\n"))
                 .indent(DEFAULT_INDENT);
-
+        // spotless:off
         return """
                 /**
                  * Returns JSON string representing an item.
@@ -44,7 +44,7 @@ final class JsonCodecWriteMethodGenerator {
                  *                        it will just be the object "{...}"
                  */
                 @Override
-                public String toJSON(@NonNull $modelClass data, String indent, boolean inline) {
+                protected String toJSONImpl(@NonNull $modelClass data, String indent, boolean inline) {
                     StringBuilder sb = new StringBuilder();
                     // start
                     sb.append(inline ? "{\\n" : indent + "{\\n");
@@ -66,6 +66,7 @@ final class JsonCodecWriteMethodGenerator {
                 .replace("$modelClass", modelClassName)
                 .replace("$fieldWriteLines", fieldWriteLines)
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
@@ -15,6 +15,7 @@ class CodecFastEqualsMethodGenerator {
 
     static String generateFastEqualsMethod(final String modelClassName, final List<Field> fields) {
         // Placeholder implementation, replace faster implementation than full parse if there is one
+        // spotless:off
         return """
                 /**
                  * Compares the given item with the bytes in the input, and returns false if it determines that
@@ -28,11 +29,12 @@ class CodecFastEqualsMethodGenerator {
                  * @return true if the bytes represent the item, false otherwise.
                  * @throws ParseException If parsing fails
                  */
-                public boolean fastEquals(@NonNull $modelClass item, @NonNull final ReadableSequentialData input) throws ParseException {
+                public boolean fastEquals(@NonNull $modelClass item, @NonNull final PbjReader input) throws ParseException {
                     return item.equals(parse(input));
                 }
                 """
                 .replace("$modelClass", modelClassName)
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -133,7 +133,7 @@ public final class CodecGenerator implements Generator {
                 /**
                  * Protobuf Codec for $modelClass model object. Generated based on protobuf schema.
                  */
-                public final$staticModifier class $codecClass implements Codec<$modelClass> {
+                public final$staticModifier class $codecClass extends Codec<$modelClass> {
                 $cacheableSupport
                     /**
                      * An initial capacity for the ArrayList where unknown fields are collected.

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
@@ -14,6 +14,7 @@ class CodecMeasureDataMethodGenerator {
 
     static String generateMeasureMethod(final String modelClassName, final List<Field> fields) {
         // Placeholder implementation, replace faster implementation than full parse if there is one
+        // spotless:off
         return """
                 /**
                  * Reads from this data input the length of the data within the input. The implementation may
@@ -24,7 +25,7 @@ class CodecMeasureDataMethodGenerator {
                  * @return The length of the data item in the input
                  * @throws ParseException If parsing fails
                  */
-                public int measure(@NonNull final ReadableSequentialData input) throws ParseException {
+                public int measure(@NonNull final PbjReader input) throws ParseException {
                     final var start = input.position();
                     parse(input);
                     final var end = input.position();
@@ -32,5 +33,6 @@ class CodecMeasureDataMethodGenerator {
                 }
                 """
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -289,44 +289,61 @@ class CodecParseMethodGenerator {
         sbFunc.append("""
 %s case%d(PbjReader input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
+        int divideAmount = fieldType.equals("List<Integer>") ? 2
+            : fieldType.equals("List<Long>") ? 4
+            : fieldType.equals("List<Float>") ? 2
+            : fieldType.equals("List<Double>") ? 4
+            : fieldType.equals("List<Boolean>") ? 1
+            : 0;
+
         if (field.type() == Field.FieldType.ENUM) {
+            divideAmount = 1;
             preRead = """
                     final int enumOrdinal = readEnum(input);
                     Object value = $enumName.fromProtobufOrdinal(enumOrdinal);
                     if (value == $enumName.UNRECOGNIZED) {
-                       value = Integer.valueOf(enumOrdinal);
+                        value = Integer.valueOf(enumOrdinal);
                     }
                     
                     """
-                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true))
-            ;
+                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true));
         } else {
             preRead = "";
         }
-        final String loopBody = preRead + "%s = addToList(%s,%s);"
-                .formatted(tempFieldName, tempFieldName, field.type() == Field.FieldType.ENUM ? "value" : readMethod(field));
+
+        if (divideAmount == 0) {
+            throw new RuntimeException("Need to implement");
+        }
+
         sbFunc.append("""
                 // Read the length of packed repeated field data
-                final long length = input.readVarInt(false);
+                final int length = input.readVarInt(false);
                 if (length > $maxSize) {
                     throw new ParseException("$fieldName size " + length + " is greater than max " + $maxSize);
                 }
                 if (input.remaining() < length) {
                     throw new BufferUnderflowException();
                 }
-                final var beforeLimit = input.limit();
-                final long beforePosition = input.position();
+                final var startLimit = input.limit();
+                final long startPosition = input.position();
                 input.limit(input.position() + length);
+                var list = new UnmodifiableArray$fieldType();
+                list.ensureCapacity(length$divideString);
                 while (input.hasRemaining()) {
-                $loopBody
+                    $preReadlist.add($readMethod);
                 }
-                input.limit(beforeLimit);
-                if (input.position() != beforePosition + length) {
+                $tempFieldName = list;
+                input.limit(startLimit);
+                if (input.position() != startPosition + length) {
                     throw new BufferUnderflowException();
                 }"""
-                .replace("$loopBody", loopBody.indent(DEFAULT_INDENT).stripTrailing())
+                .replace("$tempFieldName", tempFieldName)
+                .replace("$preRead", preRead)
+                .replace("$fieldType", fieldType)
+                .replace("$readMethod", field.type() == Field.FieldType.ENUM ? "value" : readMethod(field))
                 .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                 .replace("$fieldName", field.name())
+                .replace("$divideString", divideAmount == 1 ? "" : "/%d".formatted(divideAmount))
                 .indent(DEFAULT_INDENT));
         sbCase.append("\n}\n");
         sbFunc.append("    return %s;\n    }\n".formatted(tempFieldName));

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -82,7 +82,7 @@ class CodecParseMethodGenerator {
                  * @return Parsed $modelClassName model object or null if data input was null or empty
                  * @throws ParseException If parsing fails
                  */
-                public @NonNull $modelClassName parse(
+                protected final @NonNull $modelClassName parseImpl(
                         @NonNull final ReadableSequentialData input,
                         final boolean strictMode,
                         final boolean parseUnknownFields,

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -59,7 +59,7 @@ class CodecParseMethodGenerator {
         // spotless:off
         return """
                 /**
-                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
+                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link PbjReader}. Throws if in strict mode ONLY.
                  * <p>
                  * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
                  * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
@@ -83,7 +83,7 @@ class CodecParseMethodGenerator {
                  * @throws ParseException If parsing fails
                  */
                 protected final @NonNull $modelClassName parseImpl(
-                        @NonNull final ReadableSequentialData input,
+                        @NonNull final PbjReader input,
                         final boolean strictMode,
                         final boolean parseUnknownFields,
                         final int maxDepth,
@@ -110,8 +110,8 @@ class CodecParseMethodGenerator {
                         throw new ParseException(anyException);
                     }
                 }
-                
-                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, ReadableSequentialData input, int maxSize) throws ParseException, IOException {
+
+                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, PbjReader input, int maxSize) throws ParseException, IOException {
                 $defaultCaseBody
                     return $unknownFields;
                 }
@@ -182,20 +182,9 @@ class CodecParseMethodGenerator {
                         // -- PARSE LOOP ---------------------------------------------
                         // Continue to parse bytes out of the input stream until we get to the end.
                         while (input.hasRemaining()) {
-                            // Note: ReadableStreamingData.hasRemaining() won't flip to false
-                            // until the end of stream is actually hit with a read operation.
-                            // So we catch this exception here and **only** here, because an EOFException
-                            // anywhere else suggests that we're processing malformed data and so
-                            // we must re-throw the exception then.
-                            final int $prefixtag;
-                            try {
-                                // Read the "tag" byte which gives us the field number for the next field to read
-                                // and the wire type (way it is encoded on the wire).
-                                $prefixtag = input.readVarInt(false);
-                            } catch (EOFException e) {
-                                // There's no more fields. Stop the parsing loop.
-                                break;
-                            }
+                            // Read the "tag" byte which gives us the field number for the next field to read
+                            // and the wire type (way it is encoded on the wire).
+                            final int $prefixtag = input.readVarInt(false);
 
                             // The field is the top 5 bits of the byte. Read this off
                             final int $prefixfield = $prefixtag >>> TAG_FIELD_OFFSET;
@@ -298,7 +287,7 @@ class CodecParseMethodGenerator {
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
         sbFunc.append("""
-%s case%d(ReadableSequentialData input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
+%s case%d(PbjReader input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         if (field.type() == Field.FieldType.ENUM) {
             preRead = """
@@ -371,9 +360,9 @@ class CodecParseMethodGenerator {
                                 input.limit(input.position() + valueTypeMessageSize);
                                 // read inner tag
                                 final int valueFieldTag = input.readVarInt(false);
-                                // assert tag is as expected
-                                assert (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
-                                assert (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
+                                // assert tag is as expected; skip if a read error is already pending
+                                assert input.error() != 0 || (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
+                                assert input.error() != 0 || (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
                                 // read value
                                 value = $readMethod;
                                 input.limit(beforeLimit);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
@@ -49,7 +49,7 @@ final class CodecWriteByteArrayMethodGenerator {
              * @return The number of bytes written to the output array.
              * @throws IndexOutOfBoundsException If the output array is not large enough to hold the entire item.
              */
-            public int write(@NonNull $modelClass data, @NonNull byte[] output, final int startOffset) {
+            protected final int writeImpl(@NonNull $modelClass data, @NonNull byte[] output, final int startOffset) {
                 int offset = startOffset;
             $fieldWriteLines
                 // Write unknown fields if there are any

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -46,7 +46,7 @@ final class CodecWriteMethodGenerator {
              * @param out The output stream to write to
              * @throws IOException If there is a problem writing
              */
-            public void write(@NonNull $modelClass data, @NonNull final WritableSequentialData out) throws IOException {
+            protected final void writeImpl(@NonNull $modelClass data, @NonNull final WritableSequentialData out) throws IOException {
                 $fieldWriteLines
                 // Check if not-empty to avoid creating a lambda if there's nothing to write.
                 if (!data.getUnknownFields().isEmpty()) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -44,9 +44,8 @@ final class CodecWriteMethodGenerator {
              *
              * @param data The input model data to write
              * @param out The output stream to write to
-             * @throws IOException If there is a problem writing
              */
-            protected final void writeImpl(@NonNull $modelClass data, @NonNull final WritableSequentialData out) throws IOException {
+            protected final void writeImpl(@NonNull $modelClass data, @NonNull final PbjWriter out) {
                 $fieldWriteLines
                 // Check if not-empty to avoid creating a lambda if there's nothing to write.
                 if (!data.getUnknownFields().isEmpty()) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -3,12 +3,13 @@ package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.BufferedSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 
 /**
  * Encapsulates Serialization, Deserialization and other IO operations.
@@ -37,18 +38,100 @@ public abstract class Codec<T> {
      * consistent entry point. Subclasses implement this method rather than {@code parse} directly, since
      * {@code parse} may perform additional work before and after delegating to this implementation.
      *
+     * The only difference is it's allowed to return null, the parse overload is expected to call throwOnError.
+     *
      * @see #parse(ReadableSequentialData, boolean, boolean, int, int) for a description
      */
-    @NonNull
     protected abstract T parseImpl(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException;
 
     /**
+     * Parses an object from the {@link PbjReader} and returns it.
+     * <p>
+     * If {@code strictMode} is {@code true}, then throws an exception if fields
+     * have been defined on the encoded object that are not supported by the parser. This
+     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
+     * which is sometimes requires to avoid parsing an object that is newer than the code
+     * parsing it is prepared to handle.
+     * <p>
+     * The {@code maxDepth} specifies the maximum allowed depth of nested messages. The parsing
+     * will fail with a ParseException if the maximum depth is reached.
+     * <p>
+     * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
+     * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
+     * payload can cause the parser to allocate too much memory which can result in OutOfMemory and/or crashes.
+     * It's important to carefully estimate the maximum size limit that a particular protobuf model type should support,
+     * and then pass that value as a parameter. Note that the estimated limit should apply to the **type** as a whole,
+     * rather than to individual instances of the model. In other words, this value should be a constant, or a config
+     * value that is controlled by the application, rather than come from the input that the application reads.
+     * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
+     *
+     * @param input The {@link PbjReader} from which to read the data to construct an object
+     * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+     * @param parseUnknownFields when {@code true} and strictMode is {@code false}, the parser will collect unknown
+     *                           fields in the unknownFields list in the model; otherwise they'll be simply skipped.
+     * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
+     * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        T res = parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+        input.throwOnError();
+        return res;
+    }
+
+    /**
+     * Same as parse, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
+     * Return value may be null
+     */
+    public final T parseNoEx(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+    }
+
+    /**
+     * Same as parseStrict, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
+     * Return value may be null
+     */
+    public final T parseNoEx(@NonNull PbjReader input) throws ParseException {
+        return parseNoEx(input, true, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Parses an object from the {@link PbjReader} and returns it, using the default `Codec.DEFAULT_MAX_SIZE` and
+     * `Codec.DEFAULT_MAX_DEPTH` limits, and without strict mode or unknown field collection.
+     *
+     * @param input The {@link PbjReader} from which to read the data to construct an object
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(@NonNull PbjReader input) throws ParseException {
+        return parse(input, false, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Writes the true, logical number of bytes consumed by {@code reader} (which may be less than the number of
+     * bytes {@code reader} has physically buffered ahead from {@code input}) back onto {@code input}'s position,
+     * so that further reads of a {@link BufferedSequentialData}-backed {@code input} continue exactly where the
+     * parsed message ended. A plain stream-backed {@code input} (not a {@link BufferedSequentialData}) cannot be
+     * rewound, so it is left as-is and must be treated as fully consumed by the caller.
+     */
+    private static void syncPosition(@NonNull ReadableSequentialData input, @NonNull PbjReader reader) {
+        if (input instanceof BufferedSequentialData bsd) {
+            bsd.position(reader.position());
+        }
+    }
+
+    /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -86,10 +169,17 @@ public abstract class Codec<T> {
             int maxDepth,
             int maxSize)
             throws ParseException {
-        return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return parse(reader, strictMode, parseUnknownFields, maxDepth, maxSize);
+        } finally {
+            syncPosition(input, reader);
+        }
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -118,6 +208,8 @@ public abstract class Codec<T> {
         return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
     }
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -161,10 +253,12 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
-        return parse(bytes.toReadableSequentialData(), strictMode, maxDepth);
+        return parse(new PbjReader(bytes), strictMode, false, maxDepth, DEFAULT_MAX_SIZE);
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      *
      * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
@@ -189,6 +283,8 @@ public abstract class Codec<T> {
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it. Throws an exception if fields
      * have been defined on the encoded object that are not supported by the parser. This
      * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
@@ -225,19 +321,45 @@ public abstract class Codec<T> {
      * consistent entry point. Subclasses implement this method rather than {@code write} directly, since
      * {@code write} may perform additional work before and after delegating to this implementation.
      *
-     * @see #write(Object, WritableSequentialData) for a description
+     * @see #write(Object, PbjWriter) for a description
      */
-    protected abstract void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException;
+    protected abstract void writeImpl(@NonNull T item, @NonNull PbjWriter output);
 
     /**
+     * Writes an item to the given {@link PbjWriter}.
+     *
+     * @param item The item to write. Must not be null.
+     * @param output The {@link PbjWriter} to write to.
+     */
+    public final void write(@NonNull T item, @NonNull PbjWriter output) {
+        writeImpl(item, output);
+        output.throwOnError();
+    }
+
+    /**
+     * Writes an item to the given {@link PbjWriter}.
+     *
+     * @param item The item to write. Must not be null.
+     * @param output The {@link PbjWriter} to write to.
+     */
+    public final void writeNoEx(@NonNull T item, @NonNull PbjWriter output) {
+        writeImpl(item, output);
+    }
+
+    /**
+     * Temporary for test compatibility
+     *
      * Writes an item to the given {@link WritableSequentialData}.
      *
      * @param item The item to write. Must not be null.
      * @param output The {@link WritableSequentialData} to write to.
      * @throws IOException If the {@link WritableSequentialData} cannot be written to.
      */
-    public final void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
-        writeImpl(item, output);
+    public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+        final PbjWriter writer = new PbjWriter(output);
+        writeImpl(item, writer);
+        writer.flush();
+        writer.throwOnError();
     }
 
     /**
@@ -248,7 +370,7 @@ public abstract class Codec<T> {
      * @param output The byte array to write to, this must be large enough to hold the entire item.
      * @param startOffset The offset in the output array to start writing at.
      * @return The number of bytes written to the output array.
-     * @throws UncheckedIOException If the there is a problem writing to the output array.
+     * @throws RuntimeException If there is a problem writing to the output array.
      * @throws IndexOutOfBoundsException If the output array is not large enough to hold the entire item.
      */
     public final int write(@NonNull T item, @NonNull byte[] output, final int startOffset) {
@@ -262,18 +384,18 @@ public abstract class Codec<T> {
      * The actual byte-array writing logic for a specific codec, invoked by the {@link #write(Object, byte[], int)}
      * methods through a single, consistent entry point. Generated codecs override this method with a
      * performance-focused implementation; this default implementation delegates to
-     * {@link #writeImpl(Object, WritableSequentialData)} so that hand-written codecs don't need to provide one.
+     * {@link #writeImpl(Object, PbjWriter)} so that hand-written codecs don't need to provide one.
      *
      * @see #write(Object, byte[], int) for a description
      */
     protected int writeImpl(@NonNull T item, @NonNull byte[] output, final int startOffset) {
-        final BufferedData bufferedData = BufferedData.wrap(output, startOffset, output.length - startOffset);
+        final PbjWriter writer = new PbjWriter(output, startOffset);
         try {
-            write(item, bufferedData);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            writeImpl(item, writer);
+        } finally {
+            writer.flush();
         }
-        return (int) bufferedData.position();
+        return writer.position() - startOffset;
     }
 
     /**
@@ -285,7 +407,31 @@ public abstract class Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    public abstract int measure(@NonNull ReadableSequentialData input) throws ParseException;
+    public abstract int measure(@NonNull PbjReader input) throws ParseException;
+
+    /**
+     * Temporary for test compatibility
+     *
+     * Reads from this data input the length of the data within the input. The implementation may
+     * read all the data, or just some special serialized data, as needed to find out the length of
+     * the data.
+     * <p>
+     * If {@code input} is a {@link BufferedSequentialData} (e.g. {@code BufferedData}), its position is
+     * updated to reflect exactly the bytes consumed by this call. A plain stream-backed input should be
+     * treated as fully consumed afterward.
+     *
+     * @param input The input to use
+     * @return The length of the data item in the input
+     * @throws ParseException If parsing fails
+     */
+    public final int measure(@NonNull ReadableSequentialData input) throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return measure(reader);
+        } finally {
+            syncPosition(input, reader);
+        }
+    }
 
     /**
      * Compute number of bytes that would be written when calling {@code write()} method.
@@ -307,7 +453,34 @@ public abstract class Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public abstract boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException;
+    public abstract boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException;
+
+    /**
+     * Temporary for test compatibility
+     *
+     * Compares the given item with the bytes in the input, and returns false if it determines that
+     * the bytes in the input could not be equal to the given item. Sometimes we need to compare an
+     * item in memory with serialized bytes and don't want to incur the cost of deserializing the
+     * entire object, when we could have determined the bytes do not represent the same object very
+     * cheaply and quickly.
+     * <p>
+     * If {@code input} is a {@link BufferedSequentialData} (e.g. {@code BufferedData}), its position is
+     * updated to reflect exactly the bytes consumed by this call. A plain stream-backed input should be
+     * treated as fully consumed afterward.
+     *
+     * @param item The item to compare. Cannot be null.
+     * @param input The input with the bytes to compare
+     * @return true if the bytes represent the item, false otherwise.
+     * @throws ParseException If parsing fails
+     */
+    public final boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return fastEquals(item, reader);
+        } finally {
+            syncPosition(input, reader);
+        }
+    }
 
     /**
      * Converts a Record into a Bytes object
@@ -318,13 +491,14 @@ public abstract class Codec<T> {
      * to write to the {@link WritableStreamingData}
      */
     public Bytes toBytes(@NonNull T item) {
+        // TODO: Confirm if this next line is accurate with PbjWriter
         // it is cheaper performance wise to measure the size of the object first than grow a buffer as needed
         final byte[] bytes = new byte[measureRecord(item)];
-        final BufferedData bufferedData = BufferedData.wrap(bytes);
+        final PbjWriter writer = new PbjWriter(bytes, 0);
         try {
-            write(item, bufferedData);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            writeImpl(item, writer);
+        } finally {
+            writer.flush();
         }
         return Bytes.wrap(bytes);
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -15,7 +15,7 @@ import java.io.UncheckedIOException;
  *
  * @param <T> The type of object to serialize and deserialize
  */
-public interface Codec<T> {
+public abstract class Codec<T> {
 
     /**
      * The default maximum size of a repeated or length-encoded field (Bytes, String, Message, etc.).
@@ -23,14 +23,30 @@ public interface Codec<T> {
      * An application can override this limit when calling the `Codec.parse()` method for a specific
      * protobuf model type if that model is allowed to contain larger fields.
      */
-    int DEFAULT_MAX_SIZE = 2 * 1024 * 1024;
+    public static final int DEFAULT_MAX_SIZE = 2 * 1024 * 1024;
 
     /**
      * The default maximum depth of nested messages before the `parse()` method would error out.
      * Applications can always override the maxDepth by supplying an argument to the main `Codec.parse()` method.
      * The default depth should not be increased beyond the current limit because of the safety concerns.
      */
-    int DEFAULT_MAX_DEPTH = 128;
+    public static final int DEFAULT_MAX_DEPTH = 128;
+
+    /**
+     * The actual parsing logic for a specific codec, invoked by the {@link #parse} methods through a single,
+     * consistent entry point. Subclasses implement this method rather than {@code parse} directly, since
+     * {@code parse} may perform additional work before and after delegating to this implementation.
+     *
+     * @see #parse(ReadableSequentialData, boolean, boolean, int, int) for a description
+     */
+    @NonNull
+    protected abstract T parseImpl(
+            @NonNull ReadableSequentialData input,
+            boolean strictMode,
+            boolean parseUnknownFields,
+            int maxDepth,
+            int maxSize)
+            throws ParseException;
 
     /**
      * Parses an object from the {@link ReadableSequentialData} and returns it.
@@ -63,13 +79,15 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    T parse(
+    public final T parse(
             @NonNull ReadableSequentialData input,
             boolean strictMode,
             boolean parseUnknownFields,
             int maxDepth,
             int maxSize)
-            throws ParseException;
+            throws ParseException {
+        return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+    }
 
     /**
      * Parses an object from the {@link ReadableSequentialData} and returns it.
@@ -94,7 +112,8 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    default T parse(@NonNull ReadableSequentialData input, boolean strictMode, boolean parseUnknownFields, int maxDepth)
+    public final T parse(
+            @NonNull ReadableSequentialData input, boolean strictMode, boolean parseUnknownFields, int maxDepth)
             throws ParseException {
         return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
     }
@@ -117,7 +136,7 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    default T parse(@NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+    public final T parse(@NonNull ReadableSequentialData input, final boolean strictMode, final int maxDepth)
             throws ParseException {
         return parse(input, strictMode, false, maxDepth);
     }
@@ -141,7 +160,7 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    default T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
+    public final T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
         return parse(bytes.toReadableSequentialData(), strictMode, maxDepth);
     }
 
@@ -153,7 +172,7 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    default T parse(@NonNull ReadableSequentialData input) throws ParseException {
+    public final T parse(@NonNull ReadableSequentialData input) throws ParseException {
         return parse(input, false, DEFAULT_MAX_DEPTH);
     }
 
@@ -165,7 +184,7 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    default T parse(@NonNull Bytes bytes) throws ParseException {
+    public final T parse(@NonNull Bytes bytes) throws ParseException {
         return parse(bytes.toReadableSequentialData());
     }
 
@@ -181,7 +200,7 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    default T parseStrict(@NonNull ReadableSequentialData input) throws ParseException {
+    public final T parseStrict(@NonNull ReadableSequentialData input) throws ParseException {
         return parse(input, true, DEFAULT_MAX_DEPTH);
     }
 
@@ -197,9 +216,18 @@ public interface Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    default T parseStrict(@NonNull Bytes bytes) throws ParseException {
+    public final T parseStrict(@NonNull Bytes bytes) throws ParseException {
         return parseStrict(bytes.toReadableSequentialData());
     }
+
+    /**
+     * The actual writing logic for a specific codec, invoked by the {@link #write} methods through a single,
+     * consistent entry point. Subclasses implement this method rather than {@code write} directly, since
+     * {@code write} may perform additional work before and after delegating to this implementation.
+     *
+     * @see #write(Object, WritableSequentialData) for a description
+     */
+    protected abstract void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException;
 
     /**
      * Writes an item to the given {@link WritableSequentialData}.
@@ -208,7 +236,9 @@ public interface Codec<T> {
      * @param output The {@link WritableSequentialData} to write to.
      * @throws IOException If the {@link WritableSequentialData} cannot be written to.
      */
-    void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException;
+    public final void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+        writeImpl(item, output);
+    }
 
     /**
      * Writes an item to the given byte array, this is a performance focused method. In non-performance centric use
@@ -221,7 +251,22 @@ public interface Codec<T> {
      * @throws UncheckedIOException If the there is a problem writing to the output array.
      * @throws IndexOutOfBoundsException If the output array is not large enough to hold the entire item.
      */
-    default int write(@NonNull T item, @NonNull byte[] output, final int startOffset) {
+    public final int write(@NonNull T item, @NonNull byte[] output, final int startOffset) {
+        return writeImpl(item, output, startOffset);
+    }
+
+    /**
+     * CodecWriteByteArrayMethodGenerator.java generates this method for Codecs but not JsonCodecs
+     * We provide a default implementation here so hand written codecs don't need to
+     *
+     * The actual byte-array writing logic for a specific codec, invoked by the {@link #write(Object, byte[], int)}
+     * methods through a single, consistent entry point. Generated codecs override this method with a
+     * performance-focused implementation; this default implementation delegates to
+     * {@link #writeImpl(Object, WritableSequentialData)} so that hand-written codecs don't need to provide one.
+     *
+     * @see #write(Object, byte[], int) for a description
+     */
+    protected int writeImpl(@NonNull T item, @NonNull byte[] output, final int startOffset) {
         final BufferedData bufferedData = BufferedData.wrap(output, startOffset, output.length - startOffset);
         try {
             write(item, bufferedData);
@@ -240,7 +285,7 @@ public interface Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    int measure(@NonNull ReadableSequentialData input) throws ParseException;
+    public abstract int measure(@NonNull ReadableSequentialData input) throws ParseException;
 
     /**
      * Compute number of bytes that would be written when calling {@code write()} method.
@@ -248,7 +293,7 @@ public interface Codec<T> {
      * @param item The input model data to measure write bytes for
      * @return The length in bytes that would be written
      */
-    int measureRecord(T item);
+    public abstract int measureRecord(T item);
 
     /**
      * Compares the given item with the bytes in the input, and returns false if it determines that
@@ -262,7 +307,7 @@ public interface Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException;
+    public abstract boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException;
 
     /**
      * Converts a Record into a Bytes object
@@ -272,7 +317,7 @@ public interface Codec<T> {
      * @throws RuntimeException wrapping an IOException If it is impossible
      * to write to the {@link WritableStreamingData}
      */
-    default Bytes toBytes(@NonNull T item) {
+    public Bytes toBytes(@NonNull T item) {
         // it is cheaper performance wise to measure the size of the object first than grow a buffer as needed
         final byte[] bytes = new byte[measureRecord(item)];
         final BufferedData bufferedData = BufferedData.wrap(bytes);
@@ -289,5 +334,5 @@ public interface Codec<T> {
      *
      * @return The default value for the model class
      */
-    T getDefaultInstance();
+    public abstract T getDefaultInstance();
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -21,7 +22,7 @@ public abstract class JsonCodec<T> extends Codec<T> {
     /** {@inheritDoc} */
     @Override
     protected final @NonNull T parseImpl(
-            @NonNull ReadableSequentialData input,
+            @NonNull PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -74,7 +75,19 @@ public abstract class JsonCodec<T> extends Codec<T> {
 
     /** {@inheritDoc} */
     @Override
-    protected final void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+    protected final void writeImpl(@NonNull T item, @NonNull PbjWriter output) {
+        output.writeStringNoTag(toJSON(item));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Writes directly via {@code output.writeUTF8(...)} instead of routing through a {@link PbjWriter}, since some
+     * {@link WritableSequentialData} implementations only support the string-level {@code writeUTF8} hook and not
+     * raw byte writes.
+     */
+    @Override
+    public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         output.writeUTF8(toJSON(item));
     }
     /**
@@ -118,7 +131,8 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    public final int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    @Override
+    public final int measure(@NonNull PbjReader input) throws ParseException {
         final long startPosition = input.position();
         parse(input);
         return (int) (input.position() - startPosition);
@@ -157,7 +171,8 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public final boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    @Override
+    public final boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException {
         return Objects.equals(item, parse(input));
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -16,10 +16,11 @@ import java.util.Objects;
  *
  * @param <T> The type of object to serialize and deserialize
  */
-public interface JsonCodec<T> extends Codec<T> {
+public abstract class JsonCodec<T> extends Codec<T> {
 
     /** {@inheritDoc} */
-    default @NonNull T parse(
+    @Override
+    protected final @NonNull T parseImpl(
             @NonNull ReadableSequentialData input,
             final boolean strictMode,
             final boolean parseUnknownFields,
@@ -32,6 +33,20 @@ public interface JsonCodec<T> extends Codec<T> {
             throw new ParseException(ex);
         }
     }
+
+    /**
+     * The actual parsing logic for a specific codec, invoked by the {@link #parse} methods through a single,
+     * consistent entry point. Subclasses implement this method rather than {@code parse} directly, since
+     * {@code parse} may perform additional work before and after delegating to this implementation.
+     *
+     * @see #parse(JSONParser.ObjContext, boolean, int, int) for a description of each parameter
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    protected abstract T parseImpl(
+            @Nullable final JSONParser.ObjContext root, final boolean strictMode, final int maxDepth, final int maxSize)
+            throws ParseException;
 
     /**
      * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. Throws if in strict mode ONLY.
@@ -51,28 +66,34 @@ public interface JsonCodec<T> extends Codec<T> {
      * @throws ParseException If parsing fails
      */
     @NonNull
-    T parse(@Nullable final JSONParser.ObjContext root, final boolean strictMode, final int maxDepth, final int maxSize)
-            throws ParseException;
-
-    /**
-     * Writes an item to the given {@link WritableSequentialData}.
-     *
-     * @param item The item to write. Must not be null.
-     * @param output The {@link WritableSequentialData} to write to.
-     * @throws IOException If the {@link WritableSequentialData} cannot be written to.
-     */
-    default void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
-        output.writeUTF8(toJSON(item));
+    public final T parse(
+            @Nullable final JSONParser.ObjContext root, final boolean strictMode, final int maxDepth, final int maxSize)
+            throws ParseException {
+        return parseImpl(root, strictMode, maxDepth, maxSize);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    protected final void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+        output.writeUTF8(toJSON(item));
+    }
     /**
      * Returns JSON string representing an item.
      *
      * @param item      The item to convert. Must not be null.
      */
-    default String toJSON(@NonNull T item) {
+    public final String toJSON(@NonNull T item) {
         return toJSON(item, "", false);
     }
+
+    /**
+     * The actual JSON-writing logic for a specific codec, invoked by the {@link #toJSON} methods through a single,
+     * consistent entry point. Subclasses implement this method rather than {@code toJSON} directly, since
+     * {@code toJSON} may perform additional work before and after delegating to this implementation.
+     *
+     * @see #toJSON(Object, String, boolean) for a description
+     */
+    protected abstract String toJSONImpl(@NonNull T item, String indent, boolean inline);
 
     /**
      * Returns JSON string representing an item.
@@ -82,7 +103,9 @@ public interface JsonCodec<T> extends Codec<T> {
      * @param inline    When true the output will start with indent end with a new line otherwise
      *                        it will just be the object "{...}"
      */
-    String toJSON(@NonNull T item, String indent, boolean inline);
+    public final String toJSON(@NonNull T item, String indent, boolean inline) {
+        return toJSONImpl(item, indent, inline);
+    }
 
     /**
      * Reads from this data input the length of the data within the input. The implementation may
@@ -95,7 +118,7 @@ public interface JsonCodec<T> extends Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    default int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    public final int measure(@NonNull ReadableSequentialData input) throws ParseException {
         final long startPosition = input.position();
         parse(input);
         return (int) (input.position() - startPosition);
@@ -109,7 +132,7 @@ public interface JsonCodec<T> extends Codec<T> {
      * @param item The input model data to measure write bytes for
      * @return The length in bytes that would be written
      */
-    default int measureRecord(T item) {
+    public final int measureRecord(T item) {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         WritableStreamingData out = new WritableStreamingData(bout);
         try {
@@ -134,12 +157,12 @@ public interface JsonCodec<T> extends Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    default boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    public final boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
         return Objects.equals(item, parse(input));
     }
 
     @Override
-    default T getDefaultInstance() {
+    public final T getDefaultInstance() {
         return null;
     }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.jsonparser.JSONLexer;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -88,13 +88,13 @@ public final class JsonTools {
     // Parse Methods
 
     /**
-     * Parse a JSON string in a ReadableSequentialData into a JSON object.
+     * Parse a JSON string in a PbjReader into a JSON object.
      *
-     * @param input the ReadableSequentialData containing the JSON string
+     * @param input the PbjReader containing the JSON string
      * @return the Antlr JSON context object
      * @throws IOException if there was a problem parsing the JSON
      */
-    public static JSONParser.ObjContext parseJson(@NonNull final ReadableSequentialData input) throws IOException {
+    public static JSONParser.ObjContext parseJson(@NonNull final PbjReader input) throws IOException {
         final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
         final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
         final JSONParser.JsonContext jsonContext = parser.json();

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
@@ -16,4 +16,12 @@ public class ParseException extends Exception {
     public ParseException(String message) {
         super(message);
     }
+
+    public ParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ParseException(Throwable cause, boolean skipStackTag) {
+        super(null, cause, true, false);
+    }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
@@ -82,12 +83,32 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf int32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readInt32(PbjReader input) {
+        return input.readVarInt(false);
+    }
+
+    /**
      * Read a protobuf int64(long) from input
      *
      * @param input The input data to read from
      * @return the read long
      */
     public static long readInt64(final ReadableSequentialData input) {
+        return input.readVarLong(false);
+    }
+
+    /**
+     * Read a protobuf int64(long) from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readInt64(PbjReader input) {
         return input.readVarLong(false);
     }
 
@@ -102,12 +123,32 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf uint32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readUint32(PbjReader input) {
+        return input.readVarInt(false);
+    }
+
+    /**
      * Read a protobuf uint64 from input
      *
      * @param input The input data to read from
      * @return the read long
      */
     public static long readUint64(final ReadableSequentialData input) {
+        return input.readVarLong(false);
+    }
+
+    /**
+     * Read a protobuf uint64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readUint64(PbjReader input) {
         return input.readVarLong(false);
     }
 
@@ -127,12 +168,36 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf bool from input
+     *
+     * @param input The input data to read from
+     * @return the read boolean
+     */
+    public static boolean readBool(PbjReader input) {
+        final var i = input.readVarInt(false);
+        if (i != 1 && i != 0) {
+            input.setError(PbjReader.DataEncoding);
+        }
+        return i == 1;
+    }
+
+    /**
      * Read a protobuf enum from input
      *
      * @param input The input data to read from
      * @return the read enum protoc ordinal
      */
     public static int readEnum(final ReadableSequentialData input) {
+        return input.readVarInt(false);
+    }
+
+    /**
+     * Read a protobuf enum from input
+     *
+     * @param input The input data to read from
+     * @return the read enum protoc ordinal
+     */
+    public static int readEnum(PbjReader input) {
         return input.readVarInt(false);
     }
 
@@ -147,6 +212,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf sint32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readSignedInt32(PbjReader input) {
+        return input.readVarIntZZ();
+    }
+
+    /**
      * Read a protobuf uint64(long) from input
      *
      * @param input The input data to read from
@@ -154,6 +229,16 @@ public final class ProtoParserTools {
      */
     public static long readSignedInt64(final ReadableSequentialData input) {
         return input.readVarLong(true);
+    }
+
+    /**
+     * Read a protobuf sint64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readSignedInt64(PbjReader input) {
+        return input.readVarLongZZ();
     }
 
     /**
@@ -167,6 +252,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf sfixed32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readSignedFixed32(PbjReader input) {
+        return input.readIntLE();
+    }
+
+    /**
      * Read a protobuf fixed32 from input
      *
      * @param input The input data to read from
@@ -174,6 +269,16 @@ public final class ProtoParserTools {
      */
     public static int readFixed32(final ReadableSequentialData input) {
         return input.readInt(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a protobuf fixed32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readFixed32(PbjReader input) {
+        return input.readIntLE();
     }
 
     /**
@@ -187,6 +292,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf float from input
+     *
+     * @param input The input data to read from
+     * @return the read float
+     */
+    public static float readFloat(PbjReader input) {
+        return input.readFloatLE();
+    }
+
+    /**
      * Read a protobuf sfixed64 from input
      *
      * @param input The input data to read from
@@ -194,6 +309,16 @@ public final class ProtoParserTools {
      */
     public static long readSignedFixed64(final ReadableSequentialData input) {
         return input.readLong(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a protobuf sfixed64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readSignedFixed64(final PbjReader input) {
+        return input.readLongLE();
     }
 
     /**
@@ -207,6 +332,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a fixed 64, which is a fixed size encoded long
+     *
+     * @param input the input to read from
+     * @return read long
+     */
+    public static long readFixed64(PbjReader input) {
+        return input.readLongLE();
+    }
+
+    /**
      * Read a double from input data
      *
      * @param input the input to read from
@@ -214,6 +349,16 @@ public final class ProtoParserTools {
      */
     public static double readDouble(final ReadableSequentialData input) {
         return input.readDouble(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a double from input data
+     *
+     * @param input the input to read from
+     * @return read double
+     */
+    public static double readDouble(PbjReader input) {
+        return input.readDoubleLE();
     }
 
     /**
@@ -228,6 +373,10 @@ public final class ProtoParserTools {
         } catch (ParseException ex) {
             throw new UncheckedParseException(ex);
         }
+    }
+
+    public static String readString(final PbjReader input) {
+        return readString(input, Long.MAX_VALUE);
     }
 
     /**
@@ -265,6 +414,17 @@ public final class ProtoParserTools {
         } catch (CharacterCodingException e) {
             throw new MalformedProtobufException("Malformed UTF-8 string encountered", e);
         }
+    }
+
+    /**
+     * Read a String field from data input
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return Read string
+     */
+    public static String readString(final PbjReader input, final long maxSize) {
+        return input.readString(maxSize);
     }
 
     private static int fromUTF8Tail(char[] dst, int di, byte[] src, int i, int endPos) {
@@ -428,6 +588,24 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a Bytes field from data input, setting an error on {@code input} if the Bytes in the input
+     * is longer than the maxSize.
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return read Bytes object, this can be a copy or a direct reference to inputs data. So it has same life span
+     * of InputData
+     */
+    public static Bytes readBytes(final PbjReader input, final long maxSize) {
+        final int length = input.readVarInt(false);
+        if (length > maxSize || length < 0) {
+            input.setError(PbjReader.Parse);
+            return Bytes.EMPTY;
+        }
+        return input.readBytes(length);
+    }
+
+    /**
      * Reads a requested length-delimited protobuf field from the input and returns it as a
      * {@link Bytes} object. If the requested field is repeated or not length-delimited, this
      * method throws an {@link IllegalArgumentException}. .
@@ -486,6 +664,49 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Reads a requested length-delimited protobuf field from the input and returns it as a
+     * {@link Bytes} object. If the requested field is repeated or not length-delimited, this
+     * method throws an {@link IllegalArgumentException}. .
+     *
+     * <p>The input must contain valid protobuf encoded bytes. If the field is not found in
+     * the input {@code null} is returned. If the field occurs multiple time in the input, bytes
+     * for the first occurrence are returned.
+     *
+     * <p>The returned Bytes object, if not null, will not contain the tag or the length.
+     *
+     * @param input The input to read from
+     * @param field Field definition to extract bytes for
+     * @return Field bytes without tag or length, or {@code null} if the field is not found
+     *      in the input
+     */
+    @Nullable
+    public static Bytes extractFieldBytes(@NonNull final PbjReader input, @NonNull final FieldDefinition field) {
+        Objects.requireNonNull(input);
+        Objects.requireNonNull(field);
+        if (field.repeated()) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a repeated field: " + field);
+        }
+        if (ProtoWriterTools.wireType(field) != ProtoConstants.WIRE_TYPE_DELIMITED) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a non-length-delimited field: " + field);
+        }
+        while (input.hasRemaining()) {
+            final int tag = input.readVarIntNoZZ();
+            final int fieldNum = tag >> TAG_FIELD_OFFSET;
+            final ProtoConstants wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+            if (fieldNum == field.number()) {
+                if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    input.setError(PbjReader.Parse);
+                }
+                final int length = input.readVarIntNoZZ();
+                return input.readBytes(length);
+            } else {
+                skipField(input, wireType);
+            }
+        }
+        return null;
+    }
+
+    /**
      * Extract the bytes in a stream for a given wire type. Assumes you have already read tag.
      *
      * @param input The input to move ahead
@@ -523,6 +744,50 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Extract the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     * @param maxSize the maximum allowed size for repeated/length-encoded fields
+     * @return the extracted bytes
+     */
+    public static Bytes extractField(final PbjReader input, final ProtoConstants wireType, final long maxSize) {
+        return switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.readBytes(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.readBytes(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLongBytes();
+            case WIRE_TYPE_DELIMITED -> {
+                final Bytes lenBytes = input.readVarLongBytes();
+                final int length = lenBytes.getVarInt(0, false);
+                if (length < 0) {
+                    input.setError(PbjReader.IOError);
+                    yield Bytes.EMPTY;
+                }
+                if (length > maxSize) {
+                    input.setError(PbjReader.Parse);
+                    yield Bytes.EMPTY;
+                }
+                yield Bytes.merge(lenBytes, input.readBytes(length));
+            }
+            case WIRE_TYPE_GROUP_START -> {
+                input.setError(PbjReader.Unsupported);
+                yield Bytes.EMPTY;
+            }
+            case WIRE_TYPE_GROUP_END -> {
+                input.setError(PbjReader.Unsupported);
+                yield Bytes.EMPTY;
+            }
+            default -> {
+                input.setError(PbjReader.IOError);
+                yield Bytes.EMPTY;
+            }
+        };
+    }
+
+    /**
      * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
      *
      * @param input The input to move ahead
@@ -535,6 +800,16 @@ public final class ProtoParserTools {
         } catch (ParseException ex) {
             throw new UncheckedParseException(ex);
         }
+    }
+
+    /**
+     * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     */
+    public static void skipField(final PbjReader input, final ProtoConstants wireType) {
+        skipField(input, wireType, Long.MAX_VALUE);
     }
 
     /**
@@ -572,12 +847,54 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     * @param maxSize the maximum allowed size for repeated/length-encoded fields
+     */
+    public static void skipField(final PbjReader input, final ProtoConstants wireType, final long maxSize) {
+        switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.skip(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.skip(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLong(false);
+            case WIRE_TYPE_DELIMITED -> {
+                final int length = input.readVarIntNoZZ();
+                if (length < 0) {
+                    input.setError(PbjReader.IOError);
+                }
+                if (length > maxSize) {
+                    input.setError(PbjReader.Parse);
+                }
+                input.skip(length);
+            }
+            case WIRE_TYPE_GROUP_START -> input.setError(PbjReader.Unsupported);
+            case WIRE_TYPE_GROUP_END -> input.setError(PbjReader.Unsupported);
+            default -> input.setError(PbjReader.IOError);
+        }
+    }
+
+    /**
      * Read the next field number from the input
      *
      * @param input The input data to read from
      * @return the read tag
      */
     public static int readNextFieldNumber(final ReadableSequentialData input) {
+        final int tag = input.readVarInt(false);
+        return tag >> TAG_FIELD_OFFSET;
+    }
+
+    /**
+     * Read the next field number from the input
+     *
+     * @param input The input data to read from
+     * @return the read tag
+     */
+    public static int readNextFieldNumber(final PbjReader input) {
         final int tag = input.readVarInt(false);
         return tag >> TAG_FIELD_OFFSET;
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -267,6 +267,126 @@ public final class ProtoParserTools {
         }
     }
 
+    private static int fromUTF8Tail(char[] dst, int di, byte[] src, int i, int endPos) {
+        while (i < endPos) {
+            int a = src[i];
+            if ((a & 0x80) == 0) {
+                dst[di++] = (char) a;
+                i++;
+                continue;
+            }
+            if (i + 1 >= endPos) return -1;
+
+            int b = src[i + 1];
+            if ((a & 0xE0) == 0xC0) {
+                if ((b & 0xC0) == 0x80) {
+                    dst[di++] = (char) (((a & 0x1F) << 6) | (b & 0x3F));
+                    i += 2;
+                    continue;
+                } else {
+                    return -1; // Bad encoding
+                }
+            }
+
+            if (i + 2 >= endPos) return -1;
+
+            int c = src[i + 2];
+            int codepoint = -1;
+            if ((a & 0xF0) == 0xE0) {
+                if ((b & 0xC0) == 0x80 && (c & 0xC0) == 0x80) {
+                    codepoint = ((a & 0xF) << 12) | ((b & 0x3F) << 6) | (c & 0x3F);
+                    i += 3;
+                } else {
+                    return -1; // Bad encoding
+                }
+            } else {
+                if (i + 3 >= endPos) return -1;
+                int d = src[i + 3];
+                if ((a & 0xF8) == 0xF0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80 && (d & 0xC0) == 0x80) {
+                    codepoint = ((a & 7) << 18) | ((b & 0x3F) << 12) | ((c & 0x3F) << 6) | (d & 0x3F);
+                    i += 4;
+                } else {
+                    return -1; // Bad encoding
+                }
+            }
+
+            if (codepoint <= 0xFFFF) {
+                if (codepoint < 0 || (codepoint >= 0xD800 && codepoint < 0xE000)) return -1; // [D800, E000) is illegal
+                dst[di++] = (char) codepoint;
+                continue;
+            }
+
+            if (codepoint > 0x10FFFF) return -1; // Illegal range
+            int v = codepoint - 0x10000;
+            dst[di + 0] = (char) (0xD800 + ((v >> 10) & 0x3FF));
+            dst[di + 1] = (char) (0xDC00 + (v & 0x3FF));
+            di += 2;
+        }
+        return di;
+    }
+
+    /**
+     * Decodes UTF-8 bytes from {@code src} into the {@code char[]} destination, supporting all
+     * four UTF-8 byte widths (1–4 bytes). Codepoints above U+FFFF are written as surrogate pairs.
+     * Prefer using the simpler {@link #readString} function.
+     *
+     * <p>Decoding starts at {@code src[offset + pos]} and continues until {@code src[offset + length]}.
+     * The main loop keeps a 4-byte lookahead (exits when fewer than 5 bytes remain), delegating
+     * the final bytes to {@link #fromUTF8Tail}. Any unrecognised byte sequence returns {@code -1}.
+     *
+     * @param dst    the destination char array, written starting at index {@code pos}
+     * @param src    the source byte array containing UTF-8 data
+     * @param offset the base index within {@code src} where the UTF-8 region begins
+     * @param pos    bytes already decoded by the ASCII fast path; doubles as the read offset
+     *               (relative to {@code offset}) and the initial write index in {@code dst}
+     * @param length the total byte length of the UTF-8 region in {@code src} starting at {@code offset}
+     * @return the total number of {@code char}s written to {@code dst}, or {@code -1} if the
+     *         input contains an illegal byte sequence (surrogate range or out-of-range codepoint)
+     */
+    public static int fromUTF8(char[] dst, byte[] src, int offset, int pos, int length) {
+        int i = offset + pos;
+        int di = pos;
+        while (i + 4 < offset + length) {
+            int a = src[i];
+            if ((a & 0x80) == 0) {
+                dst[di++] = (char) a;
+                i++;
+                continue;
+            }
+            int b = src[i + 1];
+            if ((a & 0xE0) == 0xC0 && (b & 0xC0) == 0x80) {
+                dst[di++] = (char) (((a & 0x1F) << 6) | (b & 0x3F));
+                i += 2;
+                continue;
+            }
+            int c = src[i + 2];
+            int codepoint = -1;
+            if ((a & 0xF0) == 0xE0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80) {
+                codepoint = ((a & 0xF) << 12) | ((b & 0x3F) << 6) | (c & 0x3F);
+                i += 3;
+            } else {
+                int d = src[i + 3];
+                if ((a & 0xF8) == 0xF0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80 && (d & 0xC0) == 0x80) {
+                    codepoint = ((a & 7) << 18) | ((b & 0x3F) << 12) | ((c & 0x3F) << 6) | (d & 0x3F);
+                    i += 4;
+                }
+            }
+
+            if (codepoint <= 0xFFFF) {
+                if (codepoint < 0 || (codepoint >= 0xD800 && codepoint < 0xE000)) return -1; // [D800, E000) is illegal
+                dst[di++] = (char) codepoint;
+                continue;
+            }
+
+            if (codepoint > 0x10FFFF) return -1; // illegal range
+            int v = codepoint - 0x10000;
+            dst[di + 0] = (char) (0xD800 + ((v >> 10) & 0x3FF));
+            dst[di + 1] = (char) (0xDC00 + (v & 0x3FF));
+            di += 2;
+        }
+        return i == offset + length ? di : fromUTF8Tail(dst, di, src, i, offset + length);
+    }
+
     /**
      * Read a Bytes field from data input
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
@@ -1,22 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.WritableSequentialData;
-import java.io.IOException;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 
 /**
- * Interface for referencing the static write method from generated writer classes.
+ * Interface for referencing the static write method from generated writer classes
  *
  * @param <T> The model object that is being written
  */
 public interface ProtoWriter<T> {
 
     /**
-     * Write out a {@code T} model to output stream in protobuf format.
+     * Write out a {@code T} model to a {@link PbjWriter} in protobuf format.
      *
      * @param data The input model data to write
-     * @param out The output stream to write to
-     * @throws IOException If there is a problem writing
+     * @param writer The writer to write to
      */
-    void write(T data, WritableSequentialData out) throws IOException;
+    void write(T data, PbjWriter writer);
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -1340,7 +1340,7 @@ public final class ProtoWriterTools {
      * @param value string value to get encoded size for
      * @return the number of bytes for encoded value
      */
-    static int sizeOfStringNoTag(String value) {
+    public static int sizeOfStringNoTag(String value) {
         // When not a oneOf don't write default value
         if ((value == null || value.isEmpty())) {
             return 0;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -5,6 +5,7 @@ import static com.hedera.pbj.runtime.ProtoConstants.*;
 
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.RandomAccessData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -60,6 +61,16 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a protobuf tag to the output. Field wire format is calculated based on field type.
+     *
+     * @param out The data output to write to
+     * @param field The field to write the tag for
+     */
+    public static void writeTag(PbjWriter out, final FieldDefinition field) {
+        writeTag(out, field, wireType(field));
+    }
+
+    /**
      * Write a protobuf tag to the output.
      *
      * @param out The data output to write to
@@ -68,6 +79,18 @@ public final class ProtoWriterTools {
      */
     public static void writeTag(
             final WritableSequentialData out, final FieldDefinition field, final ProtoConstants wireType) {
+        out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
+    }
+
+
+    /**
+     * Write a protobuf tag to the output.
+     *
+     * @param out The data output to write to
+     * @param field The field to include in tag
+     * @param wireType The field wire type to include in tag
+     */
+    public static void writeTag(PbjWriter out, final FieldDefinition field, final ProtoConstants wireType) {
         out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
     }
 
@@ -87,6 +110,17 @@ public final class ProtoWriterTools {
      * @param value the int value to write
      */
     public static void writeInteger(WritableSequentialData out, FieldDefinition field, int value) {
+        writeInteger(out, field, value, true);
+    }
+
+    /**
+     * Write a integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     */
+    public static void writeInteger(PbjWriter out, FieldDefinition field, int value) {
         writeInteger(out, field, value, true);
     }
 
@@ -133,6 +167,47 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeInteger(PbjWriter out, FieldDefinition field, int value, boolean skipDefault) {
+        assert switch (field.type()) {
+                    case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
+                    default -> false;
+                }
+                : "Not an integer type " + field;
+        assert !field.repeated() : "Use writeIntegerList with repeated types";
+
+        if (skipDefault && !field.oneOf() && value == 0) {
+            return;
+        }
+        switch (field.type()) {
+            case INT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarInt(value, false);
+            }
+            case UINT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(Integer.toUnsignedLong(value), false);
+            }
+            case SINT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarInt(value, true);
+            }
+            case SFIXED32, FIXED32 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
+                out.writeIntLE(value);
+            }
+            default -> throw unsupported();
+        }
+    }
+    /**
      * Write a long to data output
      *
      * @param out The data output to write to
@@ -140,6 +215,17 @@ public final class ProtoWriterTools {
      * @param value the long value to write
      */
     public static void writeLong(WritableSequentialData out, FieldDefinition field, long value) {
+        writeLong(out, field, value, true);
+    }
+
+    /**
+     * Write a long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the long value to write
+     */
+    public static void writeLong(PbjWriter out, FieldDefinition field, long value) {
         writeLong(out, field, value, true);
     }
 
@@ -181,6 +267,43 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the long value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeLong(PbjWriter out, FieldDefinition field, long value, boolean skipDefault) {
+        assert switch (field.type()) {
+                    case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> true;
+                    default -> false;
+                }
+                : "Not a long type " + field;
+        assert !field.repeated() : "Use writeLongList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0) {
+            return;
+        }
+        switch (field.type()) {
+            case INT64, UINT64 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(value, false);
+            }
+            case SINT64 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(value, true);
+            }
+            case SFIXED64, FIXED64 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_FIXED_64_BIT);
+                out.writeLongLE(value);
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a float to data output
      *
      * @param out The data output to write to
@@ -196,6 +319,24 @@ public final class ProtoWriterTools {
         }
         writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
         out.writeFloat(value, ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Write a float to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the float value to write
+     */
+    public static void writeFloat(PbjWriter out, FieldDefinition field, float value) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert !field.repeated() : "Use writeFloatList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
+        out.writeFloatLE(value);
     }
 
     /**
@@ -217,6 +358,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a double to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the double value to write
+     */
+    public static void writeDouble(PbjWriter out, FieldDefinition field, double value) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert !field.repeated() : "Use writeDoubleList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_FIXED_64_BIT);
+        out.writeDoubleLE(value);
+    }
+
+    /**
      * Write a boolean to data output
      *
      * @param out The data output to write to
@@ -224,6 +383,17 @@ public final class ProtoWriterTools {
      * @param value the boolean value to write
      */
     public static void writeBoolean(WritableSequentialData out, FieldDefinition field, boolean value) {
+        writeBoolean(out, field, value, true);
+    }
+
+    /**
+     * Write a boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
+     */
+    public static void writeBoolean(PbjWriter out, FieldDefinition field, boolean value) {
         writeBoolean(out, field, value, true);
     }
 
@@ -247,6 +417,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeBoolean(PbjWriter out, FieldDefinition field, boolean value, boolean skipDefault) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert !field.repeated() : "Use writeBooleanList with repeated types";
+        // In the case of oneOf we write the value even if it is default value of false
+        if (value || field.oneOf() || !skipDefault) {
+            writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+            out.writeByte(value ? (byte) 1 : 0);
+        }
+    }
+
+    /**
      * Write a enum to data output
      *
      * @param out The data output to write to
@@ -254,6 +442,24 @@ public final class ProtoWriterTools {
      * @param enumValue the enum value to write
      */
     public static void writeEnum(WritableSequentialData out, FieldDefinition field, EnumWithProtoMetadata enumValue) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert !field.repeated() : "Use writeEnumList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (enumValue == null || enumValue.protoOrdinal() == 0)) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        out.writeVarInt(enumValue.protoOrdinal(), false);
+    }
+
+    /**
+     * Write a enum to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param enumValue the enum value to write
+     */
+    public static void writeEnum(PbjWriter out, FieldDefinition field, EnumWithProtoMetadata enumValue) {
         assert field.type() == FieldType.ENUM : "Not an enum type " + field;
         assert !field.repeated() : "Use writeEnumList with repeated types";
         // When not a oneOf don't write default value
@@ -283,6 +489,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a enum protoOrdinal to data output.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param protoOrdinal the enum value to write
+     */
+    public static void writeEnumProtoOrdinal(PbjWriter out, FieldDefinition field, int protoOrdinal) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert !field.repeated() : "Use writeEnumList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && protoOrdinal == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        out.writeVarInt(protoOrdinal, false);
+    }
+
+    /**
      * Write a string to data output, assuming the field is non-repeated.
      *
      * @param out The data output to write to
@@ -301,12 +525,38 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing, the field must be non-repeated
      * @param value the string value to write
+     */
+    public static void writeString(PbjWriter out, final FieldDefinition field, final String value) {
+        writeString(out, field, value, true);
+    }
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
      * @param skipDefault default value results in no-op for non-oneOf
      * @throws IOException If a I/O error occurs
      */
     public static void writeString(
             final WritableSequentialData out, final FieldDefinition field, final String value, boolean skipDefault)
             throws IOException {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert !field.repeated() : "Use writeStringList with repeated types";
+        writeStringNoChecks(out, field, value, skipDefault);
+    }
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeString(
+            PbjWriter out, final FieldDefinition field, final String value, boolean skipDefault) {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert !field.repeated() : "Use writeStringList with repeated types";
         writeStringNoChecks(out, field, value, skipDefault);
@@ -330,7 +580,22 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a integer to data output - no validation checks.
+     * Write a string to data output, assuming the field is repeated. Usually this method is called multiple
+     * times, one for every repeated value. If all values are available immediately, {@link #writeStringList(
+     * PbjWriter, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     */
+    public static void writeOneRepeatedString(PbjWriter out, final FieldDefinition field, final String value) {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "writeOneRepeatedString can only be used with repeated fields";
+        writeStringNoChecks(out, field, value);
+    }
+
+    /**
+     * Write a string to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -343,7 +608,18 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a integer to data output - no validation checks.
+     * Write a string to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     */
+    private static void writeStringNoChecks(PbjWriter out, final FieldDefinition field, final String value) {
+        writeStringNoChecks(out, field, value, true);
+    }
+
+    /**
+     * Write a string to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -364,6 +640,25 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a string to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    private static void writeStringNoChecks(
+            PbjWriter out, final FieldDefinition field, final String value, boolean skipDefault) {
+        // When not a oneOf don't write default value
+        if (skipDefault && !field.oneOf() && (value == null || value.isEmpty())) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(sizeOfStringNoTag(value), false);
+        out.writeStringNoTag(value);
+    }
+
+    /**
      * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
      * is any delimited: bytes, string, or message.
      *
@@ -375,6 +670,18 @@ public final class ProtoWriterTools {
     public static void writeBytes(
             final WritableSequentialData out, final FieldDefinition field, final RandomAccessData value)
             throws IOException {
+        writeBytes(out, field, value, true);
+    }
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     */
+    public static void writeBytes(PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
         writeBytes(out, field, value, true);
     }
 
@@ -400,6 +707,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeBytes(
+            PbjWriter out, final FieldDefinition field, final RandomAccessData value, boolean skipDefault) {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert !field.repeated() : "Use writeBytesList with repeated types";
+        writeBytesNoChecks(out, field, value, skipDefault);
+    }
+
+    /**
      * Write a bytes to data output, assuming the corresponding field is repeated, and field type
      * is any delimited: bytes, string, or message. Usually this method is called multiple times, one
      * for every repeated value. If all values are available immediately, {@link #writeBytesList(
@@ -413,6 +736,23 @@ public final class ProtoWriterTools {
     public static void writeOneRepeatedBytes(
             final WritableSequentialData out, final FieldDefinition field, final RandomAccessData value)
             throws IOException {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
+        writeBytesNoChecks(out, field, value, true);
+    }
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is repeated, and field type
+     * is any delimited: bytes, string, or message. Usually this method is called multiple times, one
+     * for every repeated value. If all values are available immediately, {@link #writeBytesList(
+     * PbjWriter, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param value the bytes value to write
+     */
+    public static void writeOneRepeatedBytes(
+            PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
         assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
         assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
         writeBytesNoChecks(out, field, value, true);
@@ -448,6 +788,35 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a bytes to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the bytes value to write
+     * @param skipZeroLength this is true for normal single bytes and false for repeated lists
+     */
+    private static void writeBytesNoChecks(
+            final PbjWriter out,
+            final FieldDefinition field,
+            final RandomAccessData value,
+            final boolean skipZeroLength) {
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (skipZeroLength && (value.length() == 0))) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(Math.toIntExact(value.length()), false);
+        final long posBefore = out.position();
+        out.writeBytes(value);
+        final long bytesWritten = out.position() - posBefore;
+        if (bytesWritten != value.length()) {
+            out.setError(
+                    PbjWriter.IOError,
+                    "Wrote less bytes [" + bytesWritten + "] than expected [" + value.length() + "]");
+        }
+    }
+
+    /**
      * Write a message to data output, assuming the corresponding field is non-repeated.
      *
      * @param out The data output to write to
@@ -460,6 +829,22 @@ public final class ProtoWriterTools {
     public static <T> void writeMessage(
             final WritableSequentialData out, final FieldDefinition field, final T message, final Codec<T> codec)
             throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert !field.repeated() : "Use writeMessageList with repeated types";
+        writeMessageNoChecks(out, field, message, codec);
+    }
+
+    /**
+     * Write a message to data output, assuming the corresponding field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    public static <T> void writeMessage(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert !field.repeated() : "Use writeMessageList with repeated types";
         writeMessageNoChecks(out, field, message, codec);
@@ -481,6 +866,24 @@ public final class ProtoWriterTools {
     public static <T> void writeOneRepeatedMessage(
             final WritableSequentialData out, final FieldDefinition field, final T message, final Codec<T> codec)
             throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "writeOneRepeatedMessage can only be used with repeated fields";
+        writeMessageNoChecks(out, field, message, codec);
+    }
+
+    /**
+     * Write a message to data output, assuming the corresponding field is repeated. Usually this method is
+     * called multiple times, one for every repeated value. If all values are available immediately, {@link
+     * #writeMessageList(PbjWriter, FieldDefinition, List, Codec)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    public static <T> void writeOneRepeatedMessage(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert field.repeated() : "writeOneRepeatedMessage can only be used with repeated fields";
         writeMessageNoChecks(out, field, message, codec);
@@ -513,15 +916,52 @@ public final class ProtoWriterTools {
         }
     }
 
+    /**
+     * Write a message to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    private static <T> void writeMessageNoChecks(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
+        // When not a oneOf don't write default value
+        if (field.oneOf() && message == null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            out.writeVarInt(0, false);
+        } else if (message != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final int size = codec.measureRecord(message);
+            out.writeVarInt(size, false);
+            if (size > 0) {
+                codec.write(message, out);
+            }
+        }
+    }
+
+    /**
+     * Write a map field to data output.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param map the map to write
+     * @param kWriter writer for the map key type
+     * @param vWriter writer for the map value type
+     * @param sizeOfK function that computes the encoded size of a key
+     * @param sizeOfV function that computes the encoded size of a value
+     * @param <K> type of map key
+     * @param <V> type of map value
+     */
     public static <K, V> void writeMap(
-            final WritableSequentialData out,
+            PbjWriter out,
             final FieldDefinition field,
             @NonNull final PbjMap<K, V> map,
             final ProtoWriter<K> kWriter,
             final ProtoWriter<V> vWriter,
             final ToIntFunction<K> sizeOfK,
-            final ToIntFunction<V> sizeOfV)
-            throws IOException {
+            final ToIntFunction<V> sizeOfV) {
         // https://protobuf.dev/programming-guides/proto3/#maps
         // On the wire, a map is equivalent to:
         //    message MapFieldEntry {
@@ -566,6 +1006,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional integer value to write
+     */
+    public static void writeOptionalInteger(PbjWriter out, FieldDefinition field, @Nullable Integer value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfInteger(newField, value), false);
+            writeInteger(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional long to data output
      *
      * @param out The data output to write to
@@ -573,6 +1029,22 @@ public final class ProtoWriterTools {
      * @param value the optional long value to write
      */
     public static void writeOptionalLong(WritableSequentialData out, FieldDefinition field, @Nullable Long value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfLong(newField, value), false);
+            writeLong(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional long value to write
+     */
+    public static void writeOptionalLong(PbjWriter out, FieldDefinition field, @Nullable Long value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -598,6 +1070,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional float to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional float value to write
+     */
+    public static void writeOptionalFloat(PbjWriter out, FieldDefinition field, @Nullable Float value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfFloat(newField, value), false);
+            writeFloat(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional double to data output
      *
      * @param out The data output to write to
@@ -605,6 +1093,22 @@ public final class ProtoWriterTools {
      * @param value the optional double value to write
      */
     public static void writeOptionalDouble(WritableSequentialData out, FieldDefinition field, @Nullable Double value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfDouble(newField, value), false);
+            writeDouble(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional double to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional double value to write
+     */
+    public static void writeOptionalDouble(PbjWriter out, FieldDefinition field, @Nullable Double value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -622,6 +1126,22 @@ public final class ProtoWriterTools {
      */
     public static void writeOptionalBoolean(
             WritableSequentialData out, FieldDefinition field, @Nullable Boolean value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfBoolean(newField, value), false);
+            writeBoolean(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional boolean value to write
+     */
+    public static void writeOptionalBoolean(PbjWriter out, FieldDefinition field, @Nullable Boolean value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -649,6 +1169,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional string to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional string value to write
+     */
+    public static void writeOptionalString(PbjWriter out, FieldDefinition field, @Nullable String value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfString(newField, value), false);
+            writeString(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional bytes to data output
      *
      * @param out The data output to write to
@@ -658,6 +1194,25 @@ public final class ProtoWriterTools {
      */
     public static void writeOptionalBytes(WritableSequentialData out, FieldDefinition field, @Nullable Bytes value)
             throws IOException {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            final int size = sizeOfBytes(newField, value);
+            out.writeVarInt(size, false);
+            if (size > 0) {
+                writeBytes(out, newField, value);
+            }
+        }
+    }
+
+    /**
+     * Write an optional bytes to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional bytes value to write
+     */
+    public static void writeOptionalBytes(PbjWriter out, FieldDefinition field, @Nullable Bytes value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -748,6 +1303,81 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of integers to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of integers value to write
+     */
+    public static void writeIntegerList(PbjWriter out, FieldDefinition field, List<Integer> list) {
+        assert switch (field.type()) {
+            case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
+            default -> false;
+        }
+                : "Not an integer type " + field;
+        assert field.repeated() : "Use writeInteger with non-repeated types";
+
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+
+        final int listSize = list.size();
+        switch (field.type()) {
+            case INT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfVarInt32(val);
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarInt(val, false);
+                }
+            }
+            case UINT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(Integer.toUnsignedLong(val));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarLong(Integer.toUnsignedLong(val), false);
+                }
+            }
+            case SINT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(((long) val << 1) ^ ((long) val >> 63));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarInt(val, true);
+                }
+            }
+            case SFIXED32, FIXED32 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarLong((long) list.size() * FIXED32_SIZE, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeIntLE(val);
+                }
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a list of longs to data output
      *
      * @param out The data output to write to
@@ -810,6 +1440,68 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of longs to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of longs value to write
+     */
+    public static void writeLongList(PbjWriter out, FieldDefinition field, List<Long> list) {
+        assert switch (field.type()) {
+                    case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> true;
+                    default -> false;
+                }
+                : "Not a long type " + field;
+        assert field.repeated() : "Use writeLong with non-repeated types";
+
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+
+        final int listSize = list.size();
+        switch (field.type()) {
+            case INT64, UINT64 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(val);
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeVarLong(val, false);
+                }
+            }
+            case SINT64 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    size += sizeOfUnsignedVarInt64((val << 1) ^ (val >> 63));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeVarLong(val, true);
+                }
+            }
+            case SFIXED64, FIXED64 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarLong((long) list.size() * FIXED64_SIZE, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeLongLE(val);
+                }
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a list of floats to data output
      *
      * @param out The data output to write to
@@ -829,6 +1521,29 @@ public final class ProtoWriterTools {
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             out.writeFloat(list.get(i), ByteOrder.LITTLE_ENDIAN);
+        }
+    }
+
+    /**
+     * Write a list of floats to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of floats value to write
+     */
+    public static void writeFloatList(PbjWriter out, FieldDefinition field, List<Float> list) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert field.repeated() : "Use writeFloat with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int size = list.size() * FIXED32_SIZE;
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            out.writeFloatLE(list.get(i));
         }
     }
 
@@ -856,6 +1571,29 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of doubles to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of doubles value to write
+     */
+    public static void writeDoubleList(PbjWriter out, FieldDefinition field, List<Double> list) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert field.repeated() : "Use writeDouble with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int size = list.size() * FIXED64_SIZE;
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            out.writeDoubleLE(list.get(i));
+        }
+    }
+
+    /**
      * Write a list of booleans to data output
      *
      * @param out The data output to write to
@@ -863,6 +1601,30 @@ public final class ProtoWriterTools {
      * @param list the list of booleans value to write
      */
     public static void writeBooleanList(WritableSequentialData out, FieldDefinition field, List<Boolean> list) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert field.repeated() : "Use writeBoolean with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        // write
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(list.size(), false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            final boolean b = list.get(i);
+            out.writeVarInt(b ? 1 : 0, false);
+        }
+    }
+
+    /**
+     * Write a list of booleans to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of booleans value to write
+     */
+    public static void writeBooleanList(PbjWriter out, FieldDefinition field, List<Boolean> list) {
         assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
         assert field.repeated() : "Use writeBoolean with non-repeated types";
         // When not a oneOf don't write default value
@@ -907,6 +1669,32 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of enums to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of enums value to write
+     */
+    public static void writeEnumListProtoOrdinals(PbjWriter out, FieldDefinition field, List<Integer> list) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert field.repeated() : "Use writeEnum with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            size += sizeOfUnsignedVarInt32(list.get(i));
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarInt(list.get(i), false);
+        }
+    }
+
+    /**
      * Write a list of strings to data output
      *
      * @param out The data output to write to
@@ -932,6 +1720,28 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of strings to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of strings value to write
+     */
+    public static void writeStringList(PbjWriter out, FieldDefinition field, List<String> list) {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "Use writeString with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            final String value = list.get(i);
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            out.writeStringWithTag(value);
+        }
+    }
+
+    /**
      * Write a list of messages to data output
      *
      * @param out The data output to write to
@@ -943,6 +1753,28 @@ public final class ProtoWriterTools {
      */
     public static <T> void writeMessageList(
             WritableSequentialData out, FieldDefinition field, List<T> list, Codec<T> codec) throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "Use writeMessage with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            writeMessageNoChecks(out, field, list.get(i), codec);
+        }
+    }
+
+    /**
+     * Write a list of messages to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of messages value to write
+     * @param codec the codec for the message type
+     * @param <T> type of message
+     */
+    public static <T> void writeMessageList(PbjWriter out, FieldDefinition field, List<T> list, Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert field.repeated() : "Use writeMessage with non-repeated types";
         // When not a oneOf don't write default value
@@ -979,6 +1811,26 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of bytes objects to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of bytes objects value to write
+     */
+    public static void writeBytesList(PbjWriter out, FieldDefinition field, List<? extends RandomAccessData> list) {
+        assert field.type() == FieldType.BYTES : "Not a message type " + field;
+        assert field.repeated() : "Use writeBytes with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            writeBytesNoChecks(out, field, list.get(i), false);
+        }
+    }
+
+    /**
      * Write a generic delimited field by delegating to a supplied `writer` to write the actual elements.
      *
      * @param out The data output to write to
@@ -989,6 +1841,21 @@ public final class ProtoWriterTools {
      */
     public static <T extends WritableSequentialData> void writeDelimited(
             final T out, final FieldDefinition field, final int size, final Consumer<T> writer) {
+        writeTag(out, field);
+        out.writeVarInt(size, false);
+        writer.accept(out);
+    }
+
+    /**
+     * Write a generic delimited field by delegating to a supplied `writer` to write the actual elements.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param size the size of all the elements together, in bytes
+     * @param writer the Consumer that accepts the `out` and writes the actual elements
+     */
+    public static void writeDelimited(
+            PbjWriter out, final FieldDefinition field, final int size, final Consumer<PbjWriter> writer) {
         writeTag(out, field);
         out.writeVarInt(size, false);
         writer.accept(out);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -82,7 +82,6 @@ public final class ProtoWriterTools {
         out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
     }
 
-
     /**
      * Write a protobuf tag to the output.
      *
@@ -751,8 +750,7 @@ public final class ProtoWriterTools {
      * @param field the descriptor for the field we are writing, the field must be repeated
      * @param value the bytes value to write
      */
-    public static void writeOneRepeatedBytes(
-            PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
+    public static void writeOneRepeatedBytes(PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
         assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
         assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
         writeBytesNoChecks(out, field, value, true);
@@ -1311,9 +1309,9 @@ public final class ProtoWriterTools {
      */
     public static void writeIntegerList(PbjWriter out, FieldDefinition field, List<Integer> list) {
         assert switch (field.type()) {
-            case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
-            default -> false;
-        }
+                    case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
+                    default -> false;
+                }
                 : "Not an integer type " + field;
         assert field.repeated() : "Use writeInteger with non-repeated types";
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ByteArraySequentialData.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/ByteArraySequentialData.java
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io;
+
+/**
+ * Implemented by {@link ReadableSequentialData} types that are backed directly by a heap byte array.
+ * Callers (e.g. {@link com.hedera.pbj.runtime.io.buffer.PbjReader}) can detect this and use the array directly
+ * instead of copying data through an intermediate buffer.
+ */
+public interface ByteArraySequentialData {
+    /** The raw backing byte array. */
+    byte[] byteArrayUnsafe();
+
+    /** Absolute index within {@link #byteArrayUnsafe()} where currently readable data begins. */
+    int byteArrayUnsafeOffset();
+
+    /** Absolute exclusive index within {@link #byteArrayUnsafe()} where currently readable data ends. */
+    int byteArrayUnsafeEnd();
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -386,6 +386,15 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     }
 
     /**
+     * A helper method to copy buffer data into PbjWriter
+     *
+     * @param writer the PbjWriter to copy into
+     */
+    public void writeTo(@NonNull final PbjWriter writer) {
+        writer.writeBytes(buffer, start, length);
+    }
+
+    /**
      * A helper method for efficient copy of our data into a MemorySegment starting at a given `position`
      * without creating a defensive copy of the data or writing each byte one at a time.
      * @param segment a destination MemorySegment

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -59,19 +59,19 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     public static final Comparator<Bytes> SORT_BY_UNSIGNED_VALUE = valueSorter(Byte::compareUnsigned);
 
     /** byte[] used as backing buffer */
-    private final byte[] buffer;
+    final byte[] buffer;
 
     /**
      * The offset within the backing buffer where this {@link Bytes} starts. To prevent array copies, we sometimes
      * want to have a "view" or "slice" of another buffer, where we begin at some offset and have a length.
      */
-    private final int start;
+    final int start;
 
     /**
      * The number of bytes in this {@link Bytes}. To prevent array copies, we sometimes want to have a "view" or
      * "slice" of another buffer, where we begin at some offset and have a length.
      */
-    private final int length;
+    final int length;
 
     /**
      * The hash code of this {@link Bytes}. This is cached to avoid recomputing it multiple times.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -283,6 +283,15 @@ public class PbjReader implements AutoCloseable {
     }
 
     /**
+     * Returns the number of bytes remaining before the limit. This is not the byte length since a stream may return MAX_VALUE as its limit
+     *
+     * @return the number of bytes remaining
+     */
+    public long remaining() {
+        return limit() - position();
+    }
+
+    /**
      * Skips over {@code count} bytes, advancing the read position without returning the data.
      * Sets {@link #BufferUnderflow} if there are fewer than {@code count} bytes remaining.
      *
@@ -600,6 +609,15 @@ public class PbjReader implements AutoCloseable {
      */
     public int error() {
         return err > 0 ? err : 0;
+    }
+
+    /**
+     * Returns true if all operations has been successful
+     *
+     * @return {@code true} if no error has occurred
+     */
+    public boolean ok() {
+        return err <= 0;
     }
 
     private int bufferedInternal(int count) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -1,0 +1,1036 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.ProtoParserTools;
+import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.ByteArraySequentialData;
+import com.hedera.pbj.runtime.io.DataEncodingException;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+
+/**
+ * A buffer-backed reader for decoding data. Not thread safe.
+ *
+ * <p>PbjReader maintains an internal byte buffer and reads from a {@link ReadableSequentialData},
+ * {@link InputStream}, or a byte array. When backed by a stream the internal buffer is refilled
+ * on demand as data is consumed. A stream will never be read past its limit.
+ *
+ * <p>Errors are tracked internally rather than thrown immediately. Call {@link #error()} to check
+ * for a pending error code, or {@link #throwOnError()} to surface it as a {@link ParseException}.
+ * Once an error is set it is sticky — subsequent reads return default values (zero or empty).
+ * EOF is not an error and will return 0 when error() is called.
+ * ByteBuffer using a direct buffer is not supported
+ */
+public class PbjReader implements AutoCloseable {
+    private byte[] buf;
+    private int pos, end;
+    private int relLimit, err;
+    private long absoluteLimit = Long.MAX_VALUE, offset;
+    private ReadableSequentialData rsd;
+    private InputStream stream;
+    private Exception cause;
+    private boolean seenEOF, includeCause;
+    private byte[] ownedBuf;
+
+    private char[] charArray;
+    private static final boolean useStacktrace =
+            !"false".equalsIgnoreCase(System.getProperty("pbj.ReaderWriter.useStackTrace"));
+
+    public static final int EOF = -1,
+            Closed = -2,
+            DataEncoding = 1,
+            BufferUnderflow = 2,
+            Parse = 3,
+            IllegalArgument = 4,
+            IOError = 5,
+            Unsupported = 6, // used with WIRE_TYPE_GROUP_START, WIRE_TYPE_GROUP_END
+            UsageError = 9,
+            UnknownField = 10,
+            BufferOverflow = 11,
+            MaxDepthReached = 12,
+            MalformString = 13;
+
+    private static final UnknownFieldException premadeUnknown;
+    private static final BufferUnderflowException premadeUnderflow;
+    private static final BufferOverflowException premadeOverflow;
+    private static final RuntimeException premadeRuntime, premadeUnsupported;
+    private static final DataEncodingException premadeDataEncoding;
+    private static final IllegalArgumentException premadeIllegal;
+    private static final ParseException premadeParseEmpty, premadeParseUnknown, premadeMaxDepth;
+
+    static {
+        premadeUnknown = new UnknownFieldException("");
+        premadeUnderflow = new BufferUnderflowException();
+        premadeOverflow = new BufferOverflowException();
+        premadeRuntime = new RuntimeException();
+        premadeUnsupported = new RuntimeException("Hit an unsupported feature");
+        premadeDataEncoding = new DataEncodingException("");
+        premadeIllegal = new IllegalArgumentException("");
+
+        premadeParseEmpty = new ParseException("parse error");
+        premadeParseUnknown = new ParseException("parse error", premadeUnknown);
+        premadeMaxDepth = new ParseException("Reached maximum allowed depth");
+    }
+
+    private void construct(byte[] buffer, int position, int endPosition) {
+        buf = buffer;
+        pos = position;
+        end = endPosition;
+        relLimit = end;
+        absoluteLimit = end;
+        seenEOF = true;
+        err = EOF;
+    }
+
+    /**
+     * Resets this reader to read from the given byte array slice, discarding any previous state.
+     *
+     * @param buffer      the backing byte array
+     * @param position    the inclusive start index within {@code buffer}
+     * @param endPosition the exclusive end index within {@code buffer}
+     */
+    public void resetWith(byte[] buffer, int position, int endPosition) {
+        err = 0;
+        offset = 0;
+        cause = null;
+        includeCause = false;
+        rsd = null;
+        stream = null;
+        construct(buffer, position, endPosition);
+    }
+
+    private void construct(ReadableSequentialData seq, InputStream inputStream) {
+        if (seq instanceof ByteArraySequentialData ba && ba.byteArrayUnsafe() != null) {
+            construct(ba.byteArrayUnsafe(), ba.byteArrayUnsafeOffset(), ba.byteArrayUnsafeEnd());
+            return;
+        } else if (seq != null) {
+            rsd = seq;
+            absoluteLimit = seq.limit();
+            offset = (int) seq.position();
+        } else if (inputStream != null) {
+            stream = inputStream;
+        }
+        ownedBuf = buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+    }
+
+    private void resetWith(ReadableSequentialData seq, InputStream inputStream) {
+        err = 0;
+        cause = null;
+        includeCause = false;
+        if ((seq == null && inputStream == null) || (seq != null && inputStream != null)) {
+            setError(UsageError);
+            return;
+        }
+
+        if (seq instanceof ByteArraySequentialData ba && ba.byteArrayUnsafe() != null) {
+            resetWith(ba.byteArrayUnsafe(), ba.byteArrayUnsafeOffset(), ba.byteArrayUnsafeEnd());
+            return;
+        }
+        if (seq != null) {
+            rsd = seq;
+            stream = null;
+            absoluteLimit = seq.limit();
+            offset = (int) seq.position();
+        } else if (inputStream != null) {
+            rsd = null;
+            stream = inputStream;
+            absoluteLimit = Long.MAX_VALUE;
+            offset = 0;
+        }
+        if (ownedBuf == null) {
+            ownedBuf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        }
+        buf = ownedBuf;
+        pos = 0;
+        end = 0;
+        relLimit = 0;
+        seenEOF = false;
+    }
+
+    /** Creates a reader backed by the given {@link ReadableSequentialData}. */
+    public PbjReader(ReadableSequentialData seq) {
+        construct(seq, null);
+    }
+    /** Creates a reader backed by the given {@link InputStream}. */
+    public PbjReader(InputStream inputStream) {
+        construct(null, inputStream);
+    }
+    /** Creates a reader backed by the given byte array. */
+    public PbjReader(byte[] data) {
+        construct(data, 0, data.length);
+    }
+    /**
+     * Creates a reader backed by the given byte array slice.
+     *
+     * @param data   the backing byte array
+     * @param offset the inclusive start index
+     * @param end    the exclusive end index
+     */
+    public PbjReader(byte[] data, int offset, int end) {
+        construct(data, offset, end);
+    }
+    /** Creates a reader backed by the given {@link ByteBuffer}. */
+    public PbjReader(ByteBuffer bb) {
+        int position = bb.arrayOffset() + bb.position();
+        construct(bb.array(), position, position + bb.remaining());
+    }
+
+    /** Creates a reader backed by the given {@link Bytes}. */
+    public PbjReader(Bytes bytes) {
+        construct(bytes.buffer, bytes.start, bytes.start + bytes.length);
+    }
+
+    /** Resets this reader to read from the given {@link ReadableSequentialData}. */
+    public void resetWith(ReadableSequentialData seq) {
+        resetWith(seq, null);
+    }
+    /** Resets this reader to read from the given {@link InputStream}. */
+    public void resetWith(InputStream inputStream) {
+        resetWith(null, inputStream);
+    }
+    /** Resets this reader to read from the given byte array. */
+    public void resetWith(byte[] data) {
+        resetWith(data, 0, data.length);
+    }
+    /** Resets this reader to read from the given {@link ByteBuffer}. */
+    public void resetWith(ByteBuffer bb) {
+        int position = bb.arrayOffset() + bb.position();
+        resetWith(bb.array(), position, position + bb.remaining());
+    }
+    /** Resets this reader to read from the given {@link Bytes}. */
+    public void resetWith(Bytes bytes) {
+        resetWith(bytes.buffer, bytes.start, bytes.start + (int) bytes.length());
+    }
+
+    private void bufferMore(int relAmount) {
+        if (err != 0) return;
+        offset += pos;
+        if (pos < end && pos != 0) {
+            int moveLen = end - pos;
+            System.arraycopy(buf, pos, buf, 0, end - pos);
+            end = moveLen;
+        } else if (pos == end) {
+            end = 0;
+        }
+        pos = 0;
+        int rdlen = readFromInput(buf, end, buf.length - end);
+        end += rdlen;
+        relLimit = (int) Math.min(absoluteLimit - offset, end);
+        if (rdlen == 0) {
+            seenEOF = true;
+            err = EOF;
+        }
+    }
+
+    /**
+     * Returns {@code true} if there are bytes remaining to be read.
+     * For streaming readers, triggers a buffer refill if the local buffer is exhausted.
+     *
+     * @return {@code true} if at least one byte can be read
+     */
+    public boolean hasRemaining() {
+        // small and likely to inline
+        if (pos < relLimit) return true;
+        if (offset + pos == absoluteLimit) return false;
+        return hasRemainingInternal();
+    }
+    // still small, but less likely to hit this case in steaming, and only once when not streaming
+    private boolean hasRemainingInternal() {
+        if (seenEOF) return false;
+        bufferMore(1);
+        return pos < relLimit;
+    }
+
+    /**
+     * Returns the absolute byte limit beyond which reading is not permitted.
+     *
+     * @return the absolute limit position
+     */
+    public long limit() {
+        return absoluteLimit;
+    }
+
+    /**
+     * Sets the absolute byte limit beyond which reading is not permitted.
+     * If using a stream, it will not read past that limit
+     *
+     * @param limit the new limit position
+     */
+    public void limit(long limit) {
+        absoluteLimit = limit;
+        if (rsd != null) {
+            rsd.limit(limit);
+        }
+        if (err > 0) return; // keep relLimit -1 in error state
+        relLimit = (int) Math.min(absoluteLimit - offset, end);
+    }
+
+    /**
+     * Returns the current absolute read position, accounting for any bytes already consumed
+     * from the internal buffer plus any previously buffered data.
+     *
+     * @return the current read position
+     */
+    public long position() {
+        return pos + offset;
+    }
+
+    /**
+     * Skips over {@code count} bytes, advancing the read position without returning the data.
+     * Sets {@link #BufferUnderflow} if there are fewer than {@code count} bytes remaining.
+     *
+     * @param count the number of bytes to skip
+     */
+    public void skip(int count) {
+        if (count >= 0 && pos + count <= relLimit) {
+            pos += count;
+            return;
+        }
+        skipInternal(count);
+    }
+
+    private void skipInternal(int count) {
+        if (seenEOF) {
+            setError(BufferUnderflow);
+            return;
+        }
+
+        int skippedInBuffer = relLimit - pos;
+        count -= skippedInBuffer;
+        pos = relLimit;
+        offset += count;
+        if (stream != null) {
+            try {
+                long remaining = count;
+                while (remaining > 0) {
+                    long skipped = stream.skip(remaining);
+                    if (skipped > 0) {
+                        remaining -= skipped;
+                    } else {
+                        // Docs suggest skup can return 0 w/o reaching EOF
+                        int b = stream.read();
+                        if (b == -1) break;
+                        remaining--;
+                    }
+                }
+                if (remaining != 0) {
+                    setError(BufferUnderflow);
+                }
+            } catch (IOException e) {
+                setError(IOError);
+            }
+        } else {
+            rsd.skip(count); // may throw
+        }
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as an {@code int} (no zigzag decoding).
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @return the decoded integer value
+     */
+    public int readVarIntNoZZ() {
+        return (int) readVarLongNoZZ();
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as an {@code int}, with optional zigzag decoding.
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @param zigZag if {@code true}, decodes using zigzag: {@code (n >>> 1) ^ -(n & 1)}
+     * @return the decoded integer value
+     */
+    public int readVarInt(boolean zigZag) {
+        return (int) readVarLong(zigZag);
+    }
+
+    /**
+     * Reads a base-128 varint and returns its zigzag-decoded value as an {@code int}.
+     * Zigzag decoding maps the raw unsigned value {@code n} to {@code (n >>> 1) ^ -(n & 1)}.
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @return the decoded integer value
+     */
+    public int readVarIntZZ() {
+        return (int) readVarLongZZ();
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as a {@code long}.
+     * On a malformed varint (more than 10 bytes), sets {@link #DataEncoding} and returns
+     * {@code -1}; however, {@code -1} is also a valid decoded value, so callers must check
+     * {@link #error()} to distinguish an error from a legitimate result.
+     *
+     * @param zigZag if {@code true}, decodes using zigzag: {@code (n >>> 1) ^ -(n & 1)}
+     * @return the decoded long value
+     */
+    public long readVarLong(boolean zigZag) {
+        long value = readVarLongNoZZ();
+        return zigZag ? (value >>> 1) ^ -(value & 1) : value;
+    }
+
+    /**
+     * Reads a base-128 varint and returns its zigzag-decoded value as a {@code long}.
+     * Zigzag decoding maps the raw unsigned value {@code n} to {@code (n >>> 1) ^ -(n & 1)}.
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @return the decoded long value
+     */
+    public long readVarLongZZ() {
+        long value = readVarLongNoZZ();
+        return (value >>> 1) ^ -(value & 1);
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as a {@code long} (no zigzag decoding).
+     * On a malformed varint (more than 10 bytes), sets {@link #DataEncoding} and returns
+     * {@code -1}; however, {@code -1} is also a valid decoded value, so callers must check
+     * {@link #error()} to distinguish an error from a legitimate result.
+     *
+     * @return the decoded long value
+     */
+    public long readVarLongNoZZ() {
+        if (pos + 10 <= relLimit) {
+            long value = 0;
+            for (int i = 0; i < 10; i++) {
+                byte b = buf[pos++];
+                value |= (long) (b & 0x7F) << (i * 7);
+                if (b >= 0) {
+                    return value;
+                }
+            }
+            setError(DataEncoding);
+            return -1;
+        }
+        return readVarLongNoZZInternal();
+    }
+
+    private long readVarLongNoZZInternal() {
+        long value = 0;
+        for (int i = 0; i < 10; i++) {
+            byte b = readByte();
+            value |= (long) (b & 0x7F) << (i * 7);
+            if (b >= 0) {
+                return value;
+            }
+        }
+        setError(DataEncoding);
+        return -1;
+    }
+
+    /**
+     * Reads a base-128 varint and returns the raw encoded bytes without decoding them.
+     * Sets {@link #DataEncoding} if the varint is malformed.
+     *
+     * @return the raw varint bytes, or {@link Bytes#EMPTY} on error
+     */
+    public Bytes readVarLongBytes() {
+        byte[] bytes = new byte[10];
+        if (pos + 10 <= relLimit) {
+            for (int i = 0; i < 10; i++) {
+                bytes[i] = readByte();
+                if (bytes[i] >= 0) {
+                    return Bytes.wrap(bytes, 0, i + 1);
+                }
+            }
+            setError(DataEncoding);
+            return Bytes.EMPTY;
+        }
+        return readVarLongBytesInternal(bytes);
+    }
+
+    private Bytes readVarLongBytesInternal(byte[] bytes) {
+        for (int i = 0; i < 10; i++) {
+            bytes[i] = readByte();
+            if (bytes[i] >= 0) {
+                return Bytes.wrap(bytes, 0, i + 1);
+            }
+        }
+        setError(DataEncoding);
+        return Bytes.EMPTY;
+    }
+
+    /**
+     * Records an error on this reader with no message. Once an error is recorded
+     * subsequent reads return default values (zero or empty).
+     *
+     * @param errorKind one of the error-code constants ({@link #DataEncoding}, {@link #BufferUnderflow}, etc.)
+     */
+    public void setError(int errorKind) {
+        setError(errorKind, "");
+    }
+
+    /**
+     * Records an error on this reader if no previous error is set. Once an error is recorded
+     * subsequent reads return default values (zero or empty).
+     *
+     * @param errorKind one of the error-code constants ({@link #DataEncoding}, {@link #BufferUnderflow}, etc.)
+     * @param message   a detail message associated with the error
+     */
+    public void setError(int errorKind, String message) {
+        if (err > 0) return; // if an error exists, don't overwrite
+        err = errorKind;
+        relLimit = -1;
+        seenEOF = true;
+        // TODO simplify when exceptions are not required
+        includeCause = true;
+        if (useStacktrace) {
+            if (errorKind == UnknownField) {
+                cause = new UnknownFieldException(message);
+            } else if (errorKind == BufferUnderflow) {
+                cause = new BufferUnderflowException();
+            } else if (errorKind == BufferOverflow) {
+                cause = new BufferOverflowException();
+            } else if (errorKind == Parse) {
+                cause = new RuntimeException(message);
+                includeCause = false;
+            } else {
+                cause = new RuntimeException(message);
+            }
+        } else {
+            if (errorKind == UnknownField) {
+                cause = premadeUnknown;
+            } else if (errorKind == BufferUnderflow) {
+                cause = premadeUnderflow;
+            } else if (errorKind == BufferOverflow) {
+                cause = premadeOverflow;
+            } else if (errorKind == Parse) {
+                cause = premadeParseEmpty;
+                includeCause = false;
+            } else {
+                cause = premadeRuntime;
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if no error is set; otherwise throws a {@link ParseException}.
+     *
+     * @return {@code true} if no error has occurred
+     * @throws ParseException if an error is set
+     */
+    public boolean throwOnErrorOrTrue() throws ParseException {
+        if (err <= 0) return true;
+        throw throwOnErrorImpl();
+    }
+
+    /**
+     * Throws a {@link ParseException} if an error is set; otherwise does nothing.
+     *
+     * @throws ParseException if {@link #error()} is non-zero
+     */
+    public void throwOnError() throws ParseException {
+        if (err <= 0) return;
+        throw throwOnErrorImpl();
+    }
+
+    private ParseException throwOnErrorImpl() throws ParseException {
+        if (useStacktrace) {
+            switch (err) {
+                case DataEncoding:
+                    throw new DataEncodingException("throwOnError", cause);
+                case IllegalArgument:
+                    throw new IllegalArgumentException("throwOnError", cause);
+                case Unsupported:
+                    throw new RuntimeException("Hit an unsupported feature", cause);
+                case MaxDepthReached:
+                    throw new ParseException("Reached maximum allowed depth");
+                case Parse:
+                default:
+                    if (includeCause) throw new ParseException(cause);
+                    ParseException ex = new ParseException("");
+                    ex.setStackTrace(cause.getStackTrace());
+                    throw ex;
+            }
+        } else {
+            switch (err) {
+                case DataEncoding:
+                    throw premadeDataEncoding;
+                case IllegalArgument:
+                    throw premadeIllegal;
+                case Unsupported:
+                    throw premadeUnsupported;
+                case MaxDepthReached:
+                    throw premadeMaxDepth;
+                case Parse:
+                default:
+                    if (includeCause) {
+                        throw new ParseException(cause, true);
+                    }
+                    throw premadeParseEmpty;
+            }
+        }
+    }
+
+    /**
+     * Like {@link #throwOnError()}, but throws an {@link IOException} for {@link #Unsupported}
+     * errors instead of a {@link ParseException}. Intended for tests that expect checked I/O
+     * exceptions.
+     *
+     * @throws ParseException if a parse error is set
+     * @throws IOException    if an unsupported-feature error is set
+     */
+    public void throwOnError2() throws ParseException, IOException {
+        if (err == Unsupported) {
+            throw new IOException("Hit an unsupported feature", cause);
+        }
+        throwOnError();
+    }
+
+    /**
+     * Returns the current error code, or {@code 0} if no error has occurred.
+     *
+     * @return a positive error-code constant, or {@code 0} for no error
+     */
+    public int error() {
+        return err > 0 ? err : 0;
+    }
+
+    private int bufferedInternal(int count) {
+        if (count <= buf.length) {
+            bufferMore(count);
+            if (pos + count <= relLimit) {
+                int origPos = pos;
+                pos += count;
+                return origPos;
+            }
+        }
+        return -1;
+    }
+
+    private int buffered(int count) {
+        if (pos + count <= relLimit) {
+            int origPos = pos;
+            pos += count;
+            return origPos;
+        }
+        return bufferedInternal(count);
+    }
+
+    private int readFromInput(@NonNull byte[] dst, int off, int len) {
+        if (stream != null) {
+            int total = 0;
+            try {
+                while (total < len) {
+                    int n = stream.read(dst, off + total, len - total);
+                    if (n < 0) break;
+                    total += n;
+                }
+            } catch (IOException e) {
+                setError(IOError);
+            }
+            return total;
+        }
+        long remaining = rsd.remaining();
+        if (remaining <= 0) return 0;
+        len = (int) Math.min(len, remaining); // a test requires not buffering past limit
+        return (int) rsd.readBytes(dst, off, len);
+    }
+
+    private int readBytesInternalCopy(@NonNull byte[] dst, int dstOffset, int count) {
+        if (err > 0) return -1;
+        int copiedLen = Math.min(count, relLimit - pos);
+        System.arraycopy(buf, pos, dst, dstOffset, copiedLen);
+        pos += copiedLen;
+        if (copiedLen == count || err != 0) return copiedLen;
+
+        offset += pos;
+        relLimit = pos = end = 0;
+        int rdlen = readFromInput(dst, dstOffset + copiedLen, count - copiedLen);
+        if (rdlen == 0) {
+            seenEOF = true;
+            err = EOF;
+        }
+        offset += rdlen;
+        return copiedLen + rdlen;
+    }
+
+    /**
+     * Reads up to {@code dst.length} bytes into the given array. If fewer bytes are available
+     * the array is partially filled. The number of bytes copied is returned.
+     * Returns {@code -1} on an error
+     *
+     * @param dst the destination array
+     * @return the number of bytes read, or {@code -1} if a pre-existing error is set
+     */
+    public long readBytes(@NonNull final byte[] dst) {
+        return readBytesInternalCopy(dst, 0, dst.length);
+    }
+
+    /**
+     * Reads up to {@code length} bytes into the given array starting at {@code offset}. If fewer
+     * bytes are available the array is partially filled. The number of bytes copied is returned.
+     * Returns {@code -1} on an error
+     *
+     * @param dst    the destination array
+     * @param offset the start index within {@code dst}
+     * @param length the number of bytes to read
+     * @return the number of bytes read, or {@code -1} if a pre-existing error is set
+     */
+    public long readBytes(@NonNull final byte[] dst, int offset, int length) {
+        return readBytesInternalCopy(dst, offset, length);
+    }
+
+    /**
+     * Reads bytes into the given {@link ByteBuffer}, advancing its position by the number of
+     * bytes read. If fewer bytes are available than the buffer's remaining capacity, the buffer
+     * is partially filled, and the number of bytes copied is returned.
+     * Returns {@code -1} on an error
+     *
+     * @param dst the destination buffer; bytes are written starting at its current position
+     * @return the number of bytes actually read, or {@code -1} if a pre-existing error is set
+     */
+    public long readBytes(@NonNull ByteBuffer dst) {
+        int len = readBytesInternalCopy(dst.array(), dst.arrayOffset() + dst.position(), dst.remaining());
+        if (len > 0) { // handles error case (which sets len == -1)
+            dst.position(dst.position() + len);
+        }
+        return len;
+    }
+
+    /**
+     * Reads exactly {@code length} bytes and returns them as a {@link Bytes} instance.
+     * Sets {@link #BufferUnderflow} and returns {@link Bytes#EMPTY} if fewer bytes are available.
+     *
+     * @param length the number of bytes to read
+     * @return the read bytes, or {@link Bytes#EMPTY} on error
+     */
+    public @NonNull Bytes readBytes(int length) {
+        if (length <= relLimit - pos && err <= 0) {
+            byte[] dst = new byte[length];
+            System.arraycopy(buf, pos, dst, 0, length);
+            pos += length;
+            return Bytes.wrap(dst);
+        }
+        return readBytesInternal(length);
+    }
+
+    @NonNull
+    private Bytes readBytesInternal(int length) {
+        if (length == 0 || err > 0) {
+            return Bytes.EMPTY;
+        } else if (length < 0) {
+            setError(IllegalArgument);
+            return Bytes.EMPTY;
+        }
+        byte[] dst = new byte[length];
+        int copiedLen = readBytesInternalCopy(dst, 0, length);
+        if (copiedLen < length) {
+            setError(BufferUnderflow);
+            return Bytes.EMPTY;
+        }
+        return Bytes.wrap(dst);
+    }
+
+    /**
+     * Reads a 32-bit integer in big-endian byte order. Alias for {@link #readIntBE()}.
+     *
+     * @return the integer value
+     */
+    public int readInt() {
+        return readIntBE();
+    }
+
+    /**
+     * Reads a 32-bit integer in big-endian byte order.
+     * Sets {@link #BufferUnderflow} and returns {@code 0} if fewer than 4 bytes are available.
+     *
+     * @return the integer value
+     */
+    public int readIntBE() {
+        if (pos + 4 <= relLimit) {
+            int v = 0;
+            for (int i = 0; i < 4; i++) {
+                v |= (buf[pos + 3 - i] & 255) << (i * 8);
+            }
+            pos += 4;
+            return v;
+        }
+        return readIntBEInternal();
+    }
+
+    /**
+     * Reads a 32-bit integer in little-endian byte order.
+     * Sets {@link #BufferUnderflow} and returns {@code 0} if fewer than 4 bytes are available.
+     *
+     * @return the integer value
+     */
+    public int readIntLE() {
+        if (pos + 4 <= relLimit) {
+            int v = 0;
+            for (int i = 0; i < 4; i++) {
+                v |= (buf[pos + i] & 255) << (i * 8);
+            }
+            pos += 4;
+            return v;
+        }
+        return readIntLEInternal();
+    }
+
+    private int readIntBEInternal() {
+        bufferMore(4);
+        if (pos + 4 > relLimit) {
+            setError(BufferUnderflow);
+            return 0;
+        }
+        int v = 0;
+        for (int i = 0; i < 4; i++) {
+            v |= (buf[pos + 3 - i] & 255) << (i * 8);
+        }
+        pos += 4;
+        return v;
+    }
+
+    private int readIntLEInternal() {
+        bufferMore(4);
+        if (pos + 4 > relLimit) {
+            setError(BufferUnderflow);
+            return 0;
+        }
+        int v = 0;
+        for (int i = 0; i < 4; i++) {
+            v |= (buf[pos + i] & 255) << (i * 8);
+        }
+        pos += 4;
+        return v;
+    }
+
+    /**
+     * Reads a 64-bit integer in big-endian byte order. Alias for {@link #readLongBE()}.
+     *
+     * @return the long value
+     */
+    public long readLong() {
+        return readLongBE();
+    }
+
+    /**
+     * Reads a 64-bit integer in big-endian byte order.
+     * Sets {@link #BufferUnderflow} and returns {@code 0} if fewer than 8 bytes are available.
+     *
+     * @return the long value
+     */
+    public long readLongBE() {
+        if (pos + 8 <= relLimit) {
+            long v = 0;
+            for (int i = 0; i < 8; i++) {
+                v |= (long) (buf[pos + 7 - i] & 255) << (i * 8);
+            }
+            pos += 8;
+            return v;
+        }
+        return readLongBEInternal();
+    }
+
+    private long readLongBEInternal() {
+        bufferMore(8);
+        if (pos + 8 > relLimit) {
+            setError(BufferUnderflow);
+            return 0;
+        }
+        long v = 0;
+        for (int i = 0; i < 8; i++) {
+            v |= (long) (buf[pos + 7 - i] & 255) << (i * 8);
+        }
+        pos += 8;
+        return v;
+    }
+
+    /**
+     * Reads a 64-bit integer in little-endian byte order.
+     * Sets {@link #BufferUnderflow} and returns {@code 0} if fewer than 8 bytes are available.
+     *
+     * @return the long value
+     */
+    public long readLongLE() {
+        if (pos + 8 <= relLimit) {
+            long v = 0;
+            for (int i = 0; i < 8; i++) {
+                v |= (long) (buf[pos + i] & 255) << (i * 8);
+            }
+            pos += 8;
+            return v;
+        }
+        return readLongLEInternal();
+    }
+
+    private long readLongLEInternal() {
+        bufferMore(8);
+        if (pos + 8 > relLimit) {
+            setError(BufferUnderflow);
+            return 0;
+        }
+        long v = 0;
+        for (int i = 0; i < 8; i++) {
+            v |= (long) (buf[pos + i] & 255) << (i * 8);
+        }
+        pos += 8;
+        return v;
+    }
+
+    /**
+     * Reads a 32-bit float in big-endian byte order.
+     *
+     * @return the float value
+     */
+    public float readFloat() {
+        return Float.intBitsToFloat(readInt());
+    }
+
+    /**
+     * Reads a 32-bit float in little-endian byte order.
+     *
+     * @return the float value
+     */
+    public float readFloatLE() {
+        return Float.intBitsToFloat(readIntLE());
+    }
+
+    /**
+     * Reads a 64-bit double in big-endian byte order.
+     *
+     * @return the double value
+     */
+    public double readDouble() {
+        return Double.longBitsToDouble(readLong());
+    }
+
+    /**
+     * Reads a 64-bit double in little-endian byte order.
+     *
+     * @return the double value
+     */
+    public double readDoubleLE() {
+        return Double.longBitsToDouble(readLongLE());
+    }
+
+    /**
+     * Returns an {@link InputStream} view of the remaining data in this reader.
+     * For streaming readers, returns the underlying stream directly. For byte-array readers,
+     * returns a {@link ByteArrayInputStream} over the buffered data.
+     *
+     * @return an {@code InputStream} over the unread bytes
+     * @throws UnsupportedOperationException if the reader is in a partially-buffered streaming state
+     */
+    public InputStream asInputStream() {
+        if (end == 0) return stream != null ? stream : rsd.asInputStream();
+        if (seenEOF && offset == 0) {
+            return new ByteArrayInputStream(buf, pos, end - pos);
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Reads a single byte and returns {@code true} if it is non-zero, {@code false} otherwise.
+     *
+     * @return the boolean value
+     */
+    public boolean readBoolean() {
+        return readByte() != 0;
+    }
+
+    /**
+     * Reads and returns a single signed byte, advancing the position by 1.
+     * Sets {@link #BufferUnderflow} and returns {@code 0} if no bytes remain.
+     *
+     * @return the byte value
+     */
+    public byte readByte() {
+        if (pos + 1 <= relLimit) return buf[pos++];
+        return readByteInternal();
+    }
+
+    private byte readByteInternal() {
+        if (pos + 1 > relLimit) {
+            bufferMore(1);
+            if (pos + 1 > relLimit) {
+                setError(BufferUnderflow);
+                return 0;
+            }
+        }
+        return buf[pos++];
+    }
+
+    /**
+     * Reads a length-prefixed UTF-8 string. The length is read as a base-128 varint followed
+     * by that many UTF-8 bytes. Sets {@link #Parse} and returns {@code ""} if the length exceeds
+     * {@code maxSize}, is negative, or if the UTF-8 bytes are malformed.
+     *
+     * @param maxSize the maximum allowed string byte length
+     * @return the decoded string, or {@code ""} on error
+     */
+    public String readString(final long maxSize) {
+        final int length = readVarIntNoZZ();
+        if (length > maxSize || length < 0) {
+            setError(PbjReader.Parse);
+            return "";
+        }
+
+        int bufPos = buffered(length);
+        byte[] data = null;
+        if (bufPos >= 0) {
+            data = buf;
+        } else {
+            data = new byte[length];
+            int copiedLen = readBytesInternalCopy(data, 0, length);
+            if (copiedLen < length) {
+                setError(BufferUnderflow);
+                return "";
+            }
+            bufPos = 0;
+        }
+
+        if (charArray == null || length > charArray.length) {
+            int power2Capacity = 2 << (63 - Long.numberOfLeadingZeros(Math.max(2048, length)));
+            charArray = new char[power2Capacity];
+        }
+
+        int i = 0;
+        // Ascii fast path
+        {
+            for (; i < length; i++) {
+                byte b = data[bufPos + i];
+                if ((b & 0x80) != 0) break;
+                charArray[i] = (char) b;
+            }
+            if (i == length) {
+                return new String(charArray, 0, length);
+            }
+        }
+        int utf16Len = ProtoParserTools.fromUTF8(charArray, data, bufPos, i, length);
+        if (utf16Len >= 0) {
+            return new String(charArray, 0, utf16Len);
+        }
+        setError(PbjReader.Parse);
+        return "";
+    }
+
+    @Override
+    public void close() {
+        if (stream == null) return;
+        try {
+            stream.close();
+        } catch (IOException ex) {
+            setError(IOError, ex.getMessage());
+        }
+        if (err == 0) {
+            err = Closed;
+        }
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjWriter.java
@@ -1,0 +1,1067 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.isSurrogatePair;
+import static java.lang.Character.toCodePoint;
+
+import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A buffer-backed writer for encoding protobuf data. Not thread safe.
+ *
+ * <p>PbjWriter maintains an internal byte buffer and writes to an {@link OutputStream},
+ * {@link WritableSequentialData}, or a fixed byte array. When backed by an output stream the
+ * buffer is flushed automatically when full. When not backed by a stream the buffer grows as
+ * needed (unless constructed with {@code mayGrow = false}).
+ *
+ * <p>Errors are tracked internally rather than thrown immediately. Call {@link #error()} to check
+ * for a pending error code, or {@link #throwOnError()} to surface it as an exception. Once an
+ * error is set it is sticky — subsequent write calls become no-ops.
+ *
+ * <p>Implements {@link AutoCloseable}: closing flushes pending bytes to the underlying stream.
+ */
+public class PbjWriter implements AutoCloseable {
+    private byte[] buf;
+    private int pos, cap;
+    private int offset, err;
+    private RuntimeException cause;
+    private OutputStream output;
+    private boolean reuseable;
+    private boolean mayGrow = true;
+
+    private static final boolean useStacktrace =
+            !"false".equalsIgnoreCase(System.getProperty("pbj.ReaderWriter.useStackTrace"));
+    public static final int EOF = PbjReader.EOF,
+            DataEncoding = PbjReader.DataEncoding,
+            BufferUnderflow = PbjReader.BufferUnderflow,
+            Parse = PbjReader.Parse,
+            IllegalArgument = PbjReader.IllegalArgument,
+            IOError = PbjReader.IOError,
+            Unsupported = PbjReader.Unsupported,
+            UsageError = PbjReader.UsageError,
+            UnknownField = PbjReader.UnknownField,
+            BufferOverflow = PbjReader.BufferOverflow,
+            MaxDepthReached = PbjReader.MaxDepthReached,
+            // For PbjWriter
+            Closed = PbjReader.Closed,
+            MalformString = PbjReader.MalformString;
+
+    private static final RuntimeException premadeRuntimeException;
+
+    static {
+        premadeRuntimeException = new RuntimeException("Stacktrace not enabled in PbjWriter");
+    }
+
+    /**
+     * Creates a writer that streams output to the given {@link OutputStream}.
+     * An internal 16 KB buffer is used; the buffer is flushed to the stream when full.
+     *
+     * @param output the output stream to write to
+     */
+    public PbjWriter(@NonNull OutputStream output) {
+        this.output = output;
+        buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        cap = buf.length;
+        reuseable = true;
+    }
+
+    /**
+     * Creates a writer backed by a {@link ByteBuffer}.
+     *
+     * <p>If the buffer has a backing array it is used directly. Otherwise an internal 16 KB
+     * streaming buffer is used and bytes are forwarded to the {@link ByteBuffer} on flush.
+     *
+     * @param buffer the target byte buffer
+     */
+    public PbjWriter(ByteBuffer buffer) {
+        if (buffer.hasArray()) {
+            buf = buffer.array();
+            pos = buffer.arrayOffset() + buffer.position();
+            cap = buffer.arrayOffset() + buffer.limit();
+        } else {
+            this.output = new OutputStream() {
+                @Override
+                public void write(int b) {
+                    buffer.put((byte) b);
+                }
+
+                @Override
+                public void write(@NonNull byte[] b, int off, int len) {
+                    buffer.put(b, off, len);
+                }
+            };
+            buf = new byte[16 << 10];
+            cap = buf.length;
+            reuseable = true;
+        }
+    }
+
+    /**
+     * Creates a writer that writes directly into the given byte array starting at {@code pos},
+     * writing up to the end of the array. No flushing or growing occurs.
+     *
+     * @param buffer the backing byte array
+     * @param pos    the starting write position within the array
+     */
+    public PbjWriter(byte[] buffer, int pos) {
+        this.buf = buffer;
+        this.pos = pos;
+        this.cap = buffer.length;
+    }
+
+    /**
+     * Creates a writer that streams output to the given {@link WritableSequentialData}.
+     * An internal 16 KB buffer is used; the buffer is flushed to the target when full.
+     *
+     * @param output the writable sequential data target
+     */
+    public PbjWriter(@NonNull WritableSequentialData output) {
+        this(new OutputStream() {
+            @Override
+            public void write(int b) {
+                output.writeByte((byte) b);
+            }
+
+            @Override
+            public void write(@NonNull byte[] b, int off, int len) {
+                output.writeBytes(b, off, len);
+            }
+        });
+    }
+
+    /**
+     * Creates a standalone, growable writer with an initial 16 KB internal buffer.
+     * No backing output stream is attached; use {@link #toByteArray()} to retrieve the written bytes.
+     */
+    public PbjWriter() {
+        buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        cap = buf.length;
+        reuseable = true;
+    }
+
+    /**
+     * Creates a growable (or fixed-size) standalone writer with the specified initial capacity.
+     *
+     * @param reserveSize the initial buffer capacity in bytes; if {@code mayGrow} is {@code true}
+     *                    the capacity is at least 16 KB regardless of this value
+     * @param mayGrow     {@code true} to allow the internal buffer to grow automatically;
+     *                    {@code false} to keep the buffer fixed at {@code reserveSize} bytes
+     */
+    public PbjWriter(int reserveSize, boolean mayGrow) {
+        if (mayGrow) buf = new byte[Math.max(reserveSize, 16 << 10)]; // 16k is friendly to x86-64 L1 cache
+        else {
+            buf = new byte[reserveSize];
+        }
+        cap = buf.length;
+        reuseable = true;
+        this.mayGrow = mayGrow;
+    }
+
+    /**
+     * Ensures that at least {@code len} bytes of space are available starting at the current
+     * position, flushing or growing the internal buffer if necessary.
+     *
+     * @param len the number of bytes to reserve
+     */
+    public void reserveRel(int len) {
+        if (pos + len <= cap) return;
+        flushOrGrow(len);
+    }
+
+    /**
+     * Advances the write position by {@code len} bytes without writing any data.
+     * Used to reserve placeholder space that will be filled in later via {@link #writeAtUnsafe}.
+     *
+     * @param len the number of bytes to skip over
+     */
+    public void placehold(int len) {
+        pos += len;
+    }
+
+    /**
+     * Returns the current absolute write position, accounting for any bytes already flushed
+     * to the underlying output stream.
+     *
+     * @return the current write position as a non-negative integer
+     */
+    public int position() {
+        return offset + pos;
+    }
+
+    /**
+     * Overwrites a single byte at the given absolute position without advancing the write cursor.
+     * Used to patch in placeholder bytes reserved earlier via {@link #placehold}.
+     *
+     * @param pos   the absolute write position to patch
+     * @param value the byte value to write
+     */
+    public void writeAtUnsafe(int pos, byte value) {
+        buf[pos - offset] = value;
+    }
+
+    /**
+     * Expands a 1-byte varint placeholder at the given absolute position into a 2-byte varint
+     * and shifts all subsequent bytes forward by one. The placeholder must have been reserved
+     * via {@link #placehold(int)}.
+     *
+     * @param position the absolute position of the 1-byte placeholder
+     */
+    public void reinsertVarInt(int position) {
+        int relPos = position - offset;
+        int len = this.pos - relPos - 1;
+        System.arraycopy(buf, relPos + 1, buf, relPos + 2, len);
+        buf[relPos] = (byte) ((len & 0x7F) | 0x80);
+        buf[relPos + 1] = (byte) (len >>> 7);
+        this.pos++;
+    }
+
+    /**
+     * Writes a boolean as a single byte ({@code 1} for {@code true}, {@code 0} for {@code false}).
+     *
+     * @param b the boolean value to write
+     */
+    public void writeBoolean(boolean b) {
+        writeByte((byte) (b ? 1 : 0));
+    }
+
+    /**
+     * Writes a single signed byte.
+     *
+     * @param b the byte to write
+     */
+    public void writeByte(byte b) {
+        if (pos < cap) {
+            buf[pos++] = b;
+            return;
+        }
+        writeByteInternal(b);
+    }
+
+    private void writeByteInternal(byte b) {
+        flushOrGrow(1);
+        buf[pos++] = b;
+    }
+
+    /**
+     * Writes two bytes in sequence.
+     *
+     * @param b1 the first byte
+     * @param b2 the second byte
+     */
+    public void writeByte2(byte b1, byte b2) {
+        if (pos + 2 <= cap) {
+            buf[pos] = b1;
+            buf[pos + 1] = b2;
+            pos += 2;
+            return;
+        }
+        writeByte2Internal(b1, b2);
+    }
+
+    private void writeByte2Internal(byte b1, byte b2) {
+        flushOrGrow(2);
+        buf[pos] = b1;
+        buf[pos + 1] = b2;
+        pos += 2;
+    }
+
+    /**
+     * Writes three bytes in sequence.
+     *
+     * @param b1 the first byte
+     * @param b2 the second byte
+     * @param b3 the third byte
+     */
+    public void writeByte3(byte b1, byte b2, byte b3) {
+        if (pos + 3 <= cap) {
+            buf[pos] = b1;
+            buf[pos + 1] = b2;
+            buf[pos + 2] = b3;
+            pos += 3;
+            return;
+        }
+        writeByte3Internal(b1, b2, b3);
+    }
+
+    private void writeByte3Internal(byte b1, byte b2, byte b3) {
+        flushOrGrow(3);
+        buf[pos] = b1;
+        buf[pos + 1] = b2;
+        buf[pos + 2] = b3;
+        pos += 3;
+    }
+
+    /**
+     * Writes four bytes in sequence.
+     *
+     * @param b1 the first byte
+     * @param b2 the second byte
+     * @param b3 the third byte
+     * @param b4 the fourth byte
+     */
+    public void writeByte4(byte b1, byte b2, byte b3, byte b4) {
+        if (pos + 4 <= cap) {
+            buf[pos] = b1;
+            buf[pos + 1] = b2;
+            buf[pos + 2] = b3;
+            buf[pos + 3] = b4;
+            pos += 4;
+            return;
+        }
+        writeByte4Internal(b1, b2, b3, b4);
+    }
+
+    private void writeByte4Internal(byte b1, byte b2, byte b3, byte b4) {
+        flushOrGrow(4);
+        buf[pos] = b1;
+        buf[pos + 1] = b2;
+        buf[pos + 2] = b3;
+        buf[pos + 3] = b4;
+        pos += 4;
+    }
+
+    /**
+     * Writes all remaining bytes from the given {@link BufferedData}, advancing its position.
+     *
+     * @param src the source buffer; all {@link BufferedData#remaining()} bytes are written
+     */
+    public void writeBytes(@NonNull final BufferedData src) {
+        int len = (int) src.remaining();
+        if (len <= 0) return;
+        long srcPos = src.position();
+        if (pos + len <= cap) {
+            src.getBytes(srcPos, buf, pos, len);
+            src.skip(len);
+            pos += len;
+            return;
+        }
+        writeBytesBDInternal(src, len, srcPos);
+    }
+
+    private void writeBytesBDInternal(BufferedData src, int len, long srcPos) {
+        if (output == null) {
+            flushOrGrow(len); // to grow at least to pos + len
+            src.getBytes(srcPos, buf, pos, len);
+            src.skip(len);
+            pos += len;
+        } else {
+            int remaining = len;
+            while (remaining > 0) {
+                if (pos == cap) {
+                    try {
+                        output.write(buf, 0, pos);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    offset += pos;
+                    pos = 0;
+                }
+                int chunk = Math.min(remaining, cap - pos);
+                src.getBytes(srcPos, buf, pos, chunk);
+                pos += chunk;
+                srcPos += chunk;
+                remaining -= chunk;
+            }
+            src.skip(len);
+        }
+    }
+
+    /**
+     * Writes all bytes from the given array.
+     *
+     * @param src the source byte array
+     */
+    public void writeBytes(@NonNull byte[] src) {
+        writeBytes(src, 0, src.length);
+    }
+
+    /**
+     * Writes {@code length} bytes from the given array starting at {@code offset}.
+     *
+     * @param src    the source byte array
+     * @param offset the start index within {@code src}
+     * @param length the number of bytes to write
+     */
+    public void writeBytes(@NonNull byte[] src, int offset, int length) {
+        if (length <= 0) return;
+        if (pos + length <= cap && (output == null || length < 2048)) {
+            System.arraycopy(src, offset, buf, pos, length);
+            pos += length;
+            return;
+        }
+        writeBytesInternal(src, offset, length);
+    }
+
+    private void writeBytesInternal(byte[] src, int srcOffset, int length) {
+        if (output != null && length >= 2048) {
+            if (pos > 0) {
+                try {
+                    output.write(buf, 0, pos);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                offset += pos;
+                pos = 0;
+            }
+            try {
+                output.write(src, srcOffset, length);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            offset += length;
+            return;
+        }
+        flushOrGrow(length);
+        System.arraycopy(src, srcOffset, buf, pos, length);
+        pos += length;
+    }
+
+    /**
+     * Writes all bytes from the given {@link RandomAccessData}.
+     *
+     * @param src the source data
+     */
+    public void writeBytes(@NonNull RandomAccessData src) {
+        int len = (int) src.length();
+        if (len <= 0) return;
+        if (pos + len <= cap) {
+            src.getBytes(0, buf, pos, len);
+            pos += len;
+            return;
+        }
+        writeBytesRAInternal(src, len);
+    }
+
+    private void writeBytesRAInternal(RandomAccessData src, int len) {
+        if (output == null) {
+            flushOrGrow(len);
+            src.getBytes(0, buf, pos, len);
+            pos += len;
+        } else {
+            // Maybe the below can be improved. This path seems rare
+            int srcOffset = 0;
+            int remaining = len;
+            while (remaining > 0) {
+                if (pos == cap) {
+                    try {
+                        output.write(buf, 0, pos);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    offset += pos;
+                    pos = 0;
+                }
+                int chunk = Math.min(remaining, cap - pos);
+                src.getBytes(srcOffset, buf, pos, chunk);
+                pos += chunk;
+                srcOffset += chunk;
+                remaining -= chunk;
+            }
+        }
+    }
+
+    /**
+     * Writes a 32-bit integer in big-endian byte order. Alias for {@link #writeIntBE(int)}.
+     *
+     * @param value the integer to write
+     */
+    public void writeInt(int value) {
+        writeIntBE(value);
+    }
+
+    /**
+     * Writes a 32-bit integer in big-endian byte order (most significant byte first).
+     *
+     * @param value the integer to write
+     */
+    public void writeIntBE(int value) {
+        if (pos + 4 <= cap) {
+            buf[pos] = (byte) (value >>> 24);
+            buf[pos + 1] = (byte) (value >>> 16);
+            buf[pos + 2] = (byte) (value >>> 8);
+            buf[pos + 3] = (byte) value;
+            pos += 4;
+            return;
+        }
+        writeIntBEInternal(value);
+    }
+
+    private void writeIntBEInternal(int value) {
+        flushOrGrow(4);
+        buf[pos] = (byte) (value >>> 24);
+        buf[pos + 1] = (byte) (value >>> 16);
+        buf[pos + 2] = (byte) (value >>> 8);
+        buf[pos + 3] = (byte) value;
+        pos += 4;
+    }
+
+    /**
+     * Writes a 32-bit integer in little-endian byte order (least significant byte first).
+     *
+     * @param value the integer to write
+     */
+    public void writeIntLE(int value) {
+        if (pos + 4 <= cap) {
+            buf[pos] = (byte) value;
+            buf[pos + 1] = (byte) (value >>> 8);
+            buf[pos + 2] = (byte) (value >>> 16);
+            buf[pos + 3] = (byte) (value >>> 24);
+            pos += 4;
+            return;
+        }
+        writeIntLEInternal(value);
+    }
+
+    private void writeIntLEInternal(int value) {
+        flushOrGrow(4);
+        buf[pos] = (byte) value;
+        buf[pos + 1] = (byte) (value >>> 8);
+        buf[pos + 2] = (byte) (value >>> 16);
+        buf[pos + 3] = (byte) (value >>> 24);
+        pos += 4;
+    }
+
+    /**
+     * Writes a 64-bit integer in little-endian byte order (least significant byte first).
+     *
+     * @param value the long to write
+     */
+    public void writeLongLE(long value) {
+        if (pos + 8 <= cap) {
+            buf[pos] = (byte) value;
+            buf[pos + 1] = (byte) (value >>> 8);
+            buf[pos + 2] = (byte) (value >>> 16);
+            buf[pos + 3] = (byte) (value >>> 24);
+            buf[pos + 4] = (byte) (value >>> 32);
+            buf[pos + 5] = (byte) (value >>> 40);
+            buf[pos + 6] = (byte) (value >>> 48);
+            buf[pos + 7] = (byte) (value >>> 56);
+            pos += 8;
+            return;
+        }
+        writeLongLEInternal(value);
+    }
+
+    private void writeLongLEInternal(long value) {
+        flushOrGrow(8);
+        buf[pos] = (byte) value;
+        buf[pos + 1] = (byte) (value >>> 8);
+        buf[pos + 2] = (byte) (value >>> 16);
+        buf[pos + 3] = (byte) (value >>> 24);
+        buf[pos + 4] = (byte) (value >>> 32);
+        buf[pos + 5] = (byte) (value >>> 40);
+        buf[pos + 6] = (byte) (value >>> 48);
+        buf[pos + 7] = (byte) (value >>> 56);
+        pos += 8;
+    }
+
+    /**
+     * Writes a 32-bit float in big-endian byte order. Alias for {@link #writeFloatBE(float)}.
+     *
+     * @param value the float to write
+     */
+    public void writeFloat(float value) {
+        writeFloatBE(value);
+    }
+
+    /**
+     * Writes a 32-bit float in big-endian byte order using {@link Float#floatToRawIntBits}.
+     *
+     * @param value the float to write
+     */
+    public void writeFloatBE(float value) {
+        writeIntBE(Float.floatToRawIntBits(value));
+    }
+
+    /**
+     * Writes a 32-bit float in little-endian byte order using {@link Float#floatToRawIntBits}.
+     *
+     * @param value the float to write
+     */
+    public void writeFloatLE(float value) {
+        writeIntLE(Float.floatToRawIntBits(value));
+    }
+
+    /**
+     * Writes a 64-bit double in big-endian byte order. Alias for {@link #writeDoubleBE(double)}.
+     *
+     * @param value the double to write
+     */
+    public void writeDouble(double value) {
+        writeDoubleBE(value);
+    }
+
+    /**
+     * Writes a 64-bit double in big-endian byte order using {@link Double#doubleToRawLongBits}.
+     *
+     * @param value the double to write
+     */
+    public void writeDoubleBE(double value) {
+        writeLongBE(Double.doubleToRawLongBits(value));
+    }
+
+    /**
+     * Writes a 64-bit double in little-endian byte order using {@link Double#doubleToRawLongBits}.
+     *
+     * @param value the double to write
+     */
+    public void writeDoubleLE(double value) {
+        writeLongLE(Double.doubleToRawLongBits(value));
+    }
+
+    /**
+     * Writes a 64-bit integer in big-endian byte order. Alias for {@link #writeLongBE(long)}.
+     *
+     * @param value the long to write
+     */
+    public void writeLong(long value) {
+        writeLongBE(value);
+    }
+
+    /**
+     * Writes a 64-bit integer in big-endian byte order (most significant byte first).
+     *
+     * @param value the long to write
+     */
+    public void writeLongBE(long value) {
+        if (pos + 8 <= cap) {
+            buf[pos] = (byte) (value >>> 56);
+            buf[pos + 1] = (byte) (value >>> 48);
+            buf[pos + 2] = (byte) (value >>> 40);
+            buf[pos + 3] = (byte) (value >>> 32);
+            buf[pos + 4] = (byte) (value >>> 24);
+            buf[pos + 5] = (byte) (value >>> 16);
+            buf[pos + 6] = (byte) (value >>> 8);
+            buf[pos + 7] = (byte) value;
+            pos += 8;
+            return;
+        }
+        writeLongBEInternal(value);
+    }
+
+    private void writeLongBEInternal(long value) {
+        flushOrGrow(8);
+        buf[pos] = (byte) (value >>> 56);
+        buf[pos + 1] = (byte) (value >>> 48);
+        buf[pos + 2] = (byte) (value >>> 40);
+        buf[pos + 3] = (byte) (value >>> 32);
+        buf[pos + 4] = (byte) (value >>> 24);
+        buf[pos + 5] = (byte) (value >>> 16);
+        buf[pos + 6] = (byte) (value >>> 8);
+        buf[pos + 7] = (byte) value;
+        pos += 8;
+    }
+
+    /**
+     * Writes an {@code int} as a zigzag-encoded varint. Negative values are sign-extended to
+     * 64 bits before encoding, producing the 10-byte wire format required by the protobuf spec.
+     *
+     * @param value the signed int to encode
+     */
+    public void writeVarIntZZ(int value) {
+        writeVarLongZZ(value);
+    }
+
+    /**
+     * Writes a {@code long} as a zigzag-encoded varint. The value is mapped via
+     * {@code (value << 1) ^ (value >> 63)} before varint encoding so that small negative
+     * numbers require few bytes.
+     *
+     * @param value the signed long to encode
+     */
+    public void writeVarLongZZ(long value) {
+        writeVarLongNoZZ((value << 1) ^ (value >> 63));
+    }
+
+    /**
+     * Writes an {@code int} as a base-128 varint with optional zigzag encoding.
+     *
+     * @param value  the value to encode
+     * @param zigZag if {@code true}, applies zigzag encoding before varint encoding
+     */
+    public void writeVarInt(int value, boolean zigZag) {
+        long v = zigZag ? ((long) value << 1) ^ ((long) value >> 63) : value;
+        writeVarLongNoZZ(v);
+    }
+
+    /**
+     * Writes a {@code long} as a base-128 varint with optional zigzag encoding.
+     *
+     * @param value  the value to encode
+     * @param zigZag if {@code true}, applies zigzag encoding before varint encoding
+     */
+    public void writeVarLong(long value, boolean zigZag) {
+        long v = zigZag ? (value << 1) ^ (value >> 63) : value;
+        writeVarLongNoZZ(v);
+    }
+
+    private void writeVarLongInternal(long v) {
+        flushOrGrow(10);
+        while ((v & ~0x7FL) != 0) {
+            buf[pos++] = (byte) (((int) v & 0x7F) | 0x80);
+            v >>>= 7;
+        }
+        buf[pos++] = (byte) v;
+    }
+
+    /**
+     * Writes an {@code int} as a base-128 varint without zigzag encoding.
+     * The value is zero-extended to 64 bits before encoding.
+     *
+     * @param value the value to encode
+     */
+    public void writeVarIntNoZZ(int value) {
+        writeVarLongNoZZ(value);
+    }
+
+    /**
+     * Writes a {@code long} as a base-128 varint without zigzag encoding.
+     * Each 7-bit group is written as a byte with the high bit set if more bytes follow.
+     *
+     * @param v the value to encode
+     */
+    public void writeVarLongNoZZ(long v) {
+        if (pos + 10 <= cap) {
+            while ((v & ~0x7FL) != 0) {
+                buf[pos++] = (byte) (((int) v & 0x7F) | 0x80);
+                v >>>= 7;
+            }
+            buf[pos++] = (byte) v;
+            return;
+        }
+        writeVarLongInternal(v);
+    }
+
+    /**
+     * Flushes all buffered bytes to the underlying output stream and resets the internal buffer.
+     *
+     * <p>After the flush the internal write position is reset to zero, and the absolute byte
+     * offset is advanced by the number of bytes written. This is a no-op when no output stream
+     * is attached (standalone writers). Any pending error is surfaced before writing.
+     *
+     * @throws RuntimeException     if a prior error was recorded on this writer
+     * @throws UncheckedIOException if the underlying stream throws an {@link java.io.IOException}
+     */
+    public void flush() {
+        throwOnError();
+        if (output == null) return;
+        try {
+            output.write(buf, 0, pos);
+            output.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        offset += pos;
+        pos = 0;
+    }
+
+    /**
+     * Flushes any remaining bytes to the underlying output stream and closes it.
+     * If no output stream is attached this method does nothing.
+     */
+    @Override
+    public void close() {
+        if (output == null) return;
+        flush();
+        try {
+            output.close();
+        } catch (IOException ex) {
+            setError(IOError, ex.getMessage());
+        }
+        if (err == 0) {
+            err = Closed;
+        }
+    }
+
+    private void flushOrGrow(int minLength) {
+        if (output != null) {
+            if (minLength > cap) {
+                setError(IOError, "minLength is greater than capacity");
+                return;
+            }
+            try {
+                output.write(buf, 0, pos);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            offset += pos;
+            pos = 0;
+        } else if (reuseable && mayGrow) {
+            int power2Capacity = (int) 2L << (63 - Long.numberOfLeadingZeros(Math.max(buf.length, pos + minLength)));
+            byte[] newBuf = new byte[power2Capacity];
+            System.arraycopy(buf, 0, newBuf, 0, pos);
+            buf = newBuf;
+            cap = buf.length;
+        }
+        // A possible else case is using a byte array and trying to reserve (or grow) past the length of it
+        // reserving shouldn't cause a throw so this else is ignored
+    }
+
+    /**
+     * Flushes any buffered output and resets this writer's position, offset, and error state,
+     * leaving it ready for reuse while keeping the same output destination.
+     */
+    public void reset() {
+        flush();
+        pos = 0;
+        offset = 0;
+        err = 0;
+        cause = null;
+    }
+
+    /**
+     * Resets this writer and detaches it from any output stream, allowing subsequent use as
+     * a standalone in-memory writer.
+     */
+    public void resetWithNull() {
+        resetWith((OutputStream) null);
+    }
+
+    /**
+     * Resets this writer and redirects output to a new {@link OutputStream}.
+     * Only valid on writers that were originally created with an output stream.
+     * Sets the error code to {@link #UsageError} if called on a non-reuseable writer.
+     *
+     * @param out the new output stream
+     */
+    public void resetWith(OutputStream out) {
+        reset();
+        if (!reuseable) {
+            setError(UsageError, "resetWith on non-reuseable PbjWriter");
+            return;
+        }
+        output = out;
+    }
+
+    /**
+     * Resets this writer and redirects output to a new {@link WritableSequentialData}.
+     * Only valid on writers that were originally created with an output stream.
+     *
+     * @param out the new writable sequential data target
+     */
+    public void resetWith(@NonNull WritableSequentialData out) {
+        resetWith(new OutputStream() {
+            @Override
+            public void write(int b) {
+                out.writeByte((byte) b);
+            }
+
+            @Override
+            public void write(@NonNull byte[] b, int off, int len) {
+                out.writeBytes(b, off, len);
+            }
+        });
+    }
+
+    /**
+     * Returns the raw internal byte array. The valid data occupies indices {@code [0, position())}.
+     * Intended for low-level inspection; prefer {@link #toByteArray()} for a correctly sized copy
+     *
+     * @return the internal buffer array
+     */
+    public byte[] internalArray() {
+        return buf;
+    }
+
+    /**
+     * Returns a zero-copy {@link Bytes} view wrapping the internal buffer from index 0 up to
+     * the current position. The backing array is shared, so the returned {@code Bytes} must
+     * not be retained beyond the next write operation.
+     *
+     * @return a {@code Bytes} view of the current contents
+     */
+    public Bytes internalArrayWrapped() {
+        return Bytes.wrap(buf, 0, pos);
+    }
+
+    /**
+     * Returns a {@link Bytes} wrapping a fresh copy of the written bytes.
+     * Only valid on standalone (non-streaming) writers; sets {@link #UsageError} and returns
+     * {@link Bytes#EMPTY} if called on a streaming writer.
+     *
+     * @return the written bytes wrapped in a {@code Bytes} instance
+     */
+    public Bytes toByteArrayWrapped() {
+        if (output != null) {
+            setError(UsageError, "toByteArrayWrapped used on a streaming object");
+            return Bytes.EMPTY;
+        }
+        return Bytes.wrap(toByteArray());
+    }
+
+    /**
+     * Returns a newly allocated byte array containing exactly the bytes written so far.
+     * Only valid on standalone (non-streaming) writers; sets {@link #UsageError} and returns
+     * {@code null} if called on a streaming writer.
+     *
+     * @return a copy of the written bytes, or {@code null} on error
+     */
+    public byte[] toByteArray() {
+        if (output != null) {
+            setError(UsageError, "toByteArray used on a streaming object");
+            return null;
+        }
+        byte[] bytes = new byte[pos];
+        System.arraycopy(buf, 0, bytes, 0, pos);
+        return bytes;
+    }
+
+    /**
+     * Creates a {@link PbjReader} backed by the current internal buffer contents.
+     * Useful for reading back data written to a standalone writer without copying.
+     * Only valid on standalone (non-streaming) writers; sets {@link #UsageError} and returns
+     * {@code null} if called on a streaming writer.
+     *
+     * @return a new {@code PbjReader} positioned at the start of the written bytes, or {@code null} on error
+     */
+    public PbjReader toPbjReader() {
+        if (output != null) {
+            setError(UsageError, "toPbjReader on a streaming object");
+            return null;
+        }
+        return new PbjReader(buf, 0, pos);
+    }
+
+    /**
+     * Records an error on this writer if no previous error is set. Once an error is recorded
+     * subsequent writes become no-ops.
+     *
+     * @param errorKind one of the error-code constants ({@link #IOError}, {@link #UsageError}, etc.)
+     * @param message   a message returned with an exception
+     */
+    public void setError(int errorKind, String message) {
+        if (err > 0) return;
+        err = errorKind;
+        if (useStacktrace) {
+            cause = new RuntimeException(message);
+        } else {
+            cause = premadeRuntimeException;
+        }
+    }
+
+    /**
+     * Returns the current error code, or {@code 0} if no error has occurred.
+     *
+     * @return a positive error-code constant, or {@code 0} for no error
+     */
+    public int error() {
+        return err > 0 ? err : 0;
+    }
+
+    /**
+     * Throws the recorded error as a {@link RuntimeException} if an error is set.
+     *
+     * @throws RuntimeException if {@link #error()} is non-zero
+     */
+    public void throwOnError() {
+        if (err > 0) {
+            throw cause;
+        }
+    }
+
+    /**
+     * Returns the exception that was recorded when the current error was set, or {@code null}
+     * if no error has occurred.
+     *
+     * @return the recorded exception, or {@code null}
+     */
+    public RuntimeException getCause() {
+        return cause;
+    }
+
+    /**
+     * Writes a UTF-8 encoded string without a preceding length varint.
+     * Surrogate pairs are encoded as a 4-byte UTF-8 sequence. An unpaired surrogate sets
+     * the error code to {@link #MalformString}.
+     *
+     * @param str the string to encode
+     */
+    public void writeStringNoTag(String str) {
+        int inLength = str.length();
+        for (int i = 0; i < inLength; ++i) {
+            char c = str.charAt(i);
+            if (c < 0x80) {
+                writeByte((byte) c);
+            } else if (c < 0x800) {
+                writeByte2((byte) (0xC0 | (c >>> 6)), (byte) (0x80 | (0x3F & c)));
+            } else if (c < MIN_SURROGATE || MAX_SURROGATE < c) {
+                writeByte3((byte) (0xE0 | (c >>> 12)), (byte) (0x80 | (0x3F & (c >>> 6))), (byte) (0x80 | (0x3F & c)));
+            } else {
+                char low;
+                if (i + 1 == inLength || !isSurrogatePair(c, (low = str.charAt(++i)))) {
+                    setError(MalformString, "Unpaired surrogate at index " + i + " of " + inLength);
+                    return;
+                }
+                int codePoint = toCodePoint(c, low);
+                writeByte4(
+                        (byte) ((0xF << 4) | (codePoint >>> 18)),
+                        (byte) (0x80 | (0x3F & (codePoint >>> 12))),
+                        (byte) (0x80 | (0x3F & (codePoint >>> 6))),
+                        (byte) (0x80 | (0x3F & codePoint)));
+            }
+        }
+    }
+
+    /**
+     * Writes a UTF-8 encoded string preceded by its length as a base-128 varint, as required
+     * by the protobuf wire format for {@code TYPE_STRING} fields.
+     *
+     * @param str the string to encode
+     */
+    public void writeStringWithTag(String str) {
+        int inLength = str.length();
+        if (inLength > 0x7F) {
+            writeUTF8_2byte(str);
+            return;
+        }
+        // fast path 1 byte tag case
+        reserveRel(0x7F * 4 + 2); // worse case size
+        int pos = position();
+        placehold(1);
+        writeStringNoTag(str);
+        int endPos = position();
+        int utf8Len = endPos - pos - 1;
+        if (utf8Len <= 0x7F) {
+            writeAtUnsafe(pos, (byte) utf8Len);
+        } else {
+            reinsertVarInt(pos);
+        }
+    }
+
+    private void writeUTF8_2byte(String str) {
+        // buffer is 16k, string is UTF16, so worst case is len*3.
+        // 5460 was picked bc its (16k - 2byte tag) / 3 byte worse case
+        if (str.length() > 5460) {
+            // Can't fit in buffer, todo check if we'll grow anyways
+            // I don't think anything hits this case?
+            // These two lines counts the length then write the length, making this 2 pass
+            writeVarIntNoZZ(ProtoWriterTools.sizeOfStringNoTag(str));
+            writeStringNoTag(str);
+            return;
+        }
+        reserveRel(str.length() * 3 + 2);
+        int pos = position();
+        placehold(2);
+        writeStringNoTag(str);
+        int utf8Len = position() - pos - 2;
+        writeAtUnsafe(pos, (byte) ((utf8Len & 0x7F) | 0x80));
+        writeAtUnsafe(pos + 1, (byte) (utf8Len >>> 7));
+    }
+
+    /**
+     * Advances the write position by {@code count} bytes without writing any data.
+     *
+     * @param count the number of bytes to skip
+     */
+    public void skip(int count) {
+        pos += count;
+    }
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link Codec#parse(com.hedera.pbj.runtime.io.ReadableSequentialData, boolean, boolean, int, int)},
+ * {@link Codec#measure(com.hedera.pbj.runtime.io.ReadableSequentialData)}, and
+ * {@link Codec#fastEquals(Object, com.hedera.pbj.runtime.io.ReadableSequentialData)}.
+ * <p>
+ * These methods wrap the caller's input in a {@link PbjReader}, which buffers up to 16KB ahead of what has
+ * actually been consumed. The tests here use a buffer with more than 16KB of trailing data after the
+ * encoded message, to confirm that buffering does not leak into the reported message length or the
+ * original input's position.
+ */
+class CodecParseMethodTest {
+
+    private static final LengthPrefixedCodec CODEC = new LengthPrefixedCodec();
+
+    private static BufferedData messageWithTrailingFiller(final byte[] payload, final byte[] filler) {
+        final byte[] backing = new byte[4 + payload.length + filler.length];
+        final BufferedData writable = BufferedData.wrap(backing);
+        writable.writeInt(payload.length);
+        writable.writeBytes(payload);
+        writable.writeBytes(filler);
+        return BufferedData.wrap(backing);
+    }
+
+    private static byte[] filler(final int size) {
+        final byte[] filler = new byte[size];
+        Arrays.fill(filler, (byte) 0x7F);
+        return filler;
+    }
+
+    @Test
+    void measureIsNotInflatedByTrailingData() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000); // larger than PbjReader's 16KB internal buffer
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        final int measured = CODEC.measure(data);
+
+        assertEquals(4 + payload.length, measured);
+    }
+
+    @Test
+    void measureLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        CODEC.measure(data);
+
+        assertEquals(4 + payload.length, data.position());
+        final byte[] remaining = new byte[filler.length];
+        data.readBytes(remaining);
+        assertArrayEquals(filler, remaining);
+    }
+
+    @Test
+    void parseLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        final LengthPrefixed parsed = CODEC.parse(data);
+
+        assertArrayEquals(payload, parsed.payload());
+        assertEquals(4 + payload.length, data.position());
+        final byte[] remaining = new byte[filler.length];
+        data.readBytes(remaining);
+        assertArrayEquals(filler, remaining);
+    }
+
+    @Test
+    void fastEqualsLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        assertTrue(CODEC.fastEquals(new LengthPrefixed(payload), data));
+
+        assertEquals(4 + payload.length, data.position());
+    }
+
+    private record LengthPrefixed(byte[] payload) {
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof LengthPrefixed other && Arrays.equals(payload, other.payload);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(payload);
+        }
+    }
+
+    private static final class LengthPrefixedCodec extends Codec<LengthPrefixed> {
+
+        @NonNull
+        @Override
+        protected LengthPrefixed parseImpl(
+                @NonNull final PbjReader input,
+                final boolean strictMode,
+                final boolean parseUnknownFields,
+                final int maxDepth,
+                final int maxSize)
+                throws ParseException {
+            final int length = input.readInt();
+            final byte[] payload = new byte[length];
+            if (input.readBytes(payload) != length) {
+                throw new ParseException("Failed to read payload bytes");
+            }
+            return new LengthPrefixed(payload);
+        }
+
+        @Override
+        protected void writeImpl(@NonNull final LengthPrefixed item, @NonNull final PbjWriter output) {
+            output.writeInt(item.payload().length);
+            output.writeBytes(item.payload());
+        }
+
+        @Override
+        public int measure(@NonNull final PbjReader input) throws ParseException {
+            final long start = input.position();
+            parse(input);
+            return (int) (input.position() - start);
+        }
+
+        @Override
+        public int measureRecord(final LengthPrefixed item) {
+            return 4 + item.payload().length;
+        }
+
+        @Override
+        public boolean fastEquals(@NonNull final LengthPrefixed item, @NonNull final PbjReader input)
+                throws ParseException {
+            return item.equals(parse(input));
+        }
+
+        @Override
+        public LengthPrefixed getDefaultInstance() {
+            return new LengthPrefixed(new byte[0]);
+        }
+    }
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.util.function.ToIntFunction;
 
 /**
@@ -25,22 +24,18 @@ class CodecWrapper<T> extends Codec<T> {
     @NonNull
     @Override
     protected T parseImpl(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+    protected void writeImpl(@NonNull T item, @NonNull PbjWriter output) {
         writer.write(item, output);
     }
 
     @Override
-    public int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    public int measure(@NonNull PbjReader input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 
@@ -50,7 +45,7 @@ class CodecWrapper<T> extends Codec<T> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    public boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
@@ -13,7 +13,7 @@ import java.util.function.ToIntFunction;
  *
  * @param <T> The type of the object to be encoded/decoded
  */
-class CodecWrapper<T> implements Codec<T> {
+class CodecWrapper<T> extends Codec<T> {
     private final ProtoWriter<T> writer;
     private final ToIntFunction<T> sizeOf;
 
@@ -24,7 +24,7 @@ class CodecWrapper<T> implements Codec<T> {
 
     @NonNull
     @Override
-    public T parse(
+    protected T parseImpl(
             @NonNull ReadableSequentialData input,
             boolean strictMode,
             boolean parseUnknownFields,
@@ -35,7 +35,7 @@ class CodecWrapper<T> implements Codec<T> {
     }
 
     @Override
-    public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+    protected void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         writer.write(item, output);
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -532,7 +532,7 @@ class ProtoParserToolsTest {
         }
     }
 
-    private static final class TestMessageCodec implements Codec<TestMessage> {
+    private static final class TestMessageCodec extends Codec<TestMessage> {
 
         public static final TestMessageCodec INSTANCE = new TestMessageCodec();
 
@@ -541,7 +541,7 @@ class ProtoParserToolsTest {
 
         @NonNull
         @Override
-        public TestMessage parse(
+        protected final TestMessage parseImpl(
                 @NonNull final ReadableSequentialData in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
@@ -569,7 +569,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public void write(@NonNull final TestMessage item, @NonNull final WritableSequentialData out)
+        protected final void writeImpl(@NonNull final TestMessage item, @NonNull final WritableSequentialData out)
                 throws IOException {
             final String value = item.getValue();
             if (value != null) {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -30,9 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
@@ -358,7 +359,9 @@ class ProtoParserToolsTest {
     @Test
     void testExtractBytesNullInput() {
         final FieldDefinition field = createFieldDefinition(BYTES);
-        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes(null, field));
+        assertThrows(
+                NullPointerException.class,
+                () -> ProtoParserTools.extractFieldBytes((ReadableSequentialData) null, field));
     }
 
     @Test
@@ -542,7 +545,7 @@ class ProtoParserToolsTest {
         @NonNull
         @Override
         protected final TestMessage parseImpl(
-                @NonNull final ReadableSequentialData in,
+                @NonNull final PbjReader in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
@@ -569,8 +572,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        protected final void writeImpl(@NonNull final TestMessage item, @NonNull final WritableSequentialData out)
-                throws IOException {
+        protected final void writeImpl(@NonNull final TestMessage item, @NonNull final PbjWriter out) {
             final String value = item.getValue();
             if (value != null) {
                 ProtoWriterTools.writeString(out, VALUE_FIELD, value);
@@ -578,7 +580,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public int measure(@NonNull ReadableSequentialData input) throws ParseException {
+        public int measure(@NonNull PbjReader input) throws ParseException {
             throw new UnsupportedOperationException();
         }
 
@@ -592,8 +594,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public boolean fastEquals(@NonNull TestMessage item, @NonNull ReadableSequentialData input)
-                throws ParseException {
+        public boolean fastEquals(@NonNull TestMessage item, @NonNull PbjReader input) throws ParseException {
             throw new UnsupportedOperationException();
         }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
@@ -1,0 +1,1470 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class PbjReaderWriterTest {
+
+    @Test
+    void WriteConstructorBufferSizeConsistent() {
+        final int expectedSize = new PbjWriter().internalArray().length;
+        assertEquals(expectedSize, new PbjWriter((OutputStream) null).internalArray().length);
+        assertEquals(expectedSize, new PbjWriter((WritableSequentialData) null).internalArray().length);
+        assertEquals(expectedSize, new PbjWriter(128, true).internalArray().length);
+        // Does not apply to ByteBuffer, byte[], or reserve when large, or the below
+        assertEquals(128, new PbjWriter(128, false).internalArray().length);
+    }
+
+    @Test
+    void writerConstructorCanReserveLarge() {
+        PbjWriter writer = new PbjWriter(2 << 20, true);
+        assertEquals(2 << 20, writer.internalArray().length);
+    }
+
+    @Test
+    void writeByteBufferConstructorHeap() {
+        ByteBuffer bb = ByteBuffer.allocate(32);
+        PbjWriter writer = new PbjWriter(bb);
+        writer.writeByte3((byte) 11, (byte) 22, (byte) 33);
+        assertEquals(11, bb.array()[bb.arrayOffset()]);
+        assertEquals(22, bb.array()[bb.arrayOffset() + 1]);
+        assertEquals(33, bb.array()[bb.arrayOffset() + 2]);
+        assertEquals(3, writer.position());
+    }
+
+    @Test
+    void writeByteBufferConstructorDirect() {
+        ByteBuffer bb = ByteBuffer.allocateDirect(32);
+        PbjWriter writer = new PbjWriter(bb);
+        writer.writeByte3((byte) 11, (byte) 22, (byte) 33);
+        writer.flush();
+        bb.flip();
+        assertEquals(11, bb.get());
+        assertEquals(22, bb.get());
+        assertEquals(33, bb.get());
+    }
+
+    @Test
+    void writeBytesFromRandomAccessData() {
+        Bytes src = Bytes.wrap(new byte[] {10, 20, 30, 40});
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(src);
+        assertArrayEquals(new byte[] {10, 20, 30, 40}, writer.toByteArray());
+    }
+
+    @Test
+    void writeBytesFromBufferedData() {
+        BufferedData src = BufferedData.wrap(new byte[] {10, 20, 30, 40});
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(src);
+        assertArrayEquals(new byte[] {10, 20, 30, 40}, writer.toByteArray());
+    }
+
+    @Test
+    void closeFlushesDataToOutputStream() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        writer.writeByte2((byte) 55, (byte) 66);
+        assertArrayEquals(new byte[] {}, baos.toByteArray());
+        writer.close();
+        assertArrayEquals(new byte[] {55, 66}, baos.toByteArray());
+    }
+
+    @Test
+    void closeIsNoopWithoutOutputStream() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeByte((byte) 1);
+        writer.close();
+        assertEquals(1, writer.position());
+    }
+
+    @Test
+    void toByteArrayWrappedErrorsOnStreamingWriter() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        assertEquals(Bytes.EMPTY, writer.internalArrayWrapped());
+        assertEquals(Bytes.EMPTY, writer.toByteArrayWrapped());
+        assertEquals(PbjWriter.UsageError, writer.error());
+        assertThrows(RuntimeException.class, () -> writer.throwOnError());
+    }
+
+    @Test
+    void toByteArrayErrorsOnStreamingWriter() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        assertEquals(null, writer.toByteArray());
+        assertEquals(PbjWriter.UsageError, writer.error());
+        assertThrows(RuntimeException.class, () -> writer.throwOnError());
+    }
+
+    @Test
+    void writerRelativeReserve() {
+        PbjWriter writer = new PbjWriter();
+        byte[] origArray = writer.internalArray();
+        writer.reserveRel(origArray.length);
+        byte[] arr2 = writer.internalArray();
+        assertEquals(origArray, arr2); // same object
+
+        writer.reserveRel(origArray.length + 1);
+        byte[] arr3 = writer.internalArray();
+        assertNotEquals(origArray, arr3); // diff object
+
+        writer.skip(arr3.length - 1);
+        writer.reserveRel(1);
+        byte[] arr4 = writer.internalArray();
+        assertEquals(arr3, arr4);
+
+        writer.skip(1);
+        writer.reserveRel(0);
+        byte[] arr5 = writer.internalArray();
+        assertEquals(arr4, arr5);
+
+        writer.reserveRel(1);
+        byte[] arr6 = writer.internalArray();
+        assertNotEquals(arr4, arr6);
+    }
+
+    @Test
+    void writerUsesByteArray() {
+        byte[] bytes = new byte[128];
+        PbjWriter writer = new PbjWriter(bytes, 0);
+        writer.writeByte3((byte) 10, (byte) 20, (byte) 30);
+        assertEquals(bytes[0], 10);
+        assertEquals(bytes[1], 20);
+        assertEquals(bytes[2], 30);
+    }
+
+    @Test
+    void manyStringRoundtrip() {
+        byte[] bytes = new byte[128];
+        PbjWriter writer = new PbjWriter(bytes, 0);
+        String strings[] = {
+            "a",
+            "\u0100",
+            "\u2603",
+            "\uD800\uDC00",
+            "\uE000",
+            "a\u0100\u2603\uE000\uD800\uDC00",
+            "\uD800\uDC00\uE000\u2603\u0100a",
+            "\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uE000\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100a"
+        };
+        for (String str : strings) {
+            writer.reset();
+            writer.writeStringWithTag(str);
+            String res = writer.toPbjReader().readString(128);
+            assertEquals(str, res);
+        }
+    }
+
+    @Test
+    void toByteArrayDoesAClone() {
+        byte[] bytes = new byte[128];
+        PbjWriter writer = new PbjWriter(bytes, 0);
+        for (int i = 0; i < 128; i++) {
+            writer.writeVarIntNoZZ(i);
+        }
+        assertEquals(128, writer.position());
+        assertEquals(bytes, writer.internalArray());
+        byte[] arr1 = writer.toByteArray();
+        assertNotEquals(bytes, arr1);
+        Bytes arr2 = writer.toByteArrayWrapped();
+        for (int i = 0; i < 128; i++) {
+            assertEquals(i, arr1[i]);
+            assertEquals(i, arr2.getByte(i));
+        }
+    }
+
+    @Test
+    void writeResetCheck() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeByte((byte) 10);
+        assertEquals(1, writer.position());
+        writer.reset();
+        assertEquals(0, writer.position());
+        writer.writeByte2((byte) 99, (byte) 88);
+        assertEquals(2, writer.position());
+        assertEquals(99, writer.internalArray()[0]);
+        assertEquals(88, writer.internalArray()[1]);
+        assertArrayEquals(new byte[] {99, 88}, writer.toByteArray());
+    }
+
+    @Test
+    void throwOnErrorThrows_NoPrevOverwrite() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag("\uD800"); // lone surrogate sets MalformString
+        assertEquals(PbjWriter.MalformString, writer.error());
+        assertThrows(RuntimeException.class, writer::throwOnError);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer2 = new PbjWriter(baos);
+        writer2.writeStringWithTag("\uD800"); // lone surrogate sets MalformString
+        assertEquals(PbjWriter.MalformString, writer2.error());
+        assertThrows(RuntimeException.class, writer2::throwOnError);
+        // Confirm error didn't change
+        assertEquals(Bytes.EMPTY, writer2.toByteArrayWrapped()); // if no error, this would set usage error
+        assertEquals(PbjWriter.MalformString, writer2.error());
+
+        baos = new ByteArrayOutputStream();
+        PbjWriter writer3 = new PbjWriter(baos);
+        assertEquals(Bytes.EMPTY, writer3.toByteArrayWrapped());
+        assertEquals(PbjWriter.UsageError, writer3.error());
+    }
+
+    @Test
+    void encodeUtf8HighSurrogateFollowedByHighSurrogate() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringNoTag("\uD800\uD801");
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void doesntThrowOnNoError() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4});
+        assertEquals(0x04030201, reader.readIntLE());
+        assertEquals(0, reader.error());
+        assertDoesNotThrow(() -> reader.throwOnError()); // must not throw
+
+        PbjWriter writer = new PbjWriter();
+        writer.writeByte((byte) 1);
+        assertEquals(0, writer.error());
+        writer.throwOnError(); // must not throw
+    }
+
+    @Test
+    void manyRoundtrip() {
+        PbjWriter w = new PbjWriter();
+
+        w.writeInt(0x01020304);
+        w.writeIntBE(0x05060708);
+        w.writeIntLE(0x090A0B0C);
+
+        w.writeLong(0x0102030405060708L);
+        w.writeLongBE(0x090A0B0C0D0E0F10L);
+        w.writeLongLE(0x1112131415161718L);
+
+        w.writeFloat(1.5f);
+        w.writeFloatBE(2.5f);
+        w.writeFloatLE(3.5f);
+
+        w.writeDouble(1.25);
+        w.writeDoubleBE(2.25);
+        w.writeDoubleLE(3.25);
+
+        w.writeBoolean(true);
+        w.writeBoolean(false);
+        w.writeByte((byte) 127);
+
+        byte[] arr1 = {10, 20, 30, 40, 50};
+        w.writeBytes(arr1);
+        w.writeBytes(arr1, 1, 3);
+        w.writeBytes(Bytes.wrap(new byte[] {60, 70}));
+        BufferedData bd = BufferedData.allocate(2);
+        bd.writeByte((byte) 80);
+        bd.writeByte((byte) 90);
+        bd.flip();
+        w.writeBytes(bd);
+
+        w.writeStringWithTag("hello");
+        w.writeStringWithTag("Ā☃");
+
+        PbjReader reader = w.toPbjReader();
+
+        assertEquals(0x01020304, reader.readInt());
+        assertEquals(0x05060708, reader.readIntBE());
+        assertEquals(0x090A0B0C, reader.readIntLE());
+
+        assertEquals(0x0102030405060708L, reader.readLong());
+        assertEquals(0x090A0B0C0D0E0F10L, reader.readLongBE());
+        assertEquals(0x1112131415161718L, reader.readLongLE());
+
+        assertEquals(1.5f, reader.readFloat(), 0f);
+        assertEquals(2.5f, reader.readFloat(), 0f);
+        assertEquals(3.5f, reader.readFloatLE(), 0f);
+
+        assertEquals(1.25, reader.readDouble(), 0.0);
+        assertEquals(2.25, reader.readDouble(), 0.0);
+        assertEquals(3.25, reader.readDoubleLE(), 0.0);
+
+        assertEquals(true, reader.readBoolean());
+        assertEquals(false, reader.readBoolean());
+        assertEquals(127, reader.readByte());
+
+        byte[] dst1 = new byte[5];
+        reader.readBytes(dst1);
+        assertArrayEquals(arr1, dst1);
+
+        byte[] dst2 = new byte[3];
+        reader.readBytes(dst2);
+        assertArrayEquals(new byte[] {20, 30, 40}, dst2);
+
+        byte[] dst3 = new byte[2];
+        reader.readBytes(dst3);
+        assertArrayEquals(new byte[] {60, 70}, dst3);
+
+        byte[] dst4 = new byte[2];
+        reader.readBytes(dst4);
+        assertArrayEquals(new byte[] {80, 90}, dst4);
+
+        assertEquals("hello", reader.readString(100));
+        assertEquals("Ā☃", reader.readString(100));
+
+        assertFalse(reader.hasRemaining());
+        assertEquals(0, w.error());
+    }
+
+    @Test
+    void writeVarIntZigZagRoundtrip() {
+        int[] values = {0, 1, -1, Integer.MAX_VALUE, Integer.MIN_VALUE, 100, -100};
+        PbjWriter writer = new PbjWriter();
+        for (int v : values) {
+            writer.reset();
+            writer.writeVarInt(v, true);
+            assertEquals(v, writer.toPbjReader().readVarIntZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarInt(v, false);
+            assertEquals(v, writer.toPbjReader().readVarIntNoZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarIntZZ(v);
+            assertEquals(v, writer.toPbjReader().readVarIntZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarIntNoZZ(v);
+            assertEquals(v, writer.toPbjReader().readVarIntNoZZ(), "Failed for value " + v);
+        }
+    }
+
+    @Test
+    void writeVarLongZigZagRoundtrip() {
+        long[] values = {0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE, 1_000_000_000L, -1_000_000_000L};
+        PbjWriter writer = new PbjWriter();
+        for (long v : values) {
+            writer.reset();
+            writer.writeVarLong(v, true);
+            assertEquals(v, writer.toPbjReader().readVarLongZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarLong(v, false);
+            assertEquals(v, writer.toPbjReader().readVarLongNoZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarLongZZ(v);
+            assertEquals(v, writer.toPbjReader().readVarLongZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarLongNoZZ(v);
+            int noZZLen = writer.position();
+            assertEquals(v, writer.toPbjReader().readVarLongNoZZ(), "Failed for value " + v);
+
+            // edge test
+            writer.reset();
+            int len = writer.internalArray().length;
+            writer.skip(len);
+            writer.writeVarLongNoZZ(v);
+            byte[] buf = writer.internalArray();
+            for (int i = 0; i < noZZLen; i++) {
+                assertEquals(buf[i], buf[i + len]);
+            }
+        }
+    }
+
+    @Test
+    void testWriteByteAtEdge() {
+        PbjWriter writer = new PbjWriter();
+        int defaultLen = writer.internalArray().length;
+        writer.skip(defaultLen - 1);
+        writer.writeByte((byte) 1);
+        byte[] internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 1]);
+        writer.writeByte((byte) 1);
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 1]);
+        assertEquals((byte) 1, internalArray[defaultLen]);
+
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 2);
+        writer.writeByte2((byte) 1, (byte) 2);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 2]);
+        assertEquals((byte) 2, internalArray[defaultLen - 1]);
+        writer.skip(-1);
+        writer.writeByte2((byte) 1, (byte) 2);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 1]);
+        assertEquals((byte) 2, internalArray[defaultLen]);
+
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 3);
+        writer.writeByte3((byte) 1, (byte) 2, (byte) 3);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 3]);
+        assertEquals((byte) 2, internalArray[defaultLen - 2]);
+        assertEquals((byte) 3, internalArray[defaultLen - 1]);
+        writer.skip(-2);
+        writer.writeByte3((byte) 1, (byte) 2, (byte) 3);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 2]);
+        assertEquals((byte) 2, internalArray[defaultLen - 1]);
+        assertEquals((byte) 3, internalArray[defaultLen]);
+
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeByte4((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 4]);
+        assertEquals((byte) 2, internalArray[defaultLen - 3]);
+        assertEquals((byte) 3, internalArray[defaultLen - 2]);
+        assertEquals((byte) 4, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeByte4((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 3]);
+        assertEquals((byte) 2, internalArray[defaultLen - 2]);
+        assertEquals((byte) 3, internalArray[defaultLen - 1]);
+        assertEquals((byte) 4, internalArray[defaultLen]);
+
+        // writeInt writes big-endian: 4 = {0, 0, 0, 4}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeInt(4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0, internalArray[defaultLen - 4]);
+        assertEquals((byte) 0, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 4, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeInt(4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        assertEquals((byte) 4, internalArray[defaultLen]);
+
+        // writeIntLE writes little-endian: 4 = {4, 0, 0, 0}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeIntLE(4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 4, internalArray[defaultLen - 4]);
+        assertEquals((byte) 0, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeIntLE(4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 4, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        assertEquals((byte) 0, internalArray[defaultLen]);
+
+        // writeLong writes big-endian: 8 = {0, 0, 0, 0, 0, 0, 0, 8}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 8);
+        writer.writeLong(8);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 8, internalArray[defaultLen - 1]);
+        writer.skip(-7);
+        writer.writeLong(8);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        assertEquals((byte) 8, internalArray[defaultLen]);
+
+        // writeFloatLE writes little-endian: 4.0f = 0x40800000 = {0x00, 0x00, 0x80, 0x40}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeFloatLE(4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 4]);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0x80, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0x40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeFloatLE(4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0x80, internalArray[defaultLen - 1]);
+        assertEquals((byte) 0x40, internalArray[defaultLen]);
+
+        // writeDoubleLE writes little-endian: 8.0 = 0x4020000000000000 = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20,
+        // 0x40}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 8);
+        writer.writeDoubleLE(8);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0x40, internalArray[defaultLen - 1]);
+        writer.skip(-7);
+        writer.writeDoubleLE(8);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x20, internalArray[defaultLen - 1]);
+        assertEquals((byte) 0x40, internalArray[defaultLen]);
+
+        byte[] array4 = new byte[] {10, 20, 30, 40};
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(array4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 4]);
+        assertEquals((byte) 20, internalArray[defaultLen - 3]);
+        assertEquals((byte) 30, internalArray[defaultLen - 2]);
+        assertEquals((byte) 40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeBytes(array4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 3]);
+        assertEquals((byte) 20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 30, internalArray[defaultLen - 1]);
+        assertEquals((byte) 40, internalArray[defaultLen]);
+
+        Bytes bytes4 = Bytes.wrap(new byte[] {10, 20, 30, 40});
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(bytes4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 4]);
+        assertEquals((byte) 20, internalArray[defaultLen - 3]);
+        assertEquals((byte) 30, internalArray[defaultLen - 2]);
+        assertEquals((byte) 40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeBytes(bytes4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 3]);
+        assertEquals((byte) 20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 30, internalArray[defaultLen - 1]);
+        assertEquals((byte) 40, internalArray[defaultLen]);
+
+        BufferedData bb4 = BufferedData.wrap(new byte[] {10, 20, 30, 40});
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(bb4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 4]);
+        assertEquals((byte) 20, internalArray[defaultLen - 3]);
+        assertEquals((byte) 30, internalArray[defaultLen - 2]);
+        assertEquals((byte) 40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        bb4.resetPosition();
+        writer.writeBytes(bb4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 3]);
+        assertEquals((byte) 20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 30, internalArray[defaultLen - 1]);
+        assertEquals((byte) 40, internalArray[defaultLen]);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        writer = new PbjWriter(baos);
+        writer.skip(defaultLen - 4);
+        bb4.resetPosition();
+        writer.writeBytes(bb4);
+        assertEquals(0, baos.size());
+
+        writer.skip(-3);
+        bb4.resetPosition();
+        writer.writeBytes(bb4);
+        assertEquals(defaultLen + 1, writer.position());
+
+        assertEquals(defaultLen, baos.size());
+        byte[] data = baos.toByteArray();
+        assertEquals(defaultLen, data.length);
+        assertEquals((byte) 10, data[defaultLen - 4]);
+
+        assertEquals((byte) 10, data[defaultLen - 3]);
+        assertEquals((byte) 20, data[defaultLen - 2]);
+        assertEquals((byte) 30, data[defaultLen - 1]);
+        // last byte inside internal buffer
+
+        // Again but the Bytes path
+        baos = new ByteArrayOutputStream();
+        writer = new PbjWriter(baos);
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(bytes4);
+        assertEquals(0, baos.size());
+
+        writer.skip(-3);
+        writer.writeBytes(bytes4);
+        assertEquals(defaultLen + 1, writer.position());
+
+        assertEquals(defaultLen, baos.size());
+        data = baos.toByteArray();
+        assertEquals(defaultLen, data.length);
+        assertEquals((byte) 10, data[defaultLen - 4]);
+
+        assertEquals((byte) 10, data[defaultLen - 3]);
+        assertEquals((byte) 20, data[defaultLen - 2]);
+        assertEquals((byte) 30, data[defaultLen - 1]);
+        // last byte inside internal buffer
+    }
+
+    @Test
+    void utf8EncodingTest() {
+        PbjWriter writer = new PbjWriter();
+        char arr[] = new char[6 << 10];
+        for (int i = 0; i < 127; i++) {
+            arr[i] = 'a';
+        }
+
+        writer.writeStringWithTag(new String(arr, 0, 127));
+        assertEquals(128, writer.position());
+
+        arr[50] = 'Ā';
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 127));
+        assertEquals(130, writer.position());
+
+        for (int i = 0; i < 127; i++) {
+            arr[i] = 'Ā';
+        }
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 127));
+        assertEquals(127 * 2 + 2, writer.position());
+
+        for (int i = 0; i < 5460; i++) {
+            arr[i] = 'b';
+        }
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 5460));
+        assertEquals(5460 + 2, writer.position());
+
+        for (int i = 0; i < 5460; i++) {
+            arr[i] = 'ā';
+        }
+
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 5460));
+        assertEquals(5460 * 2 + 2, writer.position());
+
+        for (int i = 0; i < 6 << 10; i++) {
+            arr[i] = (char) (32 + i);
+        }
+
+        writer.reset();
+        String str = new String(arr);
+        writer.writeStringWithTag(str);
+        String res = writer.toPbjReader().readString(1 << 20);
+        assertEquals(str, res);
+    }
+
+    @Test
+    void readerLimit() {
+        byte[] data = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+        PbjReader reader = new PbjReader(data);
+
+        assertTrue(reader.hasRemaining());
+        assertEquals(0, reader.position());
+        assertEquals(data.length, reader.limit());
+        reader.limit(0);
+        assertTrue(!reader.hasRemaining());
+        assertEquals(0, reader.position());
+
+        reader.limit(4);
+        assertTrue(reader.hasRemaining());
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        assertEquals(4, reader.position());
+        assertEquals(0, reader.readIntBE());
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void readerByteBufferConstructor() {
+        PbjReader reader = new PbjReader(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void readerResetWithByteBuffer() {
+        PbjReader reader = new PbjReader(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        reader.resetWith(ByteBuffer.wrap(new byte[] {5, 6, 7, 8}));
+        assertEquals(0, reader.position());
+        assertEquals(0x05060708, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readerBufferBytesConstructor() {
+        PbjReader reader = new PbjReader(Bytes.wrap(new byte[] {0x0A, 0x0B, 0x0C, 0x0D}));
+        assertEquals(0x0A0B0C0D, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void readerBufferInputStreamConstructor() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void readerSkipAdvancesPosition() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4, 5});
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertTrue(reader.hasRemaining());
+    }
+
+    @Test
+    void readerSkipBeyondDataSetsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4});
+        reader.skip(5);
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void readerResetAllowsReRead() {
+        byte[] data = {1, 2, 3, 4};
+        PbjReader reader = new PbjReader(data);
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        reader.resetWith(data);
+        assertEquals(0, reader.position());
+        assertTrue(reader.hasRemaining());
+        assertEquals(0x01020304, reader.readIntBE());
+    }
+
+    @Test
+    void readerResetWithReplacesBuffer() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4});
+        assertEquals(0x01020304, reader.readIntBE());
+        reader.resetWith(Bytes.wrap(new byte[] {5, 6, 7, 8}));
+        assertEquals(0x05060708, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void writeLargeBytesBypassInternalBuffer() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        writer.writeByte((byte) 7);
+        byte[] large = new byte[4096];
+        large[0] = 11;
+        large[4095] = 22;
+        writer.writeBytes(large);
+
+        byte[] result = baos.toByteArray();
+        assertEquals(4097, result.length);
+        assertEquals(7, result[0]);
+        assertEquals(11, result[1]);
+        assertEquals(22, result[4096]);
+
+        byte[] internalArray = writer.internalArray();
+        assertEquals(7, internalArray[0]);
+        assertEquals(0, internalArray[1]);
+    }
+
+    @Test
+    void writeBytesRandomAccessDataZeroLengthWritesNothing() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(Bytes.wrap(new byte[0]));
+        assertEquals(0, writer.position());
+        writer.writeBytes(Bytes.EMPTY);
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void writeBytesBufferedDataZeroRemainingWritesNothing() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(BufferedData.wrap(new byte[0]));
+        assertEquals(0, writer.position());
+
+        BufferedData bd = BufferedData.wrap(new byte[] {1, 2, 3});
+        bd.skip(3);
+        writer.writeBytes(bd);
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void writeBytesArrayZeroAndNegativeLengthWritesNothing() {
+        byte[] src = new byte[] {1, 2, 3, 4};
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(src, 0, 0);
+        assertEquals(0, writer.position());
+        writer.writeBytes(src, 0, -2);
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void quickTest() {
+        byte[] a = {2, 3};
+        var by = Bytes.wrap(a);
+        var adap = by.toReadableSequentialData();
+        var r = new PbjReader(adap);
+        var w = new PbjWriter();
+        w.setError(4, "");
+        int q = 0;
+    }
+
+    @Test
+    void largeWriteBypassCorrectness() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(out);
+
+        byte[] fewBytes = {1, 2, 3, 4, 5};
+        byte[] manyBytes = new byte[8_000];
+        Arrays.fill(manyBytes, (byte) 0x7F);
+
+        writer.writeBytes(fewBytes);
+        writer.writeBytes(manyBytes);
+        writer.flush();
+
+        byte[] expected = new byte[fewBytes.length + manyBytes.length];
+        System.arraycopy(fewBytes, 0, expected, 0, fewBytes.length);
+        System.arraycopy(manyBytes, 0, expected, fewBytes.length, manyBytes.length);
+
+        assertArrayEquals(
+                expected,
+                out.toByteArray(),
+                "Buffered prefix bytes must not be dropped when a large payload bypasses the buffer");
+    }
+
+    @Test
+    void writeBytesArrayFastPathBoundaryWithOutputStream() {
+
+        {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PbjWriter writer = new PbjWriter(baos);
+            byte[] src = new byte[2047];
+            src[0] = 11;
+            src[2046] = 22;
+            writer.writeBytes(src, 0, 2047);
+            assertEquals(11, writer.internalArray()[0]);
+            assertEquals(0, baos.toByteArray().length);
+            writer.reset();
+            baos.reset();
+            int internalLen = writer.internalArray().length;
+            writer.skip(internalLen - 1);
+            writer.writeBytes(src, 0, 2047);
+            assertEquals(internalLen - 1, baos.toByteArray().length);
+        }
+        {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PbjWriter writer = new PbjWriter(baos);
+            byte[] src = new byte[2048];
+            src[0] = 11;
+            src[2047] = 22;
+            writer.writeBytes(src, 0, 2048);
+            writer.flush();
+            assertEquals(0, writer.internalArray()[0]); // this length bypasses buffer
+            byte[] result = baos.toByteArray();
+            assertEquals(2048, result.length);
+            assertEquals((byte) 11, result[0]);
+            assertEquals((byte) 22, result[2047]);
+            byte[] internalArray = writer.internalArray();
+            assertEquals(0, internalArray[0]);
+            assertEquals(0, internalArray[2047]);
+        }
+    }
+
+    @Test
+    void writeBytesBufferedDataFlushThrowsPropagated() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("Called write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        byte[] chunk = new byte[1024]; // 2k is a fastpath
+        for (int i = 0; i < 16; i++) writer.writeBytes(chunk);
+        UncheckedIOException ex =
+                assertThrows(UncheckedIOException.class, () -> writer.writeBytes(BufferedData.wrap(new byte[] {1})));
+        assertEquals("java.io.IOException: Called write", ex.getMessage());
+    }
+
+    @Test
+    void writeLargeByteArrayFlushThrowsPropagated() {
+        OutputStream failOnLarge = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                if (len == 1) return;
+                if (len >= 2048) throw new IOException("2k write alt path");
+                throw new RuntimeException("Called write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failOnLarge);
+        writer.writeBoolean(true);
+        UncheckedIOException ex = assertThrows(UncheckedIOException.class, () -> writer.writeBytes(new byte[2048]));
+        assertEquals("java.io.IOException: 2k write alt path", ex.getMessage());
+    }
+
+    @Test
+    void writeBytesRandomAccessDataFlushThrowsPropagated() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("writeBytesRAInternal write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        byte[] chunk = new byte[1024];
+        for (int i = 0; i < 16; i++) writer.writeBytes(chunk); // fill 16k internal buffer
+        UncheckedIOException ex =
+                assertThrows(UncheckedIOException.class, () -> writer.writeBytes(Bytes.wrap(new byte[] {1})));
+        assertEquals("java.io.IOException: writeBytesRAInternal write", ex.getMessage());
+    }
+
+    @Test
+    void flushOrGrowFlushThrowsPropagated() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("Called write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        byte[] chunk = new byte[1024];
+        for (int i = 0; i < 16; i++) writer.writeBytes(chunk); // fill 16k internal buffer
+        UncheckedIOException ex = assertThrows(UncheckedIOException.class, () -> writer.writeByte((byte) 1));
+        assertEquals("java.io.IOException: Called write", ex.getMessage());
+    }
+
+    @Test
+    void flushPropagatesIOExceptionAsUnchecked() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("fake disk full");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        writer.writeByte((byte) 1);
+        UncheckedIOException ex = assertThrows(UncheckedIOException.class, writer::flush);
+        assertEquals("java.io.IOException: fake disk full", ex.getMessage());
+    }
+
+    @Test
+    void constructorWithWritableSequentialDataFlushesThrough() {
+        BufferedData bd = BufferedData.allocate(16);
+        PbjWriter writer = new PbjWriter(bd);
+        writer.writeByte2((byte) 10, (byte) 20);
+        writer.flush();
+        assertEquals(10, bd.getByte(0));
+        assertEquals(20, bd.getByte(1));
+        assertEquals(2, bd.position());
+    }
+
+    @Test
+    void resetWithWritableSequentialDataSwitchesOutput() {
+        ByteArrayOutputStream out1 = new ByteArrayOutputStream();
+        BufferedData bd = BufferedData.allocate(16);
+        PbjWriter writer = new PbjWriter(out1);
+        writer.writeByte((byte) 5);
+        writer.resetWith(bd);
+        writer.writeByte((byte) 7);
+        writer.flush();
+        assertArrayEquals(new byte[] {5}, out1.toByteArray()); // flushed to out1 during reset
+        assertEquals(7, bd.getByte(0));
+        assertEquals(1, bd.position());
+    }
+
+    @Test
+    void resetWithFlushesAndSwitchesOutput() {
+        ByteArrayOutputStream out1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(out1);
+        writer.writeByte((byte) 10);
+        assertEquals(0, out1.size());
+        writer.resetWith(out2); // flushes before reset
+        assertArrayEquals(new byte[] {10}, out1.toByteArray());
+
+        assertEquals(0, writer.position());
+        writer.writeByte((byte) 20);
+        writer.flush();
+        assertArrayEquals(new byte[] {20}, out2.toByteArray());
+        writer.writeByte((byte) 5);
+        writer.resetWithNull();
+        assertArrayEquals(new byte[] {20, 5}, out2.toByteArray());
+        writer.writeByte((byte) 7);
+        assertArrayEquals(new byte[] {7}, writer.toByteArray());
+        assertArrayEquals(new byte[] {20, 5}, out2.toByteArray());
+    }
+
+    @Test
+    void resetWithOnNonReuseableWriterSetsError() {
+        byte[] buf = new byte[64];
+        PbjWriter writer = new PbjWriter(buf, 0);
+        writer.resetWith(new ByteArrayOutputStream());
+        assertEquals(PbjWriter.UsageError, writer.error());
+    }
+
+    @Test
+    void bufferMoreBeyondAbsoluteLimitSetsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5}));
+        reader.limit(3);
+        assertEquals(1, reader.readByte());
+        assertEquals(2, reader.readByte());
+        assertEquals(3, reader.readByte());
+        assertEquals(false, reader.hasRemaining());
+        reader.readByte();
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void limitPropagatedToUnderlyingReadableSequentialData() {
+        BufferedData bd = BufferedData.allocate(8);
+        for (byte b = 0; b < 8; b++) bd.writeByte(b);
+        bd.flip();
+        PbjReader reader = new PbjReader(bd);
+        reader.limit(4);
+        reader.readByte();
+        assertEquals(4, bd.position());
+        assertEquals(1, reader.readByte());
+        assertEquals(2, reader.readByte());
+        assertEquals(3, reader.readByte());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void skipTriggersUnderflow() {
+        byte[] data = {1, 2, 3, 4, 5};
+        PbjReader reader = new PbjReader(data);
+        assertEquals(1, reader.readByte());
+        reader.skip(5);
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void skipInternalAccountsForBytesRemainingInBuffer() {
+        byte[] data = {1, 2, 3, 4, 5};
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(data));
+        assertEquals(1, reader.readByte());
+        reader.skip(5);
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void readVarLongWithMoreThanTenBytesSetsDataEncoding() {
+        byte[] malformed = new byte[16];
+        for (int i = 0; i < 16; i++) malformed[i] = (byte) 0xFF;
+        PbjReader reader = new PbjReader(malformed);
+        reader.readVarLongNoZZ();
+        assertEquals(PbjReader.DataEncoding, reader.error());
+        reader.resetWith(malformed);
+        reader.readVarLongBytes();
+        assertEquals(PbjReader.DataEncoding, reader.error());
+    }
+
+    @Test
+    void skipInternalSuccessfullySkipsFromInputStream() {
+        InputStream in = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
+        PbjReader reader = new PbjReader(in);
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertEquals(4, reader.readByte());
+    }
+
+    @Test
+    void skipInternalSuccessfullySkipsFromReadableSequentialData() {
+        BufferedData bd = BufferedData.allocate(8);
+        for (int i = 0; i < 5; i++) {
+            bd.writeByte((byte) i);
+        }
+        bd.flip();
+        PbjReader reader = new PbjReader(bd);
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertEquals(3, reader.readByte());
+    }
+
+    @Test
+    void skipInternalSetsIOErrorWhenInputStreamSkipThrows() {
+        InputStream in = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public long skip(long n) throws IOException {
+                throw new IOException("skip failed");
+            }
+        };
+        PbjReader reader = new PbjReader(in);
+        reader.skip(5);
+        assertEquals(PbjReader.IOError, reader.error());
+    }
+
+    @Test
+    void skipInternalCallsUnderlyingInputSkipForReadableSequentialData() {
+        BufferedData bd = BufferedData.allocate(8);
+        for (byte b = 0; b < 8; b++) bd.writeByte(b);
+        bd.flip();
+        PbjReader reader = new PbjReader(bd);
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertEquals(3, bd.position());
+        assertEquals(3, reader.readByte());
+    }
+
+    @Test
+    void readVarLongBytesReturnsWrappedBytesForValidVarint() {
+        PbjReader reader = new PbjReader(new byte[] {(byte) 0xAC, 0x02});
+        Bytes result = reader.readVarLongBytes();
+        assertEquals(2, result.length());
+        assertEquals((byte) 0xAC, result.getByte(0));
+        assertEquals((byte) 0x02, result.getByte(1));
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readLargeStringCantBeBuffered() {
+        int len = (16 << 10) + 1;
+        String str = "a".repeat(len);
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag(str);
+        PbjReader reader = writer.toPbjReader();
+        assertEquals(len, reader.readVarIntNoZZ());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readStringBufferedInternalSuccessPath() {
+        String str = "a".repeat(16384);
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag(str);
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(writer.toByteArray()));
+        assertEquals(str, reader.readString(16384 + 10));
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readStringBufferedInternalSuccessPathLarger() {
+        String str = "a".repeat(16385);
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag(str);
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(writer.toByteArray()));
+        assertEquals(str, reader.readString(16385 + 10));
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readFromInputSetsIOErrorWhenInputStreamReadThrows() {
+        InputStream failingOnSecondRead = new InputStream() {
+            private boolean doThrow = false;
+
+            @Override
+            public int read() {
+                return 1;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                if (doThrow) throw new IOException("io error");
+                doThrow = true;
+                b[off] = 25;
+                return 1;
+            }
+        };
+        PbjReader reader = new PbjReader(failingOnSecondRead);
+        reader.readByte();
+        assertEquals(PbjReader.IOError, reader.error());
+    }
+
+    @Test
+    void readStringLengthExceedsMaxSize() {
+        var reader = new PbjReader(new byte[] {5, 'h', 'e', 'l', 'l', 'o'});
+        assertEquals("", reader.readString(2));
+        assertEquals(PbjReader.Parse, reader.error());
+    }
+
+    @Test
+    void readStringNegativeLengthSetsParseError() {
+        var reader = new PbjReader(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x0F});
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.Parse, reader.error());
+    }
+
+    @Test
+    void readStringInvalidUtf8SetParseError() {
+        var reader = new PbjReader(new byte[] {1, (byte) 0x80});
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.Parse, reader.error());
+    }
+
+    @Test
+    void readStringReturnsEmptyOnInsufficientData() {
+        var reader = new PbjReader(new byte[] {5, 'a', 'b'}); // length=5 but only 2 bytes follow
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    ///// Reset /////
+
+    private static final byte[] DATA = {1, 2, 3, 4, 5};
+
+    @Test
+    void resetWithByteArraySequentialData_readsCorrectBytes() throws ParseException {
+        ReadableSequentialData byteArraySeq = Bytes.wrap(DATA).toReadableSequentialData();
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+
+        reader.resetWith(byteArraySeq);
+
+        for (byte expected : DATA) {
+            assertEquals(expected, reader.readByte());
+        }
+        reader.throwOnError();
+    }
+
+    @Test
+    void resetWithNonByteArraySequentialData_readsCorrectBytes() throws ParseException {
+        ReadableSequentialData buffered = BufferedData.wrap(DATA);
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+
+        reader.resetWith(buffered);
+
+        for (byte expected : DATA) {
+            assertEquals(expected, reader.readByte());
+        }
+        reader.throwOnError();
+    }
+
+    @Test
+    void resetWithInputStream_readsCorrectBytes() throws ParseException {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+
+        reader.resetWith(new ByteArrayInputStream(DATA));
+
+        for (byte expected : DATA) {
+            assertEquals(expected, reader.readByte());
+        }
+        reader.throwOnError();
+    }
+
+    @Test
+    void resetWithNull_throwsOnError() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+        reader.resetWith((ReadableSequentialData) null);
+        assertThrows(ParseException.class, reader::throwOnError);
+
+        PbjReader reader2 = new PbjReader(new ByteArrayInputStream(new byte[0]));
+        reader2.resetWith((ReadableSequentialData) null);
+        assertThrows(ParseException.class, reader2::throwOnError);
+    }
+
+    @Test
+    void resetFromBytesToStream() {
+        var reader = new PbjReader(new byte[] {1});
+        assertEquals((byte) 1, reader.readByte());
+        reader.resetWith(new ByteArrayInputStream(new byte[] {7, 8}));
+        assertEquals((byte) 7, reader.readByte());
+        assertEquals((byte) 8, reader.readByte());
+        assertEquals(0, reader.error());
+    }
+
+    //
+
+    @Test
+    void asInputStreamReturnsUnderlyingStreamIfNeverRead() {
+        var stream = new ByteArrayInputStream(new byte[] {1, 2, 3});
+        var reader = new PbjReader(stream);
+        assertSame(stream, reader.asInputStream());
+    }
+
+    @Test
+    void asInputStreamDelegatesToInputIfNeverRead() throws Exception {
+        var innerStream = new ByteArrayInputStream(new byte[] {21});
+        var reader = new PbjReader(new ReadableStreamingData(innerStream));
+        var is = reader.asInputStream();
+        assertNotNull(is);
+        assertEquals(21, is.read());
+    }
+
+    @Test
+    void asInputStreamForByteArrayReader() throws Exception {
+        var reader = new PbjReader(new byte[] {1, 2, 3});
+        var is = reader.asInputStream();
+        assertEquals(1, is.read());
+        assertEquals(2, is.read());
+        assertEquals(3, is.read());
+    }
+
+    @Test
+    void readIntLESlowPathSuccess() {
+        var reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x04030201, reader.readIntLE());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readLongLESlowPathSuccess() {
+        var reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}));
+        assertEquals(0x0807060504030201L, reader.readLongLE());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readIntLEUnderflow() {
+        var reader = new PbjReader(new byte[] {1, 2, 3}); // only 3 bytes, need 4
+        assertEquals(0, reader.readIntLE());
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void readLongLEUnderflow() {
+        var reader = new PbjReader(new byte[] {1, 2, 3, 4, 5, 6, 7}); // only 7 bytes, need 8
+        assertEquals(0L, reader.readLongLE());
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    ///// readBytes /////
+
+    @Test
+    void readBytesArrayOffsetLen_writesIntoCorrectSlice() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4, 5});
+        byte[] dst = new byte[7];
+        long n = reader.readBytes(dst, 2, 3);
+        assertEquals(3, n);
+        assertArrayEquals(new byte[] {0, 0, 1, 2, 3, 0, 0}, dst);
+    }
+
+    @Test
+    void readBytesIntoByteBuffer_dataReadAndPositionAdvances() {
+        PbjReader reader = new PbjReader(new byte[] {10, 20, 30});
+        ByteBuffer bb = ByteBuffer.allocate(5);
+        long n = reader.readBytes(bb);
+        assertEquals(3, n);
+        assertEquals(3, bb.position());
+        assertArrayEquals(new byte[] {10, 20, 30, 0, 0}, bb.array());
+    }
+
+    @Test
+    void readBytesIntoByteBuffer_positionUnchangedWhenError() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2});
+        reader.skip(10);
+        assertTrue(reader.error() > 0);
+        ByteBuffer bb = ByteBuffer.allocate(5);
+        long n = reader.readBytes(bb);
+        assertEquals(-1, n);
+        assertEquals(0, bb.position());
+    }
+
+    @Test
+    void readBytesInt_fastPath_bytesBuffered() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4, 5});
+        Bytes result = reader.readBytes(3);
+        assertEquals(3, result.length());
+        assertArrayEquals(new byte[] {1, 2, 3}, result.toByteArray());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readBytesInt_slowPath_triggersReadBytesInternal() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {7, 8, 9}));
+        Bytes result = reader.readBytes(3);
+        assertEquals(3, result.length());
+        assertArrayEquals(new byte[] {7, 8, 9}, result.toByteArray());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readBytesInternal_zeroLength_returnsEmpty() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2});
+        reader.skip(10);
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+        assertSame(Bytes.EMPTY, reader.readBytes(2));
+    }
+
+    @Test
+    void readBytesInternal_notEnoughData_setsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2}));
+        Bytes result = reader.readBytes(5);
+        assertSame(Bytes.EMPTY, result);
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void readLongBEInternal_streamingReaderSucceeds() {
+        byte[] bytes = {0, 0, 0, 0, 0, 0, 0, 7};
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(bytes));
+        assertEquals(7L, reader.readLongBE());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readLongBEInternal_notEnoughData_setsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3});
+        reader.readLongBE();
+        assertEquals(PbjReader.BufferUnderflow, reader.error());
+    }
+
+    @Test
+    void readBytesNegativeLengthSetsIllegalArgument() {
+        var reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5}));
+        reader.readByte();
+        reader.readByte();
+        reader.limit(0);
+        var result = reader.readBytes(-1);
+        assertEquals(Bytes.EMPTY, result);
+        assertEquals(PbjReader.IllegalArgument, reader.error());
+    }
+}

--- a/pbj-integration-tests/build.gradle.kts
+++ b/pbj-integration-tests/build.gradle.kts
@@ -164,6 +164,11 @@ testing {
             enableAssertions = false
             systemProperties["com.hedera.pbj.integration.test.fuzz.useRandomSeed"] = true
         }
+        tasks.register<Test>("testNoFuzz") {
+            testClassesDirs = sources.output.classesDirs
+            classpath = sources.runtimeClasspath
+            useJUnitPlatform { excludeTags("FUZZ_TEST") }
+        }
         targets.named("test") {
             testTask {
                 useJUnitPlatform { excludeTags("FUZZ_TEST") }


### PR DESCRIPTION
**Description**:

I didn't like how classes could have a 5 signature parse call a 3 signature overload ignoring some parameters (idr where I saw that, it was outside of obj). I would rather a consistent entry (which I'll use to call throwOnError in the future), and a consistent impl.

Here's a quick look. I may change (or rebase in the future) better javadoc.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

**Comments**

I noticed I couldn't make this final because sometimes a class overloads it and other times there's no impl

```java
    protected final int writeImpl(@NonNull T item, @NonNull byte[] output, final int startOffset) {
        final BufferedData bufferedData = BufferedData.wrap(output, startOffset, output.length - startOffset);
        try {
            write(item, bufferedData);
        } catch (IOException e) {
            throw new UncheckedIOException(e);
        }
        return (int) bufferedData.position();
    }
```

It seems like there's a chance they cane become inconsistent

```java
    protected int writeImpl(@NonNull MessageInProtoPackage data, @NonNull byte[] output, final int startOffset) {
        int offset = startOffset;
        // [1] - bytesField
        offset += ProtoArrayWriterTools.writeBytes(output, offset, MessageInProtoPackageSchema.BYTES_FIELD,  data.bytesField(), true);

        // Write unknown fields if there are any
        for (final UnknownField uf : data.getUnknownFields()) {
            final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
            offset += ProtoArrayWriterTools.writeUnsignedVarInt(output, offset, tag);
            offset += uf.bytes().writeTo(output, offset);
        }
        return offset - startOffset;
    }

    protected void writeImpl(@NonNull MessageInProtoPackage data, @NonNull final WritableSequentialData out) throws IOException {
            // [1] - bytesField
        writeBytes(out, MessageInProtoPackageSchema.BYTES_FIELD, data.bytesField(), true);

        // Check if not-empty to avoid creating a lambda if there's nothing to write.
        if (!data.getUnknownFields().isEmpty()) {
            data.getUnknownFields().forEach(uf -> {
                final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
                out.writeVarInt(tag, false);
                uf.bytes().writeTo(out);
            });
        }
    }
```