### PR TITLE
feat: Indent fixes

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -264,7 +264,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.BOOL) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != $modelClassName.DEFAULT.$thatFieldName$suffix) {
-                               result = 31 * result + Boolean.hashCode($prefixFieldName$fieldName);
+                                result = 31 * result + Boolean.hashCode($prefixFieldName$fieldName);
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -275,7 +275,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.FLOAT) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != $modelClassName.DEFAULT.$thatFieldName$suffix) {
-                               result = 31 * result + Float.hashCode($prefixFieldName$fieldName);
+                                result = 31 * result + Float.hashCode($prefixFieldName$fieldName);
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -286,7 +286,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.DOUBLE) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != $modelClassName.DEFAULT.$thatFieldName$suffix) {
-                               result = 31 * result + Double.hashCode($prefixFieldName$fieldName);
+                                result = 31 * result + Double.hashCode($prefixFieldName$fieldName);
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -297,7 +297,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.BYTES) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != null && !$prefixFieldName$fieldName.equals($modelClassName.DEFAULT.$thatFieldName$suffix)) {
-                               result = 31 * result + $prefixFieldName$fieldName.hashCode();
+                                result = 31 * result + $prefixFieldName$fieldName.hashCode();
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -308,7 +308,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.ENUM) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != null && !$prefixFieldName$fieldName.equals($modelClassName.DEFAULT.$thatFieldName$suffix)) {
-                               result = 31 * result + Integer.hashCode(EnumWithProtoMetadata.protoOrdinal($prefixFieldName$fieldName));
+                                result = 31 * result + Integer.hashCode(EnumWithProtoMetadata.protoOrdinal($prefixFieldName$fieldName));
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -321,7 +321,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.STRING || f.parent() == null) { // process sub message
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != null && !$prefixFieldName$fieldName.equals($modelClassName.DEFAULT.$thatFieldName$suffix)) {
-                               result = 31 * result + $prefixFieldName$fieldName.hashCode();
+                                result = 31 * result + $prefixFieldName$fieldName.hashCode();
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -451,7 +451,7 @@ public final class Common {
                         } else {
                             result = 31 * result;
                         }
-                   }
+                    }
                 }
                 """)
                 .replace("$prefixFieldName", fieldNamePrefix)

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -53,7 +53,7 @@ public final class ModelGenerator implements Generator {
             hashCode += hashCode << 10;
             hashCode ^= hashCode >>> 24;
             hashCode += hashCode << 30;
-        """.indent(DEFAULT_INDENT * 2);
+        """;
 
     /**
      * {@inheritDoc}
@@ -570,7 +570,7 @@ public final class ModelGenerator implements Generator {
                     // This doesn't have unknown fields, but that one has some. So they are greater:
                     return -1;
                 }
-                """.indent(DEFAULT_INDENT);
+                """.indent(DEFAULT_INDENT * 2);
 
         bodyContent +=
             """
@@ -608,7 +608,7 @@ public final class ModelGenerator implements Generator {
 
         bodyContent +=
         """
-            $equalsBody
+        $equalsBody
         }"""
                 .replace("$equalsBody", generateEqualsBody(fields, javaRecordName, ""))
                 .indent(DEFAULT_INDENT);
@@ -624,7 +624,7 @@ public final class ModelGenerator implements Generator {
         // and calculates the hashcode.
         equalsStatements = Common.getFieldsEqualsStatements(fields, equalsStatements, prefixFieldName);
         // spotless:off
-        String bodyContent = equalsStatements.indent(DEFAULT_INDENT);
+        String bodyContent = equalsStatements;
         bodyContent +=
                 """
                     // Treat null and empty lists as equal
@@ -644,8 +644,7 @@ public final class ModelGenerator implements Generator {
                     }
                     return true;
                 """
-                        .replace("$thatUnknownFields", thatUnknownFields)
-                        .indent(DEFAULT_INDENT);
+                .replace("$thatUnknownFields", thatUnknownFields);
         // spotless:on
         return bodyContent;
     }
@@ -682,9 +681,10 @@ public final class ModelGenerator implements Generator {
                 }
                 return $hashCode;
             }
-            """.replace("$hashCodeManipulation", HASH_CODE_MANIPULATION)
-               .replace("$hashCodeBody", generateHashCodeBody(modelClassName, fields, "").indent(DEFAULT_INDENT))
-                .indent(DEFAULT_INDENT);
+            """
+            .replace("$hashCodeManipulation", HASH_CODE_MANIPULATION)
+            .replace("$hashCodeBody", generateHashCodeBody(modelClassName, fields, "").indent(DEFAULT_INDENT))
+            .indent(DEFAULT_INDENT);
         // spotless:on
         return bodyContent;
     }
@@ -894,7 +894,7 @@ public final class ModelGenerator implements Generator {
             }
         }
         // spotless:on
-        return sb.toString().indent(DEFAULT_INDENT);
+        return sb.toString();
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -75,13 +75,13 @@ class JsonCodecParseMethodGenerator {
                     }
                     try {
                         // -- TEMP STATE FIELDS --------------------------------------
-                        $fieldDefs
+                $fieldDefs
 
                         // -- EXTRACT VALUES FROM PARSE TREE ---------------------------------------------
 
                         for (JSONParser.PairContext kvPair : root.pair()) {
                             switch (toJsonFieldName(kvPair.STRING().getText())) {
-                                $caseStatements
+                $caseStatements
                                 default: {
                                     if (strictMode) {
                                         // Since we are parsing is strict mode, this is an exceptional condition.
@@ -102,13 +102,19 @@ class JsonCodecParseMethodGenerator {
                 .replace(
                         "$fieldDefs",
                         fields.stream()
-                                .map(field -> "    %s temp_%s = %s;"
+                                .map(field -> "%s temp_%s = %s;"
                                         .formatted(field.javaFieldType(), field.name(), field.javaDefault()))
-                                .collect(Collectors.joining("\n")))
+                                .collect(Collectors.joining("\n"))
+                                .indent(DEFAULT_INDENT * 2)
+                                .stripTrailing())
                 .replace(
                         "$fieldsList",
                         fields.stream().map(field -> "temp_" + field.name()).collect(Collectors.joining(", ")))
-                .replace("$caseStatements", generateCaseStatements(fields))
+                .replace(
+                        "$caseStatements",
+                        generateCaseStatements(fields)
+                                .indent(DEFAULT_INDENT * 4)
+                                .stripTrailing())
                 .indent(DEFAULT_INDENT);
     }
 
@@ -126,11 +132,12 @@ class JsonCodecParseMethodGenerator {
                 for (final Field subField : oneOfField.fields()) {
                     sb.append("case \"" + toJsonFieldName(subField.name()) + "\" /* [" + subField.fieldNumber()
                             + "] */ " + ": temp_"
-                            + oneOfField.name() + " = new %s<>(\n".formatted(oneOfField.className())
-                            + oneOfField.getEnumClassRef().indent(DEFAULT_INDENT)
-                            + "." + Common.camelToUpperSnake(subField.name()) + ", \n".indent(DEFAULT_INDENT));
-                    generateFieldCaseStatement(sb, subField, "kvPair.value()");
-                    sb.append("); break;\n");
+                            + oneOfField.name() + " = new %s<>(\n".formatted(oneOfField.className()));
+                    final StringBuilder valueSb = new StringBuilder();
+                    generateFieldCaseStatement(valueSb, subField, "kvPair.value()");
+                    sb.append((oneOfField.getEnumClassRef() + "." + Common.camelToUpperSnake(subField.name()) + ",\n"
+                                    + valueSb + "); break;\n")
+                            .indent(DEFAULT_INDENT));
                 }
             } else {
                 sb.append("case \"" + toJsonFieldName(field.name()) + "\" /* [" + field.fieldNumber() + "] */ "

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -147,9 +147,9 @@ public final class CodecGenerator implements Generator {
                     /**
                      * Empty constructor
                      */
-                     public $codecClass() {
-                         // no-op
-                     }
+                    public $codecClass() {
+                        // no-op
+                    }
 
                 $unsetOneOfConstants
                 $parseMethod

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
@@ -87,27 +87,29 @@ class CodecMeasureRecordMethodGenerator {
                     + switch (field.messageType()) {
                         case "StringValue" -> "size += sizeOfOptionalString(%s, %s);".formatted(fieldDef, getValueCode);
                         case "BoolValue" -> "size += sizeOfOptionalBoolean(%s, %s);".formatted(fieldDef, getValueCode);
-                        case "Int32Value", "UInt32Value" -> "size += sizeOfOptionalInteger(%s, %s);"
-                                .formatted(fieldDef, getValueCode);
-                        case "Int64Value", "UInt64Value" -> "size += sizeOfOptionalLong(%s, %s);"
-                                .formatted(fieldDef, getValueCode);
+                        case "Int32Value", "UInt32Value" ->
+                            "size += sizeOfOptionalInteger(%s, %s);".formatted(fieldDef, getValueCode);
+                        case "Int64Value", "UInt64Value" ->
+                            "size += sizeOfOptionalLong(%s, %s);".formatted(fieldDef, getValueCode);
                         case "FloatValue" -> "size += sizeOfOptionalFloat(%s, %s);".formatted(fieldDef, getValueCode);
                         case "DoubleValue" -> "size += sizeOfOptionalDouble(%s, %s);".formatted(fieldDef, getValueCode);
                         case "BytesValue" -> "size += sizeOfOptionalBytes(%s, %s);".formatted(fieldDef, getValueCode);
-                        default -> throw new UnsupportedOperationException(
-                                "Unhandled optional message type:" + field.messageType());
+                        default ->
+                            throw new UnsupportedOperationException(
+                                    "Unhandled optional message type:" + field.messageType());
                     };
         } else if (field.repeated()) {
             return prefix
                     + switch (field.type()) {
                         case ENUM -> "size += sizeOfEnumList(%s, %s);".formatted(fieldDef, getValueCode);
-                        case MESSAGE -> "size += sizeOfMessageList($fieldDef, $valueCode, $codec);"
-                                .replace("$fieldDef", fieldDef)
-                                .replace("$valueCode", getValueCode)
-                                .replace(
-                                        "$codec",
-                                        ((SingleField) field).messageTypeModelPackage() + "."
-                                                + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
+                        case MESSAGE ->
+                            "size += sizeOfMessageList($fieldDef, $valueCode, $codec);"
+                                    .replace("$fieldDef", fieldDef)
+                                    .replace("$valueCode", getValueCode)
+                                    .replace(
+                                            "$codec",
+                                            ((SingleField) field).messageTypeModelPackage() + "."
+                                                    + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
                         default -> "size += sizeOf%sList(%s, %s);".formatted(writeMethodName, fieldDef, getValueCode);
                     };
         } else if (field.type() == Field.FieldType.MAP) {
@@ -127,7 +129,7 @@ class CodecMeasureRecordMethodGenerator {
                                 final int sizePre = size;
                                 $K k = pbjMap.getSortedKeys().get(i);
                                 $V v = pbjMap.get(k);
-                                $fieldSizeOfLines
+                        $fieldSizeOfLines
                                 size += sizeOfVarInt32(size - sizePre);
                             }
                         }
@@ -137,24 +139,25 @@ class CodecMeasureRecordMethodGenerator {
                     .replace("$javaFieldType", mapField.javaFieldType())
                     .replace("$K", mapField.keyField().type().boxedType)
                     .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? mapField.valueField().messageType() : mapField.valueField().type().boxedType)
-                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
+                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT * 2))
                     ;
             // spotless:on
         } else {
             return prefix
                     + switch (field.type()) {
                         case ENUM -> "size += sizeOfEnum(%s, %s);".formatted(fieldDef, getValueCode);
-                        case STRING -> "size += sizeOfString(%s, %s, %s);"
-                                .formatted(fieldDef, getValueCode, skipDefault);
-                        case MESSAGE -> "size += sizeOfMessage($fieldDef, $valueCode, $codec);"
-                                .replace("$fieldDef", fieldDef)
-                                .replace("$valueCode", getValueCode)
-                                .replace(
-                                        "$codec",
-                                        ((SingleField) field).messageTypeModelPackage() + "."
-                                                + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
-                        case BOOL -> "size += sizeOfBoolean(%s, %s, %s);"
-                                .formatted(fieldDef, getValueCode, skipDefault);
+                        case STRING ->
+                            "size += sizeOfString(%s, %s, %s);".formatted(fieldDef, getValueCode, skipDefault);
+                        case MESSAGE ->
+                            "size += sizeOfMessage($fieldDef, $valueCode, $codec);"
+                                    .replace("$fieldDef", fieldDef)
+                                    .replace("$valueCode", getValueCode)
+                                    .replace(
+                                            "$codec",
+                                            ((SingleField) field).messageTypeModelPackage() + "."
+                                                    + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
+                        case BOOL ->
+                            "size += sizeOfBoolean(%s, %s, %s);".formatted(fieldDef, getValueCode, skipDefault);
                         case INT32,
                                 UINT32,
                                 SINT32,
@@ -165,8 +168,9 @@ class CodecMeasureRecordMethodGenerator {
                                 UINT64,
                                 FIXED64,
                                 SFIXED64,
-                                BYTES -> "size += sizeOf%s(%s, %s, %s);"
-                                .formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
+                                BYTES ->
+                            "size += sizeOf%s(%s, %s, %s);"
+                                    .formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
                         default -> "size += sizeOf%s(%s, %s);".formatted(writeMethodName, fieldDef, getValueCode);
                     };
         }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -95,7 +95,7 @@ class CodecParseMethodGenerator {
                 $fieldDefs
                     List<UnknownField> $unknownFields = null;
 
-                    $parseLoop
+                $parseLoop
                 $listFieldsWriteProtection
                     if ($unknownFields != null) {
                         Collections.sort($unknownFields);
@@ -110,29 +110,34 @@ class CodecParseMethodGenerator {
                     return $unknownFields;
                 }
                 """
-        .replace("$cacheableSupport", isCacheable ? generateCacheableSupport(modelClassName, fields) : "return new $modelClassName($fieldsList);")
+        .replace(
+                "$cacheableSupport",
+                isCacheable
+                        ? generateCacheableSupport(modelClassName, fields)
+                        : "return new $modelClassName($fieldsList);".indent(DEFAULT_INDENT).stripTrailing())
         .replace("$modelClassName",modelClassName)
         .replace("$fieldDefs",fields.stream().map(field -> {
             final String javaFieldType = field.type() == Field.FieldType.ENUM ? field.repeated() ? "List" :  "Object" : field.javaFieldType();
             return "%s temp_%s = %s;"
                     .formatted(javaFieldType, field.name(), field.javaDefault());
-        }).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT * 2).stripTrailing())
+        }).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT).stripTrailing())
         .replace("$fieldsList",
                 fields.stream().map(field -> "temp_"+field.name()).collect(Collectors.joining(", "))
                 + (fields.isEmpty() ? "" : ", ") + "$unknownFields"
         )
-        .replace("$parseLoop", parseAndDefaultBodyPair.parseBody().indent(DEFAULT_INDENT * 2).stripTrailing())
+        .replace("$parseLoop", parseAndDefaultBodyPair.parseBody().indent(DEFAULT_INDENT).stripTrailing())
         .replace("$defaultCaseBody", parseAndDefaultBodyPair.defaultBody().indent(DEFAULT_INDENT).stripTrailing())
         .replace("$listFieldsWriteProtection", fields.stream()
                 .filter(Field::repeated)
                 .map(field -> "if (temp_" + field.name() + " instanceof UnmodifiableArrayList ual) ual.makeReadOnly();")
                 .collect(Collectors.joining("\n"))
-                .indent(DEFAULT_INDENT * 2))
+                .indent(DEFAULT_INDENT))
         .indent(DEFAULT_INDENT);
         // spotless:on
     }
 
     static String generateCacheableSupport(String modelClassName, final List<Field> fields) {
+        // spotless:off
         return """
                 final int objectHashCode;
                 {
@@ -154,14 +159,16 @@ class CodecParseMethodGenerator {
                 _theObject = new $modelClassName($fieldsList, objectHashCode);
                 CACHE[objectHashCode & CACHE_KEY_MASK] = _theObject;
                 return _theObject;
-                """.replace("$hashCodeBody", ModelGenerator.generateHashCodeBody(modelClassName, fields, "temp_"))
+                """
+                .replace("$hashCodeBody", ModelGenerator.generateHashCodeBody(modelClassName, fields, "temp_"))
                 .replace(
                         "$equalsBody",
                         ModelGenerator.generateEqualsBody(fields, modelClassName, "temp_")
                                 .replace("return false", "yield false")
                                 .replace("return true", "yield true")
-                                .indent(DEFAULT_INDENT))
-                .indent(DEFAULT_INDENT * 2);
+                                .indent(DEFAULT_INDENT * 2))
+                .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 
     public record ParseAndDefaultBody(String parseBody, String defaultBody) {}
@@ -282,9 +289,9 @@ class CodecParseMethodGenerator {
         // spotless:off
         sbCase.append("case %d /* type=%d [%s] packed-repeated field=%d [%s] */ -> {%n"
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
-        sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
-        sbFunc.append("""
-%s case%d(PbjReader input, int maxSize, %s %s) {""".formatted(fieldType, tag, fieldType, tempFieldName));
+        sbCase.append("    %s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
+        sbFunc.append("    %s case%d(PbjReader input, int maxSize, %s %s) {\n"
+                .formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         int divideAmount = fieldType.equals("List<Integer>") ? 2
             : fieldType.equals("List<Long>") ? 4
@@ -300,10 +307,10 @@ class CodecParseMethodGenerator {
                     Object value = $enumName.fromProtobufOrdinal(enumOrdinal);
                     if (value == $enumName.UNRECOGNIZED) {
                         value = Integer.valueOf(enumOrdinal);
-                    }
-                    
-                    """
-                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true));
+                    }"""
+                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true))
+                    .indent(DEFAULT_INDENT)
+                    .stripTrailing();
         } else {
             preRead = "";
         }
@@ -329,13 +336,16 @@ class CodecParseMethodGenerator {
                 var list = new UnmodifiableArray$fieldType();
                 list.ensureCapacity(length$divideString);
                 while (input.hasRemaining()) {
-                    $preReadlist.add($readMethod);
+                $preRead
+                    list.add($readMethod);
                 }
                 $tempFieldName = list;
                 input.limit(startLimit);
                 if (input.position() != startPosition + length) {
                     input.setError(PbjReader.BUFFER_UNDERFLOW);
-                }"""
+                }
+                return $tempFieldName;
+                """
                 .replace("$tempFieldName", tempFieldName)
                 .replace("$preRead", preRead)
                 .replace("$fieldType", fieldType)
@@ -343,9 +353,9 @@ class CodecParseMethodGenerator {
                 .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                 .replace("$fieldName", field.name())
                 .replace("$divideString", divideAmount == 1 ? "" : "/%d".formatted(divideAmount))
-                .indent(DEFAULT_INDENT));
+                .indent(DEFAULT_INDENT * 2));
         sbCase.append("\n}\n");
-        sbFunc.append("    return %s;\n    }\n".formatted(tempFieldName));
+        sbFunc.append("    }\n");
         // spotless:on
     }
 
@@ -492,7 +502,7 @@ class CodecParseMethodGenerator {
                             "%s temp_%s = %s;".formatted(mapEntryField.javaFieldType(),
                             mapEntryField.name(), mapEntryField.javaDefault())).collect(Collectors.joining("\n")))
                     .replace("$mapParseLoop", parseAndDefaultBodyPair.parseBody()
-                            .indent(DEFAULT_INDENT * 2).stripTrailing())
+                            .indent(DEFAULT_INDENT).stripTrailing())
                     .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                     .indent(DEFAULT_INDENT)
             );

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
@@ -197,9 +197,9 @@ final class CodecWriteByteArrayMethodGenerator {
                                     $K k = pbjMap.getSortedKeys().get(i);
                                     $V v = pbjMap.get(k);
                                     int size = 0;
-                                    $fieldSizeOfLines
+                            $fieldSizeOfLines
                                     offset += ProtoArrayWriterTools.writeUnsignedVarInt(output, offset, size);
-                                    $fieldWriteLines
+                            $fieldWriteLines
                                 }
                             }
                             """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -46,7 +46,7 @@ final class CodecWriteMethodGenerator {
              * @param out The output stream to write to
              */
             protected final void writeImpl(@NonNull $modelClass data, @NonNull final PbjWriter out) {
-                $fieldWriteLines
+            $fieldWriteLines
                 // Check if not-empty to avoid creating a lambda if there's nothing to write.
                 if (!data.getUnknownFields().isEmpty()) {
                     data.getUnknownFields().forEach(uf -> {
@@ -176,9 +176,9 @@ final class CodecWriteMethodGenerator {
                                     $K k = pbjMap.getSortedKeys().get(i);
                                     $V v = pbjMap.get(k);
                                     int size = 0;
-                                    $fieldSizeOfLines
+                            $fieldSizeOfLines
                                     out.writeVarInt(size, false);
-                                    $fieldWriteLines
+                            $fieldWriteLines
                                 }
                             }
                             """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
@@ -50,7 +50,7 @@ public class LazyGetProtobufSizeMethodGenerator {
                 .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
                 .replace(
                         "$unknownFieldsSizeOfLines",
-                        formatUnknownFieldsSizeOfLines().indent(DEFAULT_INDENT))
+                        formatUnknownFieldsSizeOfLines().indent(DEFAULT_INDENT * 2))
                 .indent(DEFAULT_INDENT);
         // spotless:on
     }
@@ -113,8 +113,6 @@ public class LazyGetProtobufSizeMethodGenerator {
             prefix += "if (" + oneOfField.nameCamelFirstLower() + ".kind() == " + oneOfType + "."
                     + Common.camelToUpperSnake(field.name()) + ")";
             prefix += "\n";
-            // The statement below is the (unbraced) body of the "if" above, so indent it one level
-            // deeper than the "if" itself to make that visually clear.
             statementIndent = " ".repeat(DEFAULT_INDENT);
         }
 
@@ -170,7 +168,7 @@ public class LazyGetProtobufSizeMethodGenerator {
                                 final int sizePre = _size;
                                 $K k = pbjMap.getSortedKeys().get(i);
                                 $V v = pbjMap.get(k);
-                                $fieldSizeOfLines
+                        $fieldSizeOfLines
                                 _size += sizeOfVarInt32(_size - sizePre);
                             }
                         }


### PR DESCRIPTION
Formatting-only follow-up: generator templates emit less-nested code now that try/catch was removed, so template indentation is corrected to keep generated .java properly formatted. No functional change.

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.
