### PR TITLE
feat: Convert many toReadableSequentialData to toPbjReader

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -210,6 +210,7 @@ public final class ServiceGenerator {
                 methodLambda = "typedReplies -> " + name + "(typedReplies, options)";
             }
 
+            // spotless:off
             return """
                     case $methodName -> Pipelines.<$requestType, $replyType>$kind()
                             .mapRequest(bytes -> parse$simpleRequestType(bytes, options))
@@ -225,9 +226,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$kind", kind);
+            // spotless:on
         }
 
         private String formatUnaryMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -298,9 +301,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         private String formatClientStreamingMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -369,9 +374,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         private String formatServerStreamingMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -429,9 +436,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         private String formatBidiStreamingMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -496,6 +505,7 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         String formatMethodImplementation() {
@@ -771,7 +781,7 @@ public final class ServiceGenerator {
                     Objects.requireNonNull(options);
 
                     // not strict, no unknown fields, hard-code maxDepth for now, and use custom maxSize:
-                    return get$simpleRequestTypeCodec(options).parse(message.toReadableSequentialData(), false, false, 16, options.maxMessageSizeBytes());
+                    return get$simpleRequestTypeCodec(options).parse(message, false, false, 16, options.maxMessageSizeBytes());
                 }
                 """
                 .replace("$requestType", requestType)

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -242,7 +242,7 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
 
                         try {
                             final ReplyT reply = replyCodec.parse(
-                                    replyBytes.toReadableSequentialData(),
+                                    replyBytes,
                                     false,
                                     false,
                                     Codec.DEFAULT_MAX_DEPTH,

--- a/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
@@ -21,7 +21,6 @@ import com.hedera.pbj.runtime.grpc.GrpcException;
 import com.hedera.pbj.runtime.grpc.GrpcStatus;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
@@ -279,12 +278,7 @@ public class PbjGrpcCallTest {
         final Object reply = mock(Object.class);
         doReturn(reply)
                 .when(replyCodec)
-                .parse(
-                        any(ReadableSequentialData.class),
-                        eq(false),
-                        eq(false),
-                        eq(Codec.DEFAULT_MAX_DEPTH),
-                        eq(Codec.DEFAULT_MAX_SIZE));
+                .parse(any(Bytes.class), eq(false), eq(false), eq(Codec.DEFAULT_MAX_DEPTH), eq(Codec.DEFAULT_MAX_SIZE));
 
         runnable.run();
 
@@ -342,12 +336,7 @@ public class PbjGrpcCallTest {
         final ParseException exception = new ParseException("test");
         doThrow(exception)
                 .when(replyCodec)
-                .parse(
-                        any(ReadableSequentialData.class),
-                        eq(false),
-                        eq(false),
-                        eq(Codec.DEFAULT_MAX_DEPTH),
-                        eq(Codec.DEFAULT_MAX_SIZE));
+                .parse(any(Bytes.class), eq(false), eq(false), eq(Codec.DEFAULT_MAX_DEPTH), eq(Codec.DEFAULT_MAX_SIZE));
 
         runnable.run();
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -205,6 +205,12 @@ public abstract class Codec<T> {
             throws ParseException {
         return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
     }
+
+    @NonNull
+    public final T parse(@NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth)
+            throws ParseException {
+        return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
+    }
     /**
      * Temporary for test compatibility
      *
@@ -251,7 +257,45 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
-        return parse(new PbjReader(bytes), strictMode, false, maxDepth, DEFAULT_MAX_SIZE);
+        return parse(bytes, strictMode, false, maxDepth, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Parses an object from the {@link Bytes} and returns it.
+     * <p>
+     * If {@code strictMode} is {@code true}, then throws an exception if fields
+     * have been defined on the encoded object that are not supported by the parser. This
+     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
+     * which is sometimes requires to avoid parsing an object that is newer than the code
+     * parsing it is prepared to handle.
+     * <p>
+     * The {@code maxDepth} specifies the maximum allowed depth of nested messages. The parsing
+     * will fail with a ParseException if the maximum depth is reached.
+     * <p>
+     * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
+     * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
+     * payload can cause the parser to allocate too much memory which can result in OutOfMemory and/or crashes.
+     * It's important to carefully estimate the maximum size limit that a particular protobuf model type should support,
+     * and then pass that value as a parameter. Note that the estimated limit should apply to the **type** as a whole,
+     * rather than to individual instances of the model. In other words, this value should be a constant, or a config
+     * value that is controlled by the application, rather than come from the input that the application reads.
+     * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
+     *
+     * @param input The {@link Bytes} from which to read the data to construct an object
+     * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+     * @param parseUnknownFields when {@code true} and strictMode is {@code false}, the parser will collect unknown
+     *                           fields in the unknownFields list in the model; otherwise they'll be simply skipped.
+     * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
+     * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(
+            @NonNull Bytes input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        return parse(reader, strictMode, parseUnknownFields, maxDepth, maxSize);
     }
 
     /**
@@ -277,7 +321,7 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parse(@NonNull Bytes bytes) throws ParseException {
-        return parse(bytes.toReadableSequentialData());
+        return parse(bytes, false, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
     }
 
     /**
@@ -311,7 +355,7 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parseStrict(@NonNull Bytes bytes) throws ParseException {
-        return parseStrict(bytes.toReadableSequentialData());
+        return parse(bytes, true, DEFAULT_MAX_DEPTH);
     }
 
     /**
@@ -489,7 +533,7 @@ public abstract class Codec<T> {
      * to write to the {@link WritableStreamingData}
      */
     public Bytes toBytes(@NonNull T item) {
-        // TODO: Confirm if this next line is accurate with PbjWriter
+        // TODO: Confirm if this next line is still true with PbjWriter
         // it is cheaper performance wise to measure the size of the object first than grow a buffer as needed
         final byte[] bytes = new byte[measureRecord(item)];
         final PbjWriter writer = new PbjWriter(bytes, 0);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -90,6 +90,7 @@ public abstract class JsonCodec<T> extends Codec<T> {
     public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         output.writeUTF8(toJSON(item));
     }
+
     /**
      * Returns JSON string representing an item.
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -494,6 +494,16 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
         return new RandomAccessSequenceAdapter(this);
     }
 
+    /**
+     * Create and return a new {@link PbjReader} that is backed by this {@link Bytes}.
+     *
+     * @return A {@link PbjReader} backed by this {@link Bytes}.
+     */
+    @NonNull
+    public PbjReader toPbjReader() {
+        return new PbjReader(this);
+    }
+
     @NonNull
     public void resetPbjReader(@NonNull PbjReader reader) {
         reader.resetWith(buffer, start, start + length);

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -29,17 +29,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteOrder;
@@ -359,20 +356,18 @@ class ProtoParserToolsTest {
     @Test
     void testExtractBytesNullInput() {
         final FieldDefinition field = createFieldDefinition(BYTES);
-        assertThrows(
-                NullPointerException.class,
-                () -> ProtoParserTools.extractFieldBytes((ReadableSequentialData) null, field));
+        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes((PbjReader) null, field));
     }
 
     @Test
     void testExtractBytesNullField() {
-        final ReadableSequentialData input = Bytes.EMPTY.toReadableSequentialData();
+        final PbjReader input = Bytes.EMPTY.toPbjReader();
         assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes(input, null));
     }
 
     @Test
     void testExtractBytesRepeatedField() {
-        final ReadableSequentialData input = Bytes.EMPTY.toReadableSequentialData();
+        final PbjReader input = Bytes.EMPTY.toPbjReader();
         final FieldDefinition field = new FieldDefinition("field", FieldType.BYTES, true, true, false, 1);
         assertThrows(IllegalArgumentException.class, () -> ProtoParserTools.extractFieldBytes(input, field));
     }
@@ -407,22 +402,20 @@ class ProtoParserToolsTest {
     private static final FieldDefinition BOOL_F = new FieldDefinition("boolfield", BOOL, false, true, false, 11);
     private static final boolean BOOL_V = true;
 
-    private static Bytes prepareExtractBytesTestInput() throws IOException {
-        try (final ByteArrayOutputStream bout = new ByteArrayOutputStream();
-                final WritableStreamingData out = new WritableStreamingData(bout)) {
-            ProtoWriterTools.writeInteger(out, INT32_F, INT32_V);
-            ProtoWriterTools.writeInteger(out, FIXED_F, FIXED32_V);
-            ProtoWriterTools.writeString(out, STRING_F, STRING_V);
-            ProtoWriterTools.writeBytes(out, BYTES_F, BYTES_V);
-            ProtoWriterTools.writeMessage(out, MESSAGE_F, MESSAGE_V, TestMessageCodec.INSTANCE);
-            ProtoWriterTools.writeDouble(out, DOUBLE_F, DOUBLE32_V);
-            return Bytes.wrap(bout.toByteArray());
-        }
+    private static PbjReader prepareExtractBytesTestInput() throws IOException {
+        PbjWriter out = new PbjWriter();
+        ProtoWriterTools.writeInteger(out, INT32_F, INT32_V);
+        ProtoWriterTools.writeInteger(out, FIXED_F, FIXED32_V);
+        ProtoWriterTools.writeString(out, STRING_F, STRING_V);
+        ProtoWriterTools.writeBytes(out, BYTES_F, BYTES_V);
+        ProtoWriterTools.writeMessage(out, MESSAGE_F, MESSAGE_V, TestMessageCodec.INSTANCE);
+        ProtoWriterTools.writeDouble(out, DOUBLE_F, DOUBLE32_V);
+        return out.toPbjReader();
     }
 
     @Test
     void testExtractBytesStringField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, STRING_F);
         assertNotNull(bytes);
         assertEquals(STRING_V, new String(bytes.toByteArray(), StandardCharsets.UTF_8));
@@ -430,14 +423,14 @@ class ProtoParserToolsTest {
 
     @Test
     void testExtractFieldBytesInvalidType() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         // should throw because INT32 is not a delimited type
         assertThrows(IllegalArgumentException.class, () -> ProtoParserTools.extractFieldBytes(input, INT32_F));
     }
 
     @Test
     void testExtractBytesBytesField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, BYTES_F);
         assertNotNull(bytes);
         assertEquals(BYTES_V, bytes);
@@ -445,52 +438,58 @@ class ProtoParserToolsTest {
 
     @Test
     void testExtractBytesMessageField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, MESSAGE_F);
         assertNotNull(bytes);
-        final TestMessage value = TestMessageCodec.INSTANCE.parse(bytes.toReadableSequentialData());
+        final TestMessage value = TestMessageCodec.INSTANCE.parse(bytes);
         assertNotNull(value);
         assertEquals(MESSAGE_V, value);
     }
 
     @Test
     void testExtractBytesUnknownField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, UNKNOWN_F);
         assertNull(bytes);
     }
 
     @Test
     void testExtractField32Bit() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final var res = ProtoParserTools.extractField(input, WIRE_TYPE_FIXED_32_BIT, 32);
         assertNotNull(res);
     }
 
     @Test
     void testExtractField64Bit() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final var res = ProtoParserTools.extractField(input, WIRE_TYPE_FIXED_64_BIT, 32);
         assertNotNull(res);
     }
 
     @Test
     void testExtractFieldVarInt() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final var res = ProtoParserTools.extractField(input, WIRE_TYPE_VARINT_OR_ZIGZAG, 32);
         assertNotNull(res);
     }
 
     @Test
     void testExtractFieldGroupStartUnsupported() throws IOException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
-        assertThrows(IOException.class, () -> ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_START, 32));
+        final PbjReader input = prepareExtractBytesTestInput();
+        assertThrows(IOException.class, () -> {
+            ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_START, 32);
+            input.throwOnError2();
+        });
     }
 
     @Test
     void testExtractFieldGroupEndUnsupported() throws IOException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
-        assertThrows(IOException.class, () -> ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_END, 32));
+        final PbjReader input = prepareExtractBytesTestInput();
+        assertThrows(IOException.class, () -> {
+            ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_END, 32);
+            input.throwOnError2();
+        });
     }
 
     private static void skipTag(BufferedData data) {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
@@ -930,17 +930,6 @@ public class PbjReaderWriterTest {
     }
 
     @Test
-    void quickTest() {
-        byte[] a = {2, 3};
-        var by = Bytes.wrap(a);
-        var adap = by.toReadableSequentialData();
-        var r = new PbjReader(adap);
-        var w = new PbjWriter();
-        w.setError(4, "");
-        int q = 0;
-    }
-
-    @Test
     void largeWriteBypassCorrectness() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PbjWriter writer = new PbjWriter(out);

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/MaxSizeTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/MaxSizeTest.java
@@ -88,32 +88,22 @@ public class MaxSizeTest {
         final Bytes bytes = Everything.PROTOBUF.toBytes(everything);
 
         // Try negative cases first:
-        assertThrows(ParseException.class, () -> Everything.PROTOBUF.parse(bytes.toReadableSequentialData()));
+        assertThrows(ParseException.class, () -> Everything.PROTOBUF.parse(bytes));
         assertThrows(
                 ParseException.class,
-                () -> Everything.PROTOBUF.parse(
-                        bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, 256));
+                () -> Everything.PROTOBUF.parse(bytes, false, false, Codec.DEFAULT_MAX_DEPTH, 256));
         assertThrows(
                 ParseException.class,
-                () -> Everything.PROTOBUF.parse(
-                        bytes.toReadableSequentialData(),
-                        false,
-                        false,
-                        Codec.DEFAULT_MAX_DEPTH,
-                        Codec.DEFAULT_MAX_SIZE));
+                () -> Everything.PROTOBUF.parse(bytes, false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE));
         // +1 still shouldn't work because the outer and the inner objects are still larger:
         assertThrows(
                 ParseException.class,
                 () -> Everything.PROTOBUF.parse(
-                        bytes.toReadableSequentialData(),
-                        false,
-                        false,
-                        Codec.DEFAULT_MAX_DEPTH,
-                        Codec.DEFAULT_MAX_SIZE + 1));
+                        bytes, false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE + 1));
 
         // Now try supplying a large enough maxSize to parse it:
-        final Everything parsedEverything = Everything.PROTOBUF.parse(
-                bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE * 2);
+        final Everything parsedEverything =
+                Everything.PROTOBUF.parse(bytes, false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE * 2);
 
         assertEquals(everything, parsedEverything);
     }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnknownFieldsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnknownFieldsTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.integration.EverythingTestData;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.UnknownField;
@@ -58,8 +59,7 @@ public class UnknownFieldsTest {
         final Bytes bytes2 = MessageWithBytes.PROTOBUF.toBytes(msg2);
 
         // now read it as MessageWithBytesAndString, w/o even enabling unknown fields
-        final MessageWithBytesAndString msg3 =
-                MessageWithBytesAndString.PROTOBUF.parse(bytes2.toReadableSequentialData());
+        final MessageWithBytesAndString msg3 = MessageWithBytesAndString.PROTOBUF.parse(bytes2.toPbjReader());
 
         assertEquals(msg1, msg3);
     }
@@ -77,8 +77,8 @@ public class UnknownFieldsTest {
         assertEquals(0, msgWithUnknownFieldsDisabled.getUnknownFields().size());
 
         // Now let's enable parsing unknown fields:
-        final MessageWithEverythingUnknownFields msg = MessageWithEverythingUnknownFields.PROTOBUF.parse(
-                everythingBytes.toReadableSequentialData(), false, true, 16);
+        final MessageWithEverythingUnknownFields msg =
+                MessageWithEverythingUnknownFields.PROTOBUF.parse(everythingBytes.toPbjReader(), false, true, 16);
 
         assertEquals(0, msg.knownField());
         assertEquals(65, msg.getUnknownFields().size());
@@ -108,7 +108,7 @@ public class UnknownFieldsTest {
 
         // then read it as MessageWithBytes with unknown fields
         final MessageWithBytes messageWithBytes = MessageWithBytes.PROTOBUF.parse(
-                messageWithBytesAndStringBytes.toReadableSequentialData(), false, true, 16);
+                messageWithBytesAndStringBytes, false, true, 16, Codec.DEFAULT_MAX_SIZE);
 
         final MessageWithBytesWrapper messageWithBytesWrapper = new MessageWithBytesWrapper(
                 new OneOf<>(MessageWithBytesWrapper.MessageValidOneOfType.MESSAGE_WITH_BYTES, messageWithBytes));
@@ -122,7 +122,7 @@ public class UnknownFieldsTest {
 
         // parse bytes back as a receiving user would and confirm unknown fields exist in inner message
         final MessageWithBytesWrapper parsedWrapper = MessageWithBytesWrapper.PROTOBUF.parse(
-                messageWithBytesWrapperBytes.toReadableSequentialData(), false, true, 16);
+                messageWithBytesWrapperBytes, false, true, 16, Codec.DEFAULT_MAX_SIZE);
         MessageWithBytes parsedBytes = parsedWrapper.messageWithBytes();
         assertFalse(parsedBytes.getUnknownFields().isEmpty());
         assertEquals(1, parsedBytes.getUnknownFields().size());
@@ -130,7 +130,7 @@ public class UnknownFieldsTest {
         // now confirm that user can retrieve unknown fields when using expanded message MessageWithBytesAndString
         final Bytes messageWithBytesBytes = MessageWithBytes.PROTOBUF.toBytes(parsedBytes);
         final MessageWithBytesAndString messageWithBytesAndStringParsed =
-                MessageWithBytesAndString.PROTOBUF.parse(messageWithBytesBytes.toReadableSequentialData());
+                MessageWithBytesAndString.PROTOBUF.parse(messageWithBytesBytes);
         assertTrue(messageWithBytesAndStringParsed.getUnknownFields().isEmpty());
         assertEquals(messageWithBytesAndString, messageWithBytesAndStringParsed);
     }


### PR DESCRIPTION
Closes out remaining spots (gRPC client PbjGrpcCall, generated ServiceGenerator dispatch, Codec.parse(Bytes)/parseStrict(Bytes)) still using Bytes.toReadableSequentialData(), switching them to Bytes.toPbjReader()/new Codec.parse(Bytes, ...) overloads. Public behavior unchanged; tests/mocks updated.

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.
