### PR TITLE
feat: Switched to PbjReader/PbjWriter

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
@@ -15,6 +15,7 @@ class CodecFastEqualsMethodGenerator {
 
     static String generateFastEqualsMethod(final String modelClassName, final List<Field> fields) {
         // Placeholder implementation, replace faster implementation than full parse if there is one
+        // spotless:off
         return """
                 /**
                  * Compares the given item with the bytes in the input, and returns false if it determines that
@@ -28,11 +29,12 @@ class CodecFastEqualsMethodGenerator {
                  * @return true if the bytes represent the item, false otherwise.
                  * @throws ParseException If parsing fails
                  */
-                public boolean fastEquals(@NonNull $modelClass item, @NonNull final ReadableSequentialData input) throws ParseException {
+                public boolean fastEquals(@NonNull $modelClass item, @NonNull final PbjReader input) throws ParseException {
                     return item.equals(parse(input));
                 }
                 """
                 .replace("$modelClass", modelClassName)
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
@@ -14,6 +14,7 @@ class CodecMeasureDataMethodGenerator {
 
     static String generateMeasureMethod(final String modelClassName, final List<Field> fields) {
         // Placeholder implementation, replace faster implementation than full parse if there is one
+        // spotless:off
         return """
                 /**
                  * Reads from this data input the length of the data within the input. The implementation may
@@ -24,7 +25,7 @@ class CodecMeasureDataMethodGenerator {
                  * @return The length of the data item in the input
                  * @throws ParseException If parsing fails
                  */
-                public int measure(@NonNull final ReadableSequentialData input) throws ParseException {
+                public int measure(@NonNull final PbjReader input) throws ParseException {
                     final var start = input.position();
                     parse(input);
                     final var end = input.position();
@@ -32,5 +33,6 @@ class CodecMeasureDataMethodGenerator {
                 }
                 """
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -59,7 +59,7 @@ class CodecParseMethodGenerator {
         // spotless:off
         return """
                 /**
-                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
+                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link PbjReader}. Throws if in strict mode ONLY.
                  * <p>
                  * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
                  * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
@@ -83,7 +83,7 @@ class CodecParseMethodGenerator {
                  * @throws ParseException If parsing fails
                  */
                 protected final @NonNull $modelClassName parseImpl(
-                        @NonNull final ReadableSequentialData input,
+                        @NonNull final PbjReader input,
                         final boolean strictMode,
                         final boolean parseUnknownFields,
                         final int maxDepth,
@@ -110,8 +110,8 @@ class CodecParseMethodGenerator {
                         throw new ParseException(anyException);
                     }
                 }
-                
-                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, ReadableSequentialData input, int maxSize) throws ParseException, IOException {
+
+                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, PbjReader input, int maxSize) throws ParseException, IOException {
                 $defaultCaseBody
                     return $unknownFields;
                 }
@@ -182,20 +182,9 @@ class CodecParseMethodGenerator {
                         // -- PARSE LOOP ---------------------------------------------
                         // Continue to parse bytes out of the input stream until we get to the end.
                         while (input.hasRemaining()) {
-                            // Note: ReadableStreamingData.hasRemaining() won't flip to false
-                            // until the end of stream is actually hit with a read operation.
-                            // So we catch this exception here and **only** here, because an EOFException
-                            // anywhere else suggests that we're processing malformed data and so
-                            // we must re-throw the exception then.
-                            final int $prefixtag;
-                            try {
-                                // Read the "tag" byte which gives us the field number for the next field to read
-                                // and the wire type (way it is encoded on the wire).
-                                $prefixtag = input.readVarInt(false);
-                            } catch (EOFException e) {
-                                // There's no more fields. Stop the parsing loop.
-                                break;
-                            }
+                            // Read the "tag" byte which gives us the field number for the next field to read
+                            // and the wire type (way it is encoded on the wire).
+                            final int $prefixtag = input.readVarInt(false);
 
                             // The field is the top 5 bits of the byte. Read this off
                             final int $prefixfield = $prefixtag >>> TAG_FIELD_OFFSET;
@@ -298,7 +287,7 @@ class CodecParseMethodGenerator {
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
         sbFunc.append("""
-%s case%d(ReadableSequentialData input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
+%s case%d(PbjReader input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         if (field.type() == Field.FieldType.ENUM) {
             preRead = """
@@ -371,9 +360,9 @@ class CodecParseMethodGenerator {
                                 input.limit(input.position() + valueTypeMessageSize);
                                 // read inner tag
                                 final int valueFieldTag = input.readVarInt(false);
-                                // assert tag is as expected
-                                assert (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
-                                assert (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
+                                // assert tag is as expected; skip if a read error is already pending
+                                assert input.error() != 0 || (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
+                                assert input.error() != 0 || (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
                                 // read value
                                 value = $readMethod;
                                 input.limit(beforeLimit);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -44,9 +44,8 @@ final class CodecWriteMethodGenerator {
              *
              * @param data The input model data to write
              * @param out The output stream to write to
-             * @throws IOException If there is a problem writing
              */
-            protected final void writeImpl(@NonNull $modelClass data, @NonNull final WritableSequentialData out) throws IOException {
+            protected final void writeImpl(@NonNull $modelClass data, @NonNull final PbjWriter out) {
                 $fieldWriteLines
                 // Check if not-empty to avoid creating a lambda if there's nothing to write.
                 if (!data.getUnknownFields().isEmpty()) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -3,13 +3,13 @@ package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.BufferedSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 
 /**
  * Encapsulates Serialization, Deserialization and other IO operations.
@@ -38,18 +38,100 @@ public abstract class Codec<T> {
      * consistent entry point. Subclasses implement this method rather than {@code parse} directly, since
      * {@code parse} may perform additional work before and after delegating to this implementation.
      *
+     * The only difference is it's allowed to return null, the parse overloads call throwOnError.
+     *
      * @see #parse(ReadableSequentialData, boolean, boolean, int, int) for a description
      */
-    @NonNull
     protected abstract T parseImpl(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException;
 
     /**
+     * Parses an object from the {@link PbjReader} and returns it.
+     * <p>
+     * If {@code strictMode} is {@code true}, then throws an exception if fields
+     * have been defined on the encoded object that are not supported by the parser. This
+     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
+     * which is sometimes requires to avoid parsing an object that is newer than the code
+     * parsing it is prepared to handle.
+     * <p>
+     * The {@code maxDepth} specifies the maximum allowed depth of nested messages. The parsing
+     * will fail with a ParseException if the maximum depth is reached.
+     * <p>
+     * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
+     * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
+     * payload can cause the parser to allocate too much memory which can result in OutOfMemory and/or crashes.
+     * It's important to carefully estimate the maximum size limit that a particular protobuf model type should support,
+     * and then pass that value as a parameter. Note that the estimated limit should apply to the **type** as a whole,
+     * rather than to individual instances of the model. In other words, this value should be a constant, or a config
+     * value that is controlled by the application, rather than come from the input that the application reads.
+     * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
+     *
+     * @param input The {@link PbjReader} from which to read the data to construct an object
+     * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+     * @param parseUnknownFields when {@code true} and strictMode is {@code false}, the parser will collect unknown
+     *                           fields in the unknownFields list in the model; otherwise they'll be simply skipped.
+     * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
+     * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        T res = parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+        input.throwOnError();
+        return res;
+    }
+
+    /**
+     * Same as parse, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
+     * Return value may be null
+     */
+    public final T parseNoEx(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+    }
+
+    /**
+     * Same as parseStrict, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
+     * Return value may be null
+     */
+    public final T parseNoEx(@NonNull PbjReader input) throws ParseException {
+        return parseNoEx(input, true, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Parses an object from the {@link PbjReader} and returns it, using the default `Codec.DEFAULT_MAX_SIZE` and
+     * `Codec.DEFAULT_MAX_DEPTH` limits, and without strict mode or unknown field collection.
+     *
+     * @param input The {@link PbjReader} from which to read the data to construct an object
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(@NonNull PbjReader input) throws ParseException {
+        return parse(input, false, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Writes the true, logical number of bytes consumed by {@code reader} (which may be less than the number of
+     * bytes {@code reader} has physically buffered ahead from {@code input}) back onto {@code input}'s position,
+     * so that further reads of a {@link BufferedSequentialData}-backed {@code input} continue exactly where the
+     * parsed message ended. A plain stream-backed {@code input} (not a {@link BufferedSequentialData}) cannot be
+     * rewound, so it is left as-is and must be treated as fully consumed by the caller.
+     */
+    private static void syncPosition(@NonNull ReadableSequentialData input, @NonNull PbjReader reader) {
+        if (input instanceof BufferedSequentialData bsd) {
+            bsd.position(reader.position());
+        }
+    }
+
+    /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -87,10 +169,17 @@ public abstract class Codec<T> {
             int maxDepth,
             int maxSize)
             throws ParseException {
-        return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return parse(reader, strictMode, parseUnknownFields, maxDepth, maxSize);
+        } finally {
+            syncPosition(input, reader);
+        }
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -119,6 +208,8 @@ public abstract class Codec<T> {
         return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
     }
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -162,10 +253,12 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
-        return parse(bytes.toReadableSequentialData(), strictMode, maxDepth);
+        return parse(new PbjReader(bytes), strictMode, false, maxDepth, DEFAULT_MAX_SIZE);
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      *
      * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
@@ -190,6 +283,8 @@ public abstract class Codec<T> {
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it. Throws an exception if fields
      * have been defined on the encoded object that are not supported by the parser. This
      * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
@@ -226,23 +321,45 @@ public abstract class Codec<T> {
      * consistent entry point. Subclasses implement this method rather than {@code write} directly, since
      * {@code write} may perform additional work before and after delegating to this implementation.
      *
-     * @see #write(Object, WritableSequentialData) for a description
+     * @see #write(Object, PbjWriter) for a description
      */
-    protected abstract void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException;
+    protected abstract void writeImpl(@NonNull T item, @NonNull PbjWriter output);
 
     /**
+     * Writes an item to the given {@link PbjWriter}.
+     *
+     * @param item The item to write. Must not be null.
+     * @param output The {@link PbjWriter} to write to.
+     */
+    public final void write(@NonNull T item, @NonNull PbjWriter output) {
+        writeImpl(item, output);
+        output.throwOnError();
+    }
+
+    /**
+     * Writes an item to the given {@link PbjWriter}.
+     *
+     * @param item The item to write. Must not be null.
+     * @param output The {@link PbjWriter} to write to.
+     */
+    public final void writeNoEx(@NonNull T item, @NonNull PbjWriter output) {
+        writeImpl(item, output);
+    }
+
+    /**
+     * Temporary for test compatibility
+     *
      * Writes an item to the given {@link WritableSequentialData}.
      *
      * @param item The item to write. Must not be null.
      * @param output The {@link WritableSequentialData} to write to.
      * @throws IOException If the {@link WritableSequentialData} cannot be written to.
      */
-    public final void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
-        writeImpl(item, output);
-    }
-
-    public final void write(@NonNull T item, @NonNull PbjWriter output) {
-        // Next commit implements this
+    public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+        final PbjWriter writer = new PbjWriter(output);
+        writeImpl(item, writer);
+        writer.flush();
+        writer.throwOnError();
     }
 
     /**
@@ -253,7 +370,7 @@ public abstract class Codec<T> {
      * @param output The byte array to write to, this must be large enough to hold the entire item.
      * @param startOffset The offset in the output array to start writing at.
      * @return The number of bytes written to the output array.
-     * @throws UncheckedIOException If the there is a problem writing to the output array.
+     * @throws RuntimeException If there is a problem writing to the output array.
      * @throws IndexOutOfBoundsException If the output array is not large enough to hold the entire item.
      */
     public final int write(@NonNull T item, @NonNull byte[] output, final int startOffset) {
@@ -267,18 +384,18 @@ public abstract class Codec<T> {
      * The actual byte-array writing logic for a specific codec, invoked by the {@link #write(Object, byte[], int)}
      * methods through a single, consistent entry point. Generated codecs override this method with a
      * performance-focused implementation; this default implementation delegates to
-     * {@link #writeImpl(Object, WritableSequentialData)} so that hand-written codecs don't need to provide one.
+     * {@link #writeImpl(Object, PbjWriter)} so that hand-written codecs don't need to provide one.
      *
      * @see #write(Object, byte[], int) for a description
      */
     protected int writeImpl(@NonNull T item, @NonNull byte[] output, final int startOffset) {
-        final BufferedData bufferedData = BufferedData.wrap(output, startOffset, output.length - startOffset);
+        final PbjWriter writer = new PbjWriter(output, startOffset);
         try {
-            write(item, bufferedData);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            writeImpl(item, writer);
+        } finally {
+            writer.flush();
         }
-        return (int) bufferedData.position();
+        return writer.position() - startOffset;
     }
 
     /**
@@ -290,7 +407,31 @@ public abstract class Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    public abstract int measure(@NonNull ReadableSequentialData input) throws ParseException;
+    public abstract int measure(@NonNull PbjReader input) throws ParseException;
+
+    /**
+     * Temporary for test compatibility
+     *
+     * Reads from this data input the length of the data within the input. The implementation may
+     * read all the data, or just some special serialized data, as needed to find out the length of
+     * the data.
+     * <p>
+     * If {@code input} is a {@link BufferedSequentialData} (e.g. {@code BufferedData}), its position is
+     * updated to reflect exactly the bytes consumed by this call. A plain stream-backed input should be
+     * treated as fully consumed afterward.
+     *
+     * @param input The input to use
+     * @return The length of the data item in the input
+     * @throws ParseException If parsing fails
+     */
+    public final int measure(@NonNull ReadableSequentialData input) throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return measure(reader);
+        } finally {
+            syncPosition(input, reader);
+        }
+    }
 
     /**
      * Compute number of bytes that would be written when calling {@code write()} method.
@@ -312,7 +453,34 @@ public abstract class Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public abstract boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException;
+    public abstract boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException;
+
+    /**
+     * Temporary for test compatibility
+     *
+     * Compares the given item with the bytes in the input, and returns false if it determines that
+     * the bytes in the input could not be equal to the given item. Sometimes we need to compare an
+     * item in memory with serialized bytes and don't want to incur the cost of deserializing the
+     * entire object, when we could have determined the bytes do not represent the same object very
+     * cheaply and quickly.
+     * <p>
+     * If {@code input} is a {@link BufferedSequentialData} (e.g. {@code BufferedData}), its position is
+     * updated to reflect exactly the bytes consumed by this call. A plain stream-backed input should be
+     * treated as fully consumed afterward.
+     *
+     * @param item The item to compare. Cannot be null.
+     * @param input The input with the bytes to compare
+     * @return true if the bytes represent the item, false otherwise.
+     * @throws ParseException If parsing fails
+     */
+    public final boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return fastEquals(item, reader);
+        } finally {
+            syncPosition(input, reader);
+        }
+    }
 
     /**
      * Converts a Record into a Bytes object
@@ -323,13 +491,14 @@ public abstract class Codec<T> {
      * to write to the {@link WritableStreamingData}
      */
     public Bytes toBytes(@NonNull T item) {
+        // TODO: Confirm if this next line is accurate with PbjWriter
         // it is cheaper performance wise to measure the size of the object first than grow a buffer as needed
         final byte[] bytes = new byte[measureRecord(item)];
-        final BufferedData bufferedData = BufferedData.wrap(bytes);
+        final PbjWriter writer = new PbjWriter(bytes, 0);
         try {
-            write(item, bufferedData);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            writeImpl(item, writer);
+        } finally {
+            writer.flush();
         }
         return Bytes.wrap(bytes);
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -21,7 +22,7 @@ public abstract class JsonCodec<T> extends Codec<T> {
     /** {@inheritDoc} */
     @Override
     protected final @NonNull T parseImpl(
-            @NonNull ReadableSequentialData input,
+            @NonNull PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -74,7 +75,19 @@ public abstract class JsonCodec<T> extends Codec<T> {
 
     /** {@inheritDoc} */
     @Override
-    protected final void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+    protected final void writeImpl(@NonNull T item, @NonNull PbjWriter output) {
+        output.writeStringNoTag(toJSON(item));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Writes directly via {@code output.writeUTF8(...)} instead of routing through a {@link PbjWriter}, since some
+     * {@link WritableSequentialData} implementations only support the string-level {@code writeUTF8} hook and not
+     * raw byte writes.
+     */
+    @Override
+    public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         output.writeUTF8(toJSON(item));
     }
     /**
@@ -118,7 +131,8 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    public final int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    @Override
+    public final int measure(@NonNull PbjReader input) throws ParseException {
         final long startPosition = input.position();
         parse(input);
         return (int) (input.position() - startPosition);
@@ -157,7 +171,8 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public final boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    @Override
+    public final boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException {
         return Objects.equals(item, parse(input));
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.jsonparser.JSONLexer;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -88,13 +88,13 @@ public final class JsonTools {
     // Parse Methods
 
     /**
-     * Parse a JSON string in a ReadableSequentialData into a JSON object.
+     * Parse a JSON string in a PbjReader into a JSON object.
      *
-     * @param input the ReadableSequentialData containing the JSON string
+     * @param input the PbjReader containing the JSON string
      * @return the Antlr JSON context object
      * @throws IOException if there was a problem parsing the JSON
      */
-    public static JSONParser.ObjContext parseJson(@NonNull final ReadableSequentialData input) throws IOException {
+    public static JSONParser.ObjContext parseJson(@NonNull final PbjReader input) throws IOException {
         final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
         final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
         final JSONParser.JsonContext jsonContext = parser.json();

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
@@ -1,27 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.PbjWriter;
-import java.io.IOException;
 
 /**
- * Interface for referencing the static write method from generated writer classes.
+ * Interface for referencing the static write method from generated writer classes
  *
  * @param <T> The model object that is being written
  */
 public interface ProtoWriter<T> {
 
     /**
-     * Write out a {@code T} model to output stream in protobuf format.
+     * Write out a {@code T} model to a {@link PbjWriter} in protobuf format.
      *
      * @param data The input model data to write
-     * @param out The output stream to write to
-     * @throws IOException If there is a problem writing
+     * @param writer The writer to write to
      */
-    void write(T data, WritableSequentialData out) throws IOException;
-
-    default void write(T data, PbjWriter out) {
-        // Next commit implements this
-    }
+    void write(T data, PbjWriter writer);
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -373,6 +373,15 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     }
 
     /**
+     * A helper method to copy buffer data into PbjWriter
+     *
+     * @param writer the PbjWriter to copy into
+     */
+    public void writeTo(@NonNull final PbjWriter writer) {
+        writer.writeBytes(buffer, start, length);
+    }
+
+    /**
      * A helper method for efficient copy of our data into an WritableSequentialData without creating a defensive copy
      * of the data. The implementation relies on a well-behaved WritableSequentialData that doesn't modify the buffer data.
      * The destination object may receive a direct reference to the underlying byte array, and it MUST NOT modify it.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -299,6 +299,15 @@ public class PbjReader implements AutoCloseable {
     }
 
     /**
+     * Returns the number of bytes remaining before the limit. This is not the byte length since a stream may return MAX_VALUE as its limit
+     *
+     * @return the number of bytes remaining
+     */
+    public long remaining() {
+        return limit() - position();
+    }
+
+    /**
      * Skips over {@code count} bytes, advancing the read position without returning the data.
      * Sets {@link #BUFFER_UNDERFLOW} if there are fewer than {@code count} bytes remaining.
      *

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link Codec#parse(com.hedera.pbj.runtime.io.ReadableSequentialData, boolean, boolean, int, int)},
+ * {@link Codec#measure(com.hedera.pbj.runtime.io.ReadableSequentialData)}, and
+ * {@link Codec#fastEquals(Object, com.hedera.pbj.runtime.io.ReadableSequentialData)}.
+ * <p>
+ * These methods wrap the caller's input in a {@link PbjReader}, which buffers up to 16KB ahead of what has
+ * actually been consumed. The tests here use a buffer with more than 16KB of trailing data after the
+ * encoded message, to confirm that buffering does not leak into the reported message length or the
+ * original input's position.
+ */
+class CodecParseMethodTest {
+
+    private static final LengthPrefixedCodec CODEC = new LengthPrefixedCodec();
+
+    private static BufferedData messageWithTrailingFiller(final byte[] payload, final byte[] filler) {
+        final byte[] backing = new byte[4 + payload.length + filler.length];
+        final BufferedData writable = BufferedData.wrap(backing);
+        writable.writeInt(payload.length);
+        writable.writeBytes(payload);
+        writable.writeBytes(filler);
+        return BufferedData.wrap(backing);
+    }
+
+    private static byte[] filler(final int size) {
+        final byte[] filler = new byte[size];
+        Arrays.fill(filler, (byte) 0x7F);
+        return filler;
+    }
+
+    @Test
+    void measureIsNotInflatedByTrailingData() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000); // larger than PbjReader's 16KB internal buffer
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        final int measured = CODEC.measure(data);
+
+        assertEquals(4 + payload.length, measured);
+    }
+
+    @Test
+    void measureLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        CODEC.measure(data);
+
+        assertEquals(4 + payload.length, data.position());
+        final byte[] remaining = new byte[filler.length];
+        data.readBytes(remaining);
+        assertArrayEquals(filler, remaining);
+    }
+
+    @Test
+    void parseLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        final LengthPrefixed parsed = CODEC.parse(data);
+
+        assertArrayEquals(payload, parsed.payload());
+        assertEquals(4 + payload.length, data.position());
+        final byte[] remaining = new byte[filler.length];
+        data.readBytes(remaining);
+        assertArrayEquals(filler, remaining);
+    }
+
+    @Test
+    void fastEqualsLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        assertTrue(CODEC.fastEquals(new LengthPrefixed(payload), data));
+
+        assertEquals(4 + payload.length, data.position());
+    }
+
+    private record LengthPrefixed(byte[] payload) {
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof LengthPrefixed other && Arrays.equals(payload, other.payload);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(payload);
+        }
+    }
+
+    private static final class LengthPrefixedCodec extends Codec<LengthPrefixed> {
+
+        @NonNull
+        @Override
+        protected LengthPrefixed parseImpl(
+                @NonNull final PbjReader input,
+                final boolean strictMode,
+                final boolean parseUnknownFields,
+                final int maxDepth,
+                final int maxSize)
+                throws ParseException {
+            final int length = input.readInt();
+            final byte[] payload = new byte[length];
+            if (input.readBytes(payload) != length) {
+                throw new ParseException("Failed to read payload bytes");
+            }
+            return new LengthPrefixed(payload);
+        }
+
+        @Override
+        protected void writeImpl(@NonNull final LengthPrefixed item, @NonNull final PbjWriter output) {
+            output.writeInt(item.payload().length);
+            output.writeBytes(item.payload());
+        }
+
+        @Override
+        public int measure(@NonNull final PbjReader input) throws ParseException {
+            final long start = input.position();
+            parse(input);
+            return (int) (input.position() - start);
+        }
+
+        @Override
+        public int measureRecord(final LengthPrefixed item) {
+            return 4 + item.payload().length;
+        }
+
+        @Override
+        public boolean fastEquals(@NonNull final LengthPrefixed item, @NonNull final PbjReader input)
+                throws ParseException {
+            return item.equals(parse(input));
+        }
+
+        @Override
+        public LengthPrefixed getDefaultInstance() {
+            return new LengthPrefixed(new byte[0]);
+        }
+    }
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.util.function.ToIntFunction;
 
 /**
@@ -25,22 +24,18 @@ class CodecWrapper<T> extends Codec<T> {
     @NonNull
     @Override
     protected T parseImpl(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+    protected void writeImpl(@NonNull T item, @NonNull PbjWriter output) {
         writer.write(item, output);
     }
 
     @Override
-    public int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    public int measure(@NonNull PbjReader input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 
@@ -50,7 +45,7 @@ class CodecWrapper<T> extends Codec<T> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    public boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
@@ -359,7 +359,9 @@ class ProtoParserToolsTest {
     @Test
     void testExtractBytesNullInput() {
         final FieldDefinition field = createFieldDefinition(BYTES);
-        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes((PbjReader) null, field));
+        assertThrows(
+                NullPointerException.class,
+                () -> ProtoParserTools.extractFieldBytes((ReadableSequentialData) null, field));
     }
 
     @Test
@@ -543,7 +545,7 @@ class ProtoParserToolsTest {
         @NonNull
         @Override
         protected final TestMessage parseImpl(
-                @NonNull final ReadableSequentialData in,
+                @NonNull final PbjReader in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
@@ -570,8 +572,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        protected final void writeImpl(@NonNull final TestMessage item, @NonNull final WritableSequentialData out)
-                throws IOException {
+        protected final void writeImpl(@NonNull final TestMessage item, @NonNull final PbjWriter out) {
             final String value = item.getValue();
             if (value != null) {
                 ProtoWriterTools.writeString(out, VALUE_FIELD, value);
@@ -579,7 +580,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public int measure(@NonNull ReadableSequentialData input) throws ParseException {
+        public int measure(@NonNull PbjReader input) throws ParseException {
             throw new UnsupportedOperationException();
         }
 
@@ -593,8 +594,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public boolean fastEquals(@NonNull TestMessage item, @NonNull ReadableSequentialData input)
-                throws ParseException {
+        public boolean fastEquals(@NonNull TestMessage item, @NonNull PbjReader input) throws ParseException {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
The actual cutover: Codec.parseImpl/writeImpl now take PbjReader/PbjWriter, with new parse/parseNoEx/write/writeNoEx entry points (old sequential-data methods kept temporarily as compatibility wrappers). Generators (CodecParseMethodGenerator, CodecWriteMethodGenerator, etc.) emit the new types and drop the old EOFException-catch idiom. JsonCodec/JsonTools/ProtoWriter updated similarly. Adds CodecParseMethodTest.

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.
