### PR TITLE
feat: Duplicate functions in ProtoParserTools.java

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
@@ -82,12 +83,32 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf int32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readInt32(PbjReader input) {
+        return input.readVarInt(false);
+    }
+
+    /**
      * Read a protobuf int64(long) from input
      *
      * @param input The input data to read from
      * @return the read long
      */
     public static long readInt64(final ReadableSequentialData input) {
+        return input.readVarLong(false);
+    }
+
+    /**
+     * Read a protobuf int64(long) from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readInt64(PbjReader input) {
         return input.readVarLong(false);
     }
 
@@ -102,12 +123,32 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf uint32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readUint32(PbjReader input) {
+        return input.readVarInt(false);
+    }
+
+    /**
      * Read a protobuf uint64 from input
      *
      * @param input The input data to read from
      * @return the read long
      */
     public static long readUint64(final ReadableSequentialData input) {
+        return input.readVarLong(false);
+    }
+
+    /**
+     * Read a protobuf uint64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readUint64(PbjReader input) {
         return input.readVarLong(false);
     }
 
@@ -127,12 +168,36 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf bool from input
+     *
+     * @param input The input data to read from
+     * @return the read boolean
+     */
+    public static boolean readBool(PbjReader input) {
+        final var i = input.readVarInt(false);
+        if (i != 1 && i != 0) {
+            input.setError(PbjReader.DATA_ENCODING);
+        }
+        return i == 1;
+    }
+
+    /**
      * Read a protobuf enum from input
      *
      * @param input The input data to read from
      * @return the read enum protoc ordinal
      */
     public static int readEnum(final ReadableSequentialData input) {
+        return input.readVarInt(false);
+    }
+
+    /**
+     * Read a protobuf enum from input
+     *
+     * @param input The input data to read from
+     * @return the read enum protoc ordinal
+     */
+    public static int readEnum(PbjReader input) {
         return input.readVarInt(false);
     }
 
@@ -147,6 +212,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf sint32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readSignedInt32(PbjReader input) {
+        return input.readVarIntZZ();
+    }
+
+    /**
      * Read a protobuf uint64(long) from input
      *
      * @param input The input data to read from
@@ -154,6 +229,16 @@ public final class ProtoParserTools {
      */
     public static long readSignedInt64(final ReadableSequentialData input) {
         return input.readVarLong(true);
+    }
+
+    /**
+     * Read a protobuf sint64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readSignedInt64(PbjReader input) {
+        return input.readVarLongZZ();
     }
 
     /**
@@ -167,6 +252,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf sfixed32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readSignedFixed32(PbjReader input) {
+        return input.readIntLE();
+    }
+
+    /**
      * Read a protobuf fixed32 from input
      *
      * @param input The input data to read from
@@ -174,6 +269,16 @@ public final class ProtoParserTools {
      */
     public static int readFixed32(final ReadableSequentialData input) {
         return input.readInt(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a protobuf fixed32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readFixed32(PbjReader input) {
+        return input.readIntLE();
     }
 
     /**
@@ -187,6 +292,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf float from input
+     *
+     * @param input The input data to read from
+     * @return the read float
+     */
+    public static float readFloat(PbjReader input) {
+        return input.readFloatLE();
+    }
+
+    /**
      * Read a protobuf sfixed64 from input
      *
      * @param input The input data to read from
@@ -194,6 +309,16 @@ public final class ProtoParserTools {
      */
     public static long readSignedFixed64(final ReadableSequentialData input) {
         return input.readLong(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a protobuf sfixed64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readSignedFixed64(final PbjReader input) {
+        return input.readLongLE();
     }
 
     /**
@@ -207,6 +332,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a fixed 64, which is a fixed size encoded long
+     *
+     * @param input the input to read from
+     * @return read long
+     */
+    public static long readFixed64(PbjReader input) {
+        return input.readLongLE();
+    }
+
+    /**
      * Read a double from input data
      *
      * @param input the input to read from
@@ -214,6 +349,16 @@ public final class ProtoParserTools {
      */
     public static double readDouble(final ReadableSequentialData input) {
         return input.readDouble(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a double from input data
+     *
+     * @param input the input to read from
+     * @return read double
+     */
+    public static double readDouble(PbjReader input) {
+        return input.readDoubleLE();
     }
 
     /**
@@ -228,6 +373,10 @@ public final class ProtoParserTools {
         } catch (ParseException ex) {
             throw new UncheckedParseException(ex);
         }
+    }
+
+    public static String readString(final PbjReader input) {
+        return readString(input, Long.MAX_VALUE);
     }
 
     /**
@@ -265,6 +414,17 @@ public final class ProtoParserTools {
         } catch (CharacterCodingException e) {
             throw new MalformedProtobufException("Malformed UTF-8 string encountered", e);
         }
+    }
+
+    /**
+     * Read a String field from data input
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return Read string
+     */
+    public static String readString(final PbjReader input, final long maxSize) {
+        return input.readString(maxSize);
     }
 
     private static int fromUTF8Tail(char[] dst, int di, byte[] src, int i, int endPos) {
@@ -436,6 +596,24 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a Bytes field from data input, setting an error on {@code input} if the Bytes in the input
+     * is longer than the maxSize.
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return read Bytes object, this can be a copy or a direct reference to inputs data. So it has same life span
+     * of InputData
+     */
+    public static Bytes readBytes(final PbjReader input, final long maxSize) {
+        final int length = input.readVarInt(false);
+        if (length > maxSize || length < 0) {
+            input.setError(PbjReader.PARSE);
+            return Bytes.EMPTY;
+        }
+        return input.readBytes(length);
+    }
+
+    /**
      * Reads a requested length-delimited protobuf field from the input and returns it as a
      * {@link Bytes} object. If the requested field is repeated or not length-delimited, this
      * method throws an {@link IllegalArgumentException}. .
@@ -494,6 +672,49 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Reads a requested length-delimited protobuf field from the input and returns it as a
+     * {@link Bytes} object. If the requested field is repeated or not length-delimited, this
+     * method throws an {@link IllegalArgumentException}. .
+     *
+     * <p>The input must contain valid protobuf encoded bytes. If the field is not found in
+     * the input {@code null} is returned. If the field occurs multiple time in the input, bytes
+     * for the first occurrence are returned.
+     *
+     * <p>The returned Bytes object, if not null, will not contain the tag or the length.
+     *
+     * @param input The input to read from
+     * @param field Field definition to extract bytes for
+     * @return Field bytes without tag or length, or {@code null} if the field is not found
+     *      in the input
+     */
+    @Nullable
+    public static Bytes extractFieldBytes(@NonNull final PbjReader input, @NonNull final FieldDefinition field) {
+        Objects.requireNonNull(input);
+        Objects.requireNonNull(field);
+        if (field.repeated()) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a repeated field: " + field);
+        }
+        if (ProtoWriterTools.wireType(field) != ProtoConstants.WIRE_TYPE_DELIMITED) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a non-length-delimited field: " + field);
+        }
+        while (input.hasRemaining()) {
+            final int tag = input.readVarIntNoZZ();
+            final int fieldNum = tag >> TAG_FIELD_OFFSET;
+            final ProtoConstants wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+            if (fieldNum == field.number()) {
+                if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    input.setError(PbjReader.PARSE);
+                }
+                final int length = input.readVarIntNoZZ();
+                return input.readBytes(length);
+            } else {
+                skipField(input, wireType);
+            }
+        }
+        return null;
+    }
+
+    /**
      * Extract the bytes in a stream for a given wire type. Assumes you have already read tag.
      *
      * @param input The input to move ahead
@@ -531,6 +752,50 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Extract the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     * @param maxSize the maximum allowed size for repeated/length-encoded fields
+     * @return the extracted bytes
+     */
+    public static Bytes extractField(final PbjReader input, final ProtoConstants wireType, final long maxSize) {
+        return switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.readBytes(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.readBytes(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLongBytes();
+            case WIRE_TYPE_DELIMITED -> {
+                final Bytes lenBytes = input.readVarLongBytes();
+                final int length = lenBytes.getVarInt(0, false);
+                if (length < 0) {
+                    input.setError(PbjReader.IO_ERROR);
+                    yield Bytes.EMPTY;
+                }
+                if (length > maxSize) {
+                    input.setError(PbjReader.PARSE);
+                    yield Bytes.EMPTY;
+                }
+                yield Bytes.merge(lenBytes, input.readBytes(length));
+            }
+            case WIRE_TYPE_GROUP_START -> {
+                input.setError(PbjReader.UNSUPPORTED);
+                yield Bytes.EMPTY;
+            }
+            case WIRE_TYPE_GROUP_END -> {
+                input.setError(PbjReader.UNSUPPORTED);
+                yield Bytes.EMPTY;
+            }
+            default -> {
+                input.setError(PbjReader.IO_ERROR);
+                yield Bytes.EMPTY;
+            }
+        };
+    }
+
+    /**
      * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
      *
      * @param input The input to move ahead
@@ -543,6 +808,16 @@ public final class ProtoParserTools {
         } catch (ParseException ex) {
             throw new UncheckedParseException(ex);
         }
+    }
+
+    /**
+     * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     */
+    public static void skipField(final PbjReader input, final ProtoConstants wireType) {
+        skipField(input, wireType, Long.MAX_VALUE);
     }
 
     /**
@@ -580,12 +855,54 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     * @param maxSize the maximum allowed size for repeated/length-encoded fields
+     */
+    public static void skipField(final PbjReader input, final ProtoConstants wireType, final long maxSize) {
+        switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.skip(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.skip(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLong(false);
+            case WIRE_TYPE_DELIMITED -> {
+                final int length = input.readVarIntNoZZ();
+                if (length < 0) {
+                    input.setError(PbjReader.IO_ERROR);
+                }
+                if (length > maxSize) {
+                    input.setError(PbjReader.PARSE);
+                }
+                input.skip(length);
+            }
+            case WIRE_TYPE_GROUP_START -> input.setError(PbjReader.UNSUPPORTED);
+            case WIRE_TYPE_GROUP_END -> input.setError(PbjReader.UNSUPPORTED);
+            default -> input.setError(PbjReader.IO_ERROR);
+        }
+    }
+
+    /**
      * Read the next field number from the input
      *
      * @param input The input data to read from
      * @return the read tag
      */
     public static int readNextFieldNumber(final ReadableSequentialData input) {
+        final int tag = input.readVarInt(false);
+        return tag >> TAG_FIELD_OFFSET;
+    }
+
+    /**
+     * Read the next field number from the input
+     *
+     * @param input The input data to read from
+     * @return the read tag
+     */
+    public static int readNextFieldNumber(final PbjReader input) {
         final int tag = input.readVarInt(false);
         return tag >> TAG_FIELD_OFFSET;
     }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -33,6 +33,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
@@ -358,7 +359,7 @@ class ProtoParserToolsTest {
     @Test
     void testExtractBytesNullInput() {
         final FieldDefinition field = createFieldDefinition(BYTES);
-        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes(null, field));
+        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes((PbjReader) null, field));
     }
 
     @Test


### PR DESCRIPTION
Adds PbjReader overloads alongside nearly every existing read method in ProtoParserTools, delegating to PbjReader's typed methods. Purely additive — no call sites switched yet.

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.
