### PR TITLE
feat: Remove Exceptions

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -216,7 +216,7 @@ public record SingleField(
     @Override
     public String parseCode() {
         if (type == FieldType.MESSAGE) {
-            return "%s.PROTOBUF.parse(input, strictMode, parseUnknownFields, maxDepth - 1, maxSize)"
+            return "%s.PROTOBUF.parseNoEx(input, strictMode, parseUnknownFields, maxDepth - 1, maxSize)"
                     .formatted(messageType);
         } else {
             return "input";

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -421,7 +421,9 @@ public final class TestGenerator implements Generator {
                     assertEquals(charBuffer2, charBuffer);
                 
                     // Test JSON Reading
-                    final $modelClassName jsonReadPbj = $modelClassName.JSON.parse(JsonTools.parseJson(charBuffer), false, Integer.MAX_VALUE, Integer.MAX_VALUE);
+                    final var jsonReader = new PbjReader(new byte[0]);
+                    final $modelClassName jsonReadPbj = $modelClassName.JSON.parseNoEx(JsonTools.parseJson(charBuffer), jsonReader, false, Integer.MAX_VALUE, Integer.MAX_VALUE);
+                    jsonReader.throwOnError();
                     assertEquals(modelObj, jsonReadPbj);
                 }
                 

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -58,17 +58,20 @@ class JsonCodecParseMethodGenerator {
                  * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
                  *
                  * @param root The JSON parsed object tree to parse data from
-                 * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
-                 * @return Parsed HashObject model object or null if data input was null or empty
-                 * @throws ParseException If parsing fails
+                 * @param input the {@link PbjReader} used solely to carry error state for this parse; sets
+                 *              {@link PbjReader#PARSE} if the size of a delimited field exceeds the limit
+                 * @return Parsed HashObject model object, or {@code null} if data input was null or empty, or an
+                 *         error was set on {@code input}
                  */
-                protected final @NonNull $modelClassName parseImpl(
+                protected final $modelClassName parseImpl(
                         @Nullable final JSONParser.ObjContext root,
+                        @NonNull final PbjReader input,
                         final boolean strictMode,
                         final int maxDepth,
-                        final int maxSize) throws ParseException {
+                        final int maxSize) {
                     if (maxDepth < 0) {
-                        throw new ParseException("Reached maximum allowed depth of nested messages");
+                        input.setError(PbjReader.MAX_DEPTH_REACHED);
+                        return null;
                     }
                     try {
                         // -- TEMP STATE FIELDS --------------------------------------
@@ -82,7 +85,8 @@ class JsonCodecParseMethodGenerator {
                                 default: {
                                     if (strictMode) {
                                         // Since we are parsing is strict mode, this is an exceptional condition.
-                                        throw new UnknownFieldException(kvPair.STRING().getText());
+                                        input.setError(PbjReader.UNKNOWN_FIELD, kvPair.STRING().getText());
+                                        return null;
                                     }
                                 }
                             }
@@ -90,7 +94,8 @@ class JsonCodecParseMethodGenerator {
 
                         return new $modelClassName($fieldsList);
                     } catch (Exception ex) {
-                        throw new ParseException(ex);
+                        input.setError(PbjReader.PARSE, ex.getMessage());
+                        return null;
                     }
                 }
                 """.replace("$modelClassName", modelClassName)
@@ -150,7 +155,7 @@ class JsonCodecParseMethodGenerator {
         if (field.repeated()) {
             if (field.type() == Field.FieldType.MESSAGE) {
                 sb.append(("parseObjArray(checkSize(\"$fieldName\", $valueGetter.arr().value(), $maxSize), "
-                                + field.messageType() + ".JSON, maxDepth - 1, $maxSize)")
+                                + field.messageType() + ".JSON, input, maxDepth - 1, $maxSize)")
                         .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                         .replace("$fieldName", field.name()));
             } else {
@@ -228,7 +233,7 @@ class JsonCodecParseMethodGenerator {
             switch (field.type()) {
                 case MESSAGE ->
                     sb.append(field.javaFieldType()
-                            + ".JSON.parse($valueGetter.getChild(JSONParser.ObjContext.class, 0), false, maxDepth - 1, $maxSize)"
+                            + ".JSON.parseNoEx($valueGetter.getChild(JSONParser.ObjContext.class, 0), input, false, maxDepth - 1, $maxSize)"
                                     .replace(
                                             "$maxSize",
                                             field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize"));

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -77,41 +77,35 @@ class CodecParseMethodGenerator {
                  * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
                  * @param parseUnknownFields when {@code true} and strictMode is {@code false}, the parser will collect unknown
                  *                           fields in the unknownFields list in the model; otherwise they'll be simply skipped.
-                 * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
-                 * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
-                 * @return Parsed $modelClassName model object or null if data input was null or empty
-                 * @throws ParseException If parsing fails
+                 * @param maxDepth sets the {@link PbjReader#MAX_DEPTH_REACHED} error if the depth of nested messages exceeds it.
+                 * @param maxSize sets the {@link PbjReader#PARSE} error if the size of a delimited field exceeds the limit
+                 * @return Parsed $modelClassName model object, or {@code null} if an error was set on {@code input}
                  */
-                protected final @NonNull $modelClassName parseImpl(
+                protected final $modelClassName parseImpl(
                         @NonNull final PbjReader input,
                         final boolean strictMode,
                         final boolean parseUnknownFields,
                         final int maxDepth,
-                        final int maxSize) throws ParseException {
+                        final int maxSize) {
                     if (maxDepth < 0) {
-                        throw new ParseException("Reached maximum allowed depth of nested messages");
+                        input.setError(PbjReader.MAX_DEPTH_REACHED);
+                        return null;
                     }
-                    try {
-                        // -- TEMP STATE FIELDS --------------------------------------
+                    // -- TEMP STATE FIELDS --------------------------------------
                 $fieldDefs
-                        List<UnknownField> $unknownFields = null;
+                    List<UnknownField> $unknownFields = null;
 
-                        $parseLoop
+                    $parseLoop
                 $listFieldsWriteProtection
-                        if ($unknownFields != null) {
-                            Collections.sort($unknownFields);
-                            $initialSizeOfUnknownFieldsArray = Math.max($initialSizeOfUnknownFieldsArray, $unknownFields.size());
-                        }
-                $cacheableSupport
-                    } catch (final Exception anyException) {
-                        if (anyException instanceof ParseException parseException) {
-                            throw parseException;
-                        }
-                        throw new ParseException(anyException);
+                    if ($unknownFields != null) {
+                        Collections.sort($unknownFields);
+                        $initialSizeOfUnknownFieldsArray = Math.max($initialSizeOfUnknownFieldsArray, $unknownFields.size());
                     }
+                    if (input.error() > 0) return null;
+                $cacheableSupport
                 }
 
-                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, PbjReader input, int maxSize) throws ParseException, IOException {
+                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, PbjReader input, int maxSize) {
                 $defaultCaseBody
                     return $unknownFields;
                 }
@@ -204,20 +198,22 @@ class CodecParseMethodGenerator {
                         // handle error cases here, so we do not do if statements in normal loop
                         // Validate the field number is valid (must be > 0)
                         if ($prefixfield == 0) {
-                            throw new IOException("Bad protobuf encoding. We read a field value of "
+                            input.setError(PbjReader.IO_ERROR, "Bad protobuf encoding. We read a field value of "
                                 + $prefixfield);
+                            return $unknownFields;
                         }
                         // Validate the wire type is valid (must be >=0 && <= 5).
                         // Otherwise we cannot parse this.
                         // Note: it is always >= 0 at this point (see code above where it is defined).
                         if (wireType > 5) {
-                            throw new IOException("Cannot understand wire_type of " + wireType);
+                            input.setError(PbjReader.PARSE, "Cannot understand wire_type of " + wireType);
+                            return $unknownFields;
                         }
                         // It may be that the parser subclass doesn't know about this field
                         if ($prefixf == null) {
                             if (strictMode) {
-                                // Since we are parsing is strict mode, this is an exceptional condition.
-                                throw new UnknownFieldException($prefixfield);
+                                input.setError(PbjReader.UNKNOWN_FIELD, String.valueOf($prefixfield));
+                                return $unknownFields;
                             } else if (parseUnknownFields) {
                                 if ($unknownFields == null) {
                                     $unknownFields = new ArrayList<>($initialSizeOfUnknownFieldsArray);
@@ -233,8 +229,9 @@ class CodecParseMethodGenerator {
                                 skipField(input, ProtoConstants.get(wireType), $skipMaxSize);
                             }
                         } else {
-                            throw new IOException("Bad tag [" + $prefixtag + "], field [" + $prefixfield
+                            input.setError(PbjReader.IO_ERROR, "Bad tag [" + $prefixtag + "], field [" + $prefixfield
                                     + "] wireType [" + wireType + "]");
+                            return $unknownFields;
                         }""");
         for (int i = 0; i < list.size(); i++) {
             list.set(i, list.get(i)
@@ -287,7 +284,7 @@ class CodecParseMethodGenerator {
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
         sbFunc.append("""
-%s case%d(PbjReader input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
+%s case%d(PbjReader input, int maxSize, %s %s) {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         int divideAmount = fieldType.equals("List<Integer>") ? 2
             : fieldType.equals("List<Long>") ? 4
@@ -319,10 +316,12 @@ class CodecParseMethodGenerator {
                 // Read the length of packed repeated field data
                 final int length = input.readVarInt(false);
                 if (length > $maxSize) {
-                    throw new ParseException("$fieldName size " + length + " is greater than max " + $maxSize);
+                    input.setError(PbjReader.PARSE, "$fieldName size " + length + " is greater than max " + $maxSize);
+                    return $tempFieldName;
                 }
                 if (input.remaining() < length) {
-                    throw new BufferUnderflowException();
+                    input.setError(PbjReader.BUFFER_UNDERFLOW);
+                    return $tempFieldName;
                 }
                 final var startLimit = input.limit();
                 final long startPosition = input.position();
@@ -335,7 +334,7 @@ class CodecParseMethodGenerator {
                 $tempFieldName = list;
                 input.limit(startLimit);
                 if (input.position() != startPosition + length) {
-                    throw new BufferUnderflowException();
+                    input.setError(PbjReader.BUFFER_UNDERFLOW);
                 }"""
                 .replace("$tempFieldName", tempFieldName)
                 .replace("$preRead", preRead)
@@ -421,7 +420,8 @@ class CodecParseMethodGenerator {
                             value = $fieldType.DEFAULT;
                         } else {
                             if (messageLength > $maxSize) {
-                                throw new ParseException("$fieldName size " + messageLength + " is greater than max " + $maxSize);
+                                input.setError(PbjReader.PARSE, "$fieldName size " + messageLength + " is greater than max " + $maxSize);
+                                return null;
                             }
                             final var limitBefore = input.limit();
                             // Make sure that we have enough bytes in the message
@@ -429,18 +429,17 @@ class CodecParseMethodGenerator {
                             // If the buffer is truncated on the boundary of a subObject,
                             // we will not throw.
                             final var startPos = input.position();
-                            try {
-                                if ((startPos + messageLength) > limitBefore) {
-                                    throw new BufferUnderflowException();
-                                }
-                                input.limit(startPos + messageLength);
-                                value = $readMethod;
-                                // Make sure we read the full number of bytes. for the types
-                                if ((startPos + messageLength) != input.position()) {
-                                    throw new BufferOverflowException();
-                                }
-                            } finally {
-                                input.limit(limitBefore);
+                            if ((startPos + messageLength) > limitBefore) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
+                            }
+                            input.limit(startPos + messageLength);
+                            value = $readMethod;
+                            input.limit(limitBefore);
+                            // Make sure we read the full number of bytes. for the types
+                            if ((startPos + messageLength) != input.position()) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
                             }
                         }
                         """
@@ -461,11 +460,12 @@ class CodecParseMethodGenerator {
             // spotless:off
             sbCase.append("""
                         final var __map_messageLength = input.readVarInt(false);
-                        
+
                         $fieldDefs
                         if (__map_messageLength != 0) {
                             if (__map_messageLength > $maxSize) {
-                                throw new ParseException("$fieldName size " + __map_messageLength + " is greater than max " + $maxSize);
+                                input.setError(PbjReader.PARSE, "$fieldName size " + __map_messageLength + " is greater than max " + $maxSize);
+                                return null;
                             }
                             final var __map_limitBefore = input.limit();
                             // Make sure that we have enough bytes in the message
@@ -473,18 +473,17 @@ class CodecParseMethodGenerator {
                             // If the buffer is truncated on the boundary of a subObject,
                             // we will not throw.
                             final var __map_startPos = input.position();
-                            try {
-                                if ((__map_startPos + __map_messageLength) > __map_limitBefore) {
-                                    throw new BufferUnderflowException();
-                                }
-                                input.limit(__map_startPos + __map_messageLength);
+                            if ((__map_startPos + __map_messageLength) > __map_limitBefore) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
+                            }
+                            input.limit(__map_startPos + __map_messageLength);
                         $mapParseLoop
-                                // Make sure we read the full number of bytes. for the types
-                                if ((__map_startPos + __map_messageLength) != input.position()) {
-                                    throw new BufferOverflowException();
-                                }
-                            } finally {
-                                input.limit(__map_limitBefore);
+                            input.limit(__map_limitBefore);
+                            // Make sure we read the full number of bytes. for the types
+                            if ((__map_startPos + __map_messageLength) != input.position()) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
                             }
                         }
                         """
@@ -525,7 +524,8 @@ class CodecParseMethodGenerator {
             sbCase.append(
                 """
                 if (temp_%s.size() >= %s) {
-                    throw new ParseException("%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                    input.setError(PbjReader.PARSE, "%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                    return null;
                 }
                 temp_%1$s = addToList(temp_%1$s,value);
                 """.formatted(field.name(), field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
@@ -536,7 +536,8 @@ class CodecParseMethodGenerator {
                 """
                 if (__map_messageLength != 0) {
                     if (temp_%s.size() >= %s) {
-                        throw new ParseException("%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                        input.setError(PbjReader.PARSE, "%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                        return null;
                     }
                     temp_%1$s = addToMap(temp_%1$s, temp_%s, temp_%s);
                 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -43,8 +43,7 @@ public abstract class Codec<T> {
      * @see #parse(ReadableSequentialData, boolean, boolean, int, int) for a description
      */
     protected abstract T parseImpl(
-            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
-            throws ParseException;
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize);
 
     /**
      * Parses an object from the {@link PbjReader} and returns it.
@@ -90,8 +89,7 @@ public abstract class Codec<T> {
      * Return value may be null
      */
     public final T parseNoEx(
-            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
-            throws ParseException {
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
         return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
     }
 
@@ -99,7 +97,7 @@ public abstract class Codec<T> {
      * Same as parseStrict, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
      * Return value may be null
      */
-    public final T parseNoEx(@NonNull PbjReader input) throws ParseException {
+    public final T parseNoEx(@NonNull PbjReader input) {
         return parseNoEx(input, true, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -21,36 +21,34 @@ public abstract class JsonCodec<T> extends Codec<T> {
 
     /** {@inheritDoc} */
     @Override
-    protected final @NonNull T parseImpl(
+    protected final T parseImpl(
             @NonNull PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
-            final int maxSize)
-            throws ParseException {
-        try {
-            return parse(JsonTools.parseJson(input), strictMode, maxDepth, maxSize);
-        } catch (IOException ex) {
-            throw new ParseException(ex);
-        }
+            final int maxSize) {
+        return parseImpl(JsonTools.parseJson(input), input, strictMode, maxDepth, maxSize);
     }
 
     /**
-     * The actual parsing logic for a specific codec, invoked by the {@link #parse} methods through a single,
-     * consistent entry point. Subclasses implement this method rather than {@code parse} directly, since
-     * {@code parse} may perform additional work before and after delegating to this implementation.
+     * The actual parsing logic for a specific codec, invoked by the {@link #parseNoEx} methods through a single,
+     * consistent entry point. Subclasses implement this method rather than {@code parseNoEx} directly, since
+     * {@code parseNoEx} may perform additional work before and after delegating to this implementation.
      *
-     * @see #parse(JSONParser.ObjContext, boolean, int, int) for a description of each parameter
-     * @return The parsed object. It must not return null.
-     * @throws ParseException If parsing fails
+     * @see #parseNoEx(JSONParser.ObjContext, PbjReader, boolean, int, int) for a description of each parameter
+     * @return The parsed object, or {@code null} if an error was set on {@code input}
      */
-    @NonNull
     protected abstract T parseImpl(
-            @Nullable final JSONParser.ObjContext root, final boolean strictMode, final int maxDepth, final int maxSize)
-            throws ParseException;
+            @Nullable final JSONParser.ObjContext root,
+            @NonNull final PbjReader input,
+            final boolean strictMode,
+            final int maxDepth,
+            final int maxSize);
 
     /**
-     * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. Throws if in strict mode ONLY.
+     * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. Sets an error on
+     * {@code input} in strict mode ONLY. Same as parse, except doesn't throw. Check for error by using
+     * {@code input.error() != 0} (or {@code > 0}), or {@code input.ok()}. Return value may be null.
      * <p>
      * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
      * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
@@ -62,15 +60,17 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
      *
      * @param root The JSON parsed object tree to parse data from
-     * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
-     * @return Parsed HashObject model object or null if data input was null or empty
-     * @throws ParseException If parsing fails
+     * @param input the {@link PbjReader} used solely to carry error state for this parse; sets
+     *              {@link PbjReader#PARSE} if the size of a delimited field exceeds the limit
+     * @return Parsed HashObject model object, or {@code null} if data input was null or empty, or an error was set
      */
-    @NonNull
-    public final T parse(
-            @Nullable final JSONParser.ObjContext root, final boolean strictMode, final int maxDepth, final int maxSize)
-            throws ParseException {
-        return parseImpl(root, strictMode, maxDepth, maxSize);
+    public final T parseNoEx(
+            @Nullable final JSONParser.ObjContext root,
+            @NonNull final PbjReader input,
+            final boolean strictMode,
+            final int maxDepth,
+            final int maxSize) {
+        return parseImpl(root, input, strictMode, maxDepth, maxSize);
     }
 
     /** {@inheritDoc} */

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -8,6 +8,7 @@ import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.CharBuffer;
 import java.util.Base64;
 import java.util.List;
@@ -92,14 +93,17 @@ public final class JsonTools {
      *
      * @param input the PbjReader containing the JSON string
      * @return the Antlr JSON context object
-     * @throws IOException if there was a problem parsing the JSON
      */
-    public static JSONParser.ObjContext parseJson(@NonNull final PbjReader input) throws IOException {
-        final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
-        final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
-        final JSONParser.JsonContext jsonContext = parser.json();
-        final JSONParser.ValueContext valueContext = jsonContext.value();
-        return valueContext.obj();
+    public static JSONParser.ObjContext parseJson(@NonNull final PbjReader input) {
+        try {
+            final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
+            final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
+            final JSONParser.JsonContext jsonContext = parser.json();
+            final JSONParser.ValueContext valueContext = jsonContext.value();
+            return valueContext.obj();
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     /**
@@ -158,19 +162,18 @@ public final class JsonTools {
      *
      * @param list the JSON list to parse
      * @param codec the JsonCodec to use to parse the objects
+     * @param input the {@link PbjReader} used solely to carry error state for this parse
      * @return the list of parsed objects
      * @param <T> the type of the objects to parse
      */
     public static <T> List<T> parseObjArray(
-            List<JSONParser.ValueContext> list, JsonCodec<T> codec, final int maxDepth, final int maxSize) {
+            List<JSONParser.ValueContext> list,
+            JsonCodec<T> codec,
+            @NonNull final PbjReader input,
+            final int maxDepth,
+            final int maxSize) {
         return list.stream()
-                .map(v -> {
-                    try {
-                        return codec.parse(v.obj(), false, maxDepth - 1, maxSize);
-                    } catch (ParseException e) {
-                        throw new UncheckedParseException(e);
-                    }
-                })
+                .map(v -> codec.parseNoEx(v.obj(), input, false, maxDepth - 1, maxSize))
                 .toList();
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
@@ -114,12 +114,12 @@ class CodecParseMethodTest {
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
-                final int maxSize)
-                throws ParseException {
+                final int maxSize) {
             final int length = input.readInt();
             final byte[] payload = new byte[length];
             if (input.readBytes(payload) != length) {
-                throw new ParseException("Failed to read payload bytes");
+                input.setError(PbjReader.PARSE, "Failed to read payload bytes");
+                return null;
             }
             return new LengthPrefixed(payload);
         }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
@@ -24,8 +24,7 @@ class CodecWrapper<T> extends Codec<T> {
     @NonNull
     @Override
     protected T parseImpl(
-            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
-            throws ParseException {
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
         throw new UnsupportedOperationException();
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -549,8 +549,7 @@ class ProtoParserToolsTest {
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
-                final int maxSize)
-                throws ParseException {
+                final int maxSize) {
             String value = null;
             while (in.hasRemaining()) {
                 final int tag = in.readVarInt(false);
@@ -561,11 +560,13 @@ class ProtoParserToolsTest {
                     final int length = in.readVarInt(false);
                     final byte[] valueBytes = new byte[length];
                     if (in.readBytes(valueBytes) != length) {
-                        throw new ParseException("Failed to read value bytes");
+                        in.setError(PbjReader.PARSE, "Failed to read value bytes");
+                        return null;
                     }
                     value = new String(valueBytes, StandardCharsets.UTF_8);
                 } else {
-                    throw new ParseException("Unknown field: " + tag);
+                    in.setError(PbjReader.PARSE, "Unknown field: " + tag);
+                    return null;
                 }
             }
             return new TestMessage(value);


### PR DESCRIPTION
Generated parseImpl no longer declares throws ParseException/IOException; error paths now call input.setError(...) and return null, routed through a new parseNoEx entry point. Public throwing parse/parseStrict API is unchanged — it wraps parseNoEx and throws once at the top if an error was recorded.

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.
