### PR TITLE
feat: Duplicate functions in ProtoWriterTools.java

### DIFF
--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -5,6 +5,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -238,6 +239,10 @@ public abstract class Codec<T> {
      */
     public final void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         writeImpl(item, output);
+    }
+
+    public final void write(@NonNull T item, @NonNull PbjWriter output) {
+        // Next commit implements this
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
@@ -2,6 +2,7 @@
 package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import java.io.IOException;
 
 /**
@@ -19,4 +20,8 @@ public interface ProtoWriter<T> {
      * @throws IOException If there is a problem writing
      */
     void write(T data, WritableSequentialData out) throws IOException;
+
+    default void write(T data, PbjWriter out) {
+        // Next commit implements this
+    }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -5,6 +5,7 @@ import static com.hedera.pbj.runtime.ProtoConstants.*;
 
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.RandomAccessData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -60,6 +61,16 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a protobuf tag to the output. Field wire format is calculated based on field type.
+     *
+     * @param out The data output to write to
+     * @param field The field to write the tag for
+     */
+    public static void writeTag(PbjWriter out, final FieldDefinition field) {
+        writeTag(out, field, wireType(field));
+    }
+
+    /**
      * Write a protobuf tag to the output.
      *
      * @param out The data output to write to
@@ -68,6 +79,17 @@ public final class ProtoWriterTools {
      */
     public static void writeTag(
             final WritableSequentialData out, final FieldDefinition field, final ProtoConstants wireType) {
+        out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
+    }
+
+    /**
+     * Write a protobuf tag to the output.
+     *
+     * @param out The data output to write to
+     * @param field The field to include in tag
+     * @param wireType The field wire type to include in tag
+     */
+    public static void writeTag(PbjWriter out, final FieldDefinition field, final ProtoConstants wireType) {
         out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
     }
 
@@ -87,6 +109,17 @@ public final class ProtoWriterTools {
      * @param value the int value to write
      */
     public static void writeInteger(WritableSequentialData out, FieldDefinition field, int value) {
+        writeInteger(out, field, value, true);
+    }
+
+    /**
+     * Write a integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     */
+    public static void writeInteger(PbjWriter out, FieldDefinition field, int value) {
         writeInteger(out, field, value, true);
     }
 
@@ -133,6 +166,47 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeInteger(PbjWriter out, FieldDefinition field, int value, boolean skipDefault) {
+        assert switch (field.type()) {
+                    case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
+                    default -> false;
+                }
+                : "Not an integer type " + field;
+        assert !field.repeated() : "Use writeIntegerList with repeated types";
+
+        if (skipDefault && !field.oneOf() && value == 0) {
+            return;
+        }
+        switch (field.type()) {
+            case INT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarInt(value, false);
+            }
+            case UINT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(Integer.toUnsignedLong(value), false);
+            }
+            case SINT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarInt(value, true);
+            }
+            case SFIXED32, FIXED32 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
+                out.writeIntLE(value);
+            }
+            default -> throw unsupported();
+        }
+    }
+    /**
      * Write a long to data output
      *
      * @param out The data output to write to
@@ -140,6 +214,17 @@ public final class ProtoWriterTools {
      * @param value the long value to write
      */
     public static void writeLong(WritableSequentialData out, FieldDefinition field, long value) {
+        writeLong(out, field, value, true);
+    }
+
+    /**
+     * Write a long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the long value to write
+     */
+    public static void writeLong(PbjWriter out, FieldDefinition field, long value) {
         writeLong(out, field, value, true);
     }
 
@@ -181,6 +266,43 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the long value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeLong(PbjWriter out, FieldDefinition field, long value, boolean skipDefault) {
+        assert switch (field.type()) {
+                    case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> true;
+                    default -> false;
+                }
+                : "Not a long type " + field;
+        assert !field.repeated() : "Use writeLongList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0) {
+            return;
+        }
+        switch (field.type()) {
+            case INT64, UINT64 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(value, false);
+            }
+            case SINT64 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(value, true);
+            }
+            case SFIXED64, FIXED64 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_FIXED_64_BIT);
+                out.writeLongLE(value);
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a float to data output
      *
      * @param out The data output to write to
@@ -196,6 +318,24 @@ public final class ProtoWriterTools {
         }
         writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
         out.writeFloat(value, ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Write a float to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the float value to write
+     */
+    public static void writeFloat(PbjWriter out, FieldDefinition field, float value) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert !field.repeated() : "Use writeFloatList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
+        out.writeFloatLE(value);
     }
 
     /**
@@ -217,6 +357,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a double to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the double value to write
+     */
+    public static void writeDouble(PbjWriter out, FieldDefinition field, double value) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert !field.repeated() : "Use writeDoubleList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_FIXED_64_BIT);
+        out.writeDoubleLE(value);
+    }
+
+    /**
      * Write a boolean to data output
      *
      * @param out The data output to write to
@@ -224,6 +382,17 @@ public final class ProtoWriterTools {
      * @param value the boolean value to write
      */
     public static void writeBoolean(WritableSequentialData out, FieldDefinition field, boolean value) {
+        writeBoolean(out, field, value, true);
+    }
+
+    /**
+     * Write a boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
+     */
+    public static void writeBoolean(PbjWriter out, FieldDefinition field, boolean value) {
         writeBoolean(out, field, value, true);
     }
 
@@ -247,6 +416,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeBoolean(PbjWriter out, FieldDefinition field, boolean value, boolean skipDefault) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert !field.repeated() : "Use writeBooleanList with repeated types";
+        // In the case of oneOf we write the value even if it is default value of false
+        if (value || field.oneOf() || !skipDefault) {
+            writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+            out.writeByte(value ? (byte) 1 : 0);
+        }
+    }
+
+    /**
      * Write a enum to data output
      *
      * @param out The data output to write to
@@ -254,6 +441,24 @@ public final class ProtoWriterTools {
      * @param enumValue the enum value to write
      */
     public static void writeEnum(WritableSequentialData out, FieldDefinition field, EnumWithProtoMetadata enumValue) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert !field.repeated() : "Use writeEnumList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (enumValue == null || enumValue.protoOrdinal() == 0)) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        out.writeVarInt(enumValue.protoOrdinal(), false);
+    }
+
+    /**
+     * Write a enum to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param enumValue the enum value to write
+     */
+    public static void writeEnum(PbjWriter out, FieldDefinition field, EnumWithProtoMetadata enumValue) {
         assert field.type() == FieldType.ENUM : "Not an enum type " + field;
         assert !field.repeated() : "Use writeEnumList with repeated types";
         // When not a oneOf don't write default value
@@ -283,6 +488,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a enum protoOrdinal to data output.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param protoOrdinal the enum value to write
+     */
+    public static void writeEnumProtoOrdinal(PbjWriter out, FieldDefinition field, int protoOrdinal) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert !field.repeated() : "Use writeEnumList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && protoOrdinal == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        out.writeVarInt(protoOrdinal, false);
+    }
+
+    /**
      * Write a string to data output, assuming the field is non-repeated.
      *
      * @param out The data output to write to
@@ -301,12 +524,38 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing, the field must be non-repeated
      * @param value the string value to write
+     */
+    public static void writeString(PbjWriter out, final FieldDefinition field, final String value) {
+        writeString(out, field, value, true);
+    }
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
      * @param skipDefault default value results in no-op for non-oneOf
      * @throws IOException If a I/O error occurs
      */
     public static void writeString(
             final WritableSequentialData out, final FieldDefinition field, final String value, boolean skipDefault)
             throws IOException {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert !field.repeated() : "Use writeStringList with repeated types";
+        writeStringNoChecks(out, field, value, skipDefault);
+    }
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeString(
+            PbjWriter out, final FieldDefinition field, final String value, boolean skipDefault) {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert !field.repeated() : "Use writeStringList with repeated types";
         writeStringNoChecks(out, field, value, skipDefault);
@@ -330,7 +579,22 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a integer to data output - no validation checks.
+     * Write a string to data output, assuming the field is repeated. Usually this method is called multiple
+     * times, one for every repeated value. If all values are available immediately, {@link #writeStringList(
+     * PbjWriter, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     */
+    public static void writeOneRepeatedString(PbjWriter out, final FieldDefinition field, final String value) {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "writeOneRepeatedString can only be used with repeated fields";
+        writeStringNoChecks(out, field, value);
+    }
+
+    /**
+     * Write a string to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -343,7 +607,18 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a integer to data output - no validation checks.
+     * Write a string to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     */
+    private static void writeStringNoChecks(PbjWriter out, final FieldDefinition field, final String value) {
+        writeStringNoChecks(out, field, value, true);
+    }
+
+    /**
+     * Write a string to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -364,6 +639,25 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a string to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    private static void writeStringNoChecks(
+            PbjWriter out, final FieldDefinition field, final String value, boolean skipDefault) {
+        // When not a oneOf don't write default value
+        if (skipDefault && !field.oneOf() && (value == null || value.isEmpty())) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(sizeOfStringNoTag(value), false);
+        out.writeStringNoTag(value);
+    }
+
+    /**
      * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
      * is any delimited: bytes, string, or message.
      *
@@ -375,6 +669,18 @@ public final class ProtoWriterTools {
     public static void writeBytes(
             final WritableSequentialData out, final FieldDefinition field, final RandomAccessData value)
             throws IOException {
+        writeBytes(out, field, value, true);
+    }
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     */
+    public static void writeBytes(PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
         writeBytes(out, field, value, true);
     }
 
@@ -400,6 +706,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeBytes(
+            PbjWriter out, final FieldDefinition field, final RandomAccessData value, boolean skipDefault) {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert !field.repeated() : "Use writeBytesList with repeated types";
+        writeBytesNoChecks(out, field, value, skipDefault);
+    }
+
+    /**
      * Write a bytes to data output, assuming the corresponding field is repeated, and field type
      * is any delimited: bytes, string, or message. Usually this method is called multiple times, one
      * for every repeated value. If all values are available immediately, {@link #writeBytesList(
@@ -413,6 +735,22 @@ public final class ProtoWriterTools {
     public static void writeOneRepeatedBytes(
             final WritableSequentialData out, final FieldDefinition field, final RandomAccessData value)
             throws IOException {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
+        writeBytesNoChecks(out, field, value, true);
+    }
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is repeated, and field type
+     * is any delimited: bytes, string, or message. Usually this method is called multiple times, one
+     * for every repeated value. If all values are available immediately, {@link #writeBytesList(
+     * PbjWriter, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param value the bytes value to write
+     */
+    public static void writeOneRepeatedBytes(PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
         assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
         assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
         writeBytesNoChecks(out, field, value, true);
@@ -448,6 +786,35 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a bytes to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the bytes value to write
+     * @param skipZeroLength this is true for normal single bytes and false for repeated lists
+     */
+    private static void writeBytesNoChecks(
+            final PbjWriter out,
+            final FieldDefinition field,
+            final RandomAccessData value,
+            final boolean skipZeroLength) {
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (skipZeroLength && (value.length() == 0))) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(Math.toIntExact(value.length()), false);
+        final long posBefore = out.position();
+        out.writeBytes(value);
+        final long bytesWritten = out.position() - posBefore;
+        if (bytesWritten != value.length()) {
+            out.setError(
+                    PbjWriter.IO_ERROR,
+                    "Wrote less bytes [" + bytesWritten + "] than expected [" + value.length() + "]");
+        }
+    }
+
+    /**
      * Write a message to data output, assuming the corresponding field is non-repeated.
      *
      * @param out The data output to write to
@@ -460,6 +827,22 @@ public final class ProtoWriterTools {
     public static <T> void writeMessage(
             final WritableSequentialData out, final FieldDefinition field, final T message, final Codec<T> codec)
             throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert !field.repeated() : "Use writeMessageList with repeated types";
+        writeMessageNoChecks(out, field, message, codec);
+    }
+
+    /**
+     * Write a message to data output, assuming the corresponding field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    public static <T> void writeMessage(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert !field.repeated() : "Use writeMessageList with repeated types";
         writeMessageNoChecks(out, field, message, codec);
@@ -481,6 +864,24 @@ public final class ProtoWriterTools {
     public static <T> void writeOneRepeatedMessage(
             final WritableSequentialData out, final FieldDefinition field, final T message, final Codec<T> codec)
             throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "writeOneRepeatedMessage can only be used with repeated fields";
+        writeMessageNoChecks(out, field, message, codec);
+    }
+
+    /**
+     * Write a message to data output, assuming the corresponding field is repeated. Usually this method is
+     * called multiple times, one for every repeated value. If all values are available immediately, {@link
+     * #writeMessageList(PbjWriter, FieldDefinition, List, Codec)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    public static <T> void writeOneRepeatedMessage(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert field.repeated() : "writeOneRepeatedMessage can only be used with repeated fields";
         writeMessageNoChecks(out, field, message, codec);
@@ -513,15 +914,52 @@ public final class ProtoWriterTools {
         }
     }
 
+    /**
+     * Write a message to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    private static <T> void writeMessageNoChecks(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
+        // When not a oneOf don't write default value
+        if (field.oneOf() && message == null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            out.writeVarInt(0, false);
+        } else if (message != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final int size = codec.measureRecord(message);
+            out.writeVarInt(size, false);
+            if (size > 0) {
+                codec.write(message, out);
+            }
+        }
+    }
+
+    /**
+     * Write a map field to data output.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param map the map to write
+     * @param kWriter writer for the map key type
+     * @param vWriter writer for the map value type
+     * @param sizeOfK function that computes the encoded size of a key
+     * @param sizeOfV function that computes the encoded size of a value
+     * @param <K> type of map key
+     * @param <V> type of map value
+     */
     public static <K, V> void writeMap(
-            final WritableSequentialData out,
+            PbjWriter out,
             final FieldDefinition field,
             @NonNull final PbjMap<K, V> map,
             final ProtoWriter<K> kWriter,
             final ProtoWriter<V> vWriter,
             final ToIntFunction<K> sizeOfK,
-            final ToIntFunction<V> sizeOfV)
-            throws IOException {
+            final ToIntFunction<V> sizeOfV) {
         // https://protobuf.dev/programming-guides/proto3/#maps
         // On the wire, a map is equivalent to:
         //    message MapFieldEntry {
@@ -566,6 +1004,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional integer value to write
+     */
+    public static void writeOptionalInteger(PbjWriter out, FieldDefinition field, @Nullable Integer value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfInteger(newField, value), false);
+            writeInteger(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional long to data output
      *
      * @param out The data output to write to
@@ -573,6 +1027,22 @@ public final class ProtoWriterTools {
      * @param value the optional long value to write
      */
     public static void writeOptionalLong(WritableSequentialData out, FieldDefinition field, @Nullable Long value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfLong(newField, value), false);
+            writeLong(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional long value to write
+     */
+    public static void writeOptionalLong(PbjWriter out, FieldDefinition field, @Nullable Long value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -598,6 +1068,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional float to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional float value to write
+     */
+    public static void writeOptionalFloat(PbjWriter out, FieldDefinition field, @Nullable Float value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfFloat(newField, value), false);
+            writeFloat(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional double to data output
      *
      * @param out The data output to write to
@@ -605,6 +1091,22 @@ public final class ProtoWriterTools {
      * @param value the optional double value to write
      */
     public static void writeOptionalDouble(WritableSequentialData out, FieldDefinition field, @Nullable Double value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfDouble(newField, value), false);
+            writeDouble(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional double to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional double value to write
+     */
+    public static void writeOptionalDouble(PbjWriter out, FieldDefinition field, @Nullable Double value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -622,6 +1124,22 @@ public final class ProtoWriterTools {
      */
     public static void writeOptionalBoolean(
             WritableSequentialData out, FieldDefinition field, @Nullable Boolean value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfBoolean(newField, value), false);
+            writeBoolean(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional boolean value to write
+     */
+    public static void writeOptionalBoolean(PbjWriter out, FieldDefinition field, @Nullable Boolean value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -649,6 +1167,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional string to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional string value to write
+     */
+    public static void writeOptionalString(PbjWriter out, FieldDefinition field, @Nullable String value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfString(newField, value), false);
+            writeString(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional bytes to data output
      *
      * @param out The data output to write to
@@ -658,6 +1192,25 @@ public final class ProtoWriterTools {
      */
     public static void writeOptionalBytes(WritableSequentialData out, FieldDefinition field, @Nullable Bytes value)
             throws IOException {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            final int size = sizeOfBytes(newField, value);
+            out.writeVarInt(size, false);
+            if (size > 0) {
+                writeBytes(out, newField, value);
+            }
+        }
+    }
+
+    /**
+     * Write an optional bytes to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional bytes value to write
+     */
+    public static void writeOptionalBytes(PbjWriter out, FieldDefinition field, @Nullable Bytes value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -748,6 +1301,81 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of integers to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of integers value to write
+     */
+    public static void writeIntegerList(PbjWriter out, FieldDefinition field, List<Integer> list) {
+        assert switch (field.type()) {
+                    case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
+                    default -> false;
+                }
+                : "Not an integer type " + field;
+        assert field.repeated() : "Use writeInteger with non-repeated types";
+
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+
+        final int listSize = list.size();
+        switch (field.type()) {
+            case INT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfVarInt32(val);
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarInt(val, false);
+                }
+            }
+            case UINT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(Integer.toUnsignedLong(val));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarLong(Integer.toUnsignedLong(val), false);
+                }
+            }
+            case SINT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(((long) val << 1) ^ ((long) val >> 63));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarInt(val, true);
+                }
+            }
+            case SFIXED32, FIXED32 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarLong((long) list.size() * FIXED32_SIZE, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeIntLE(val);
+                }
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a list of longs to data output
      *
      * @param out The data output to write to
@@ -810,6 +1438,68 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of longs to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of longs value to write
+     */
+    public static void writeLongList(PbjWriter out, FieldDefinition field, List<Long> list) {
+        assert switch (field.type()) {
+                    case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> true;
+                    default -> false;
+                }
+                : "Not a long type " + field;
+        assert field.repeated() : "Use writeLong with non-repeated types";
+
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+
+        final int listSize = list.size();
+        switch (field.type()) {
+            case INT64, UINT64 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(val);
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeVarLong(val, false);
+                }
+            }
+            case SINT64 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    size += sizeOfUnsignedVarInt64((val << 1) ^ (val >> 63));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeVarLong(val, true);
+                }
+            }
+            case SFIXED64, FIXED64 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarLong((long) list.size() * FIXED64_SIZE, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeLongLE(val);
+                }
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a list of floats to data output
      *
      * @param out The data output to write to
@@ -829,6 +1519,29 @@ public final class ProtoWriterTools {
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             out.writeFloat(list.get(i), ByteOrder.LITTLE_ENDIAN);
+        }
+    }
+
+    /**
+     * Write a list of floats to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of floats value to write
+     */
+    public static void writeFloatList(PbjWriter out, FieldDefinition field, List<Float> list) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert field.repeated() : "Use writeFloat with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int size = list.size() * FIXED32_SIZE;
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            out.writeFloatLE(list.get(i));
         }
     }
 
@@ -856,6 +1569,29 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of doubles to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of doubles value to write
+     */
+    public static void writeDoubleList(PbjWriter out, FieldDefinition field, List<Double> list) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert field.repeated() : "Use writeDouble with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int size = list.size() * FIXED64_SIZE;
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            out.writeDoubleLE(list.get(i));
+        }
+    }
+
+    /**
      * Write a list of booleans to data output
      *
      * @param out The data output to write to
@@ -863,6 +1599,30 @@ public final class ProtoWriterTools {
      * @param list the list of booleans value to write
      */
     public static void writeBooleanList(WritableSequentialData out, FieldDefinition field, List<Boolean> list) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert field.repeated() : "Use writeBoolean with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        // write
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(list.size(), false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            final boolean b = list.get(i);
+            out.writeVarInt(b ? 1 : 0, false);
+        }
+    }
+
+    /**
+     * Write a list of booleans to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of booleans value to write
+     */
+    public static void writeBooleanList(PbjWriter out, FieldDefinition field, List<Boolean> list) {
         assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
         assert field.repeated() : "Use writeBoolean with non-repeated types";
         // When not a oneOf don't write default value
@@ -907,6 +1667,32 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of enums to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of enums value to write
+     */
+    public static void writeEnumListProtoOrdinals(PbjWriter out, FieldDefinition field, List<Integer> list) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert field.repeated() : "Use writeEnum with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            size += sizeOfUnsignedVarInt32(list.get(i));
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarInt(list.get(i), false);
+        }
+    }
+
+    /**
      * Write a list of strings to data output
      *
      * @param out The data output to write to
@@ -932,6 +1718,28 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of strings to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of strings value to write
+     */
+    public static void writeStringList(PbjWriter out, FieldDefinition field, List<String> list) {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "Use writeString with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            final String value = list.get(i);
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            out.writeStringWithTag(value);
+        }
+    }
+
+    /**
      * Write a list of messages to data output
      *
      * @param out The data output to write to
@@ -943,6 +1751,28 @@ public final class ProtoWriterTools {
      */
     public static <T> void writeMessageList(
             WritableSequentialData out, FieldDefinition field, List<T> list, Codec<T> codec) throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "Use writeMessage with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            writeMessageNoChecks(out, field, list.get(i), codec);
+        }
+    }
+
+    /**
+     * Write a list of messages to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of messages value to write
+     * @param codec the codec for the message type
+     * @param <T> type of message
+     */
+    public static <T> void writeMessageList(PbjWriter out, FieldDefinition field, List<T> list, Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert field.repeated() : "Use writeMessage with non-repeated types";
         // When not a oneOf don't write default value
@@ -979,6 +1809,26 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of bytes objects to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of bytes objects value to write
+     */
+    public static void writeBytesList(PbjWriter out, FieldDefinition field, List<? extends RandomAccessData> list) {
+        assert field.type() == FieldType.BYTES : "Not a message type " + field;
+        assert field.repeated() : "Use writeBytes with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            writeBytesNoChecks(out, field, list.get(i), false);
+        }
+    }
+
+    /**
      * Write a generic delimited field by delegating to a supplied `writer` to write the actual elements.
      *
      * @param out The data output to write to
@@ -989,6 +1839,21 @@ public final class ProtoWriterTools {
      */
     public static <T extends WritableSequentialData> void writeDelimited(
             final T out, final FieldDefinition field, final int size, final Consumer<T> writer) {
+        writeTag(out, field);
+        out.writeVarInt(size, false);
+        writer.accept(out);
+    }
+
+    /**
+     * Write a generic delimited field by delegating to a supplied `writer` to write the actual elements.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param size the size of all the elements together, in bytes
+     * @param writer the Consumer that accepts the `out` and writes the actual elements
+     */
+    public static void writeDelimited(
+            PbjWriter out, final FieldDefinition field, final int size, final Consumer<PbjWriter> writer) {
         writeTag(out, field);
         out.writeVarInt(size, false);
         writer.accept(out);


### PR DESCRIPTION
Mirrors the previous commit for writes. Also adds placeholder write(T, PbjWriter) stubs to Codec/ProtoWriter — scaffolding only, bodies deferred.

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.
