### PR TITLE
perf: zz/noZZ

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -185,7 +185,7 @@ class CodecParseMethodGenerator {
                         while (input.hasRemaining()) {
                             // Read the "tag" byte which gives us the field number for the next field to read
                             // and the wire type (way it is encoded on the wire).
-                            final int $prefixtag = input.readVarInt(false);
+                            final int $prefixtag = input.readVarIntNoZZ();
 
                             // The field is the top 5 bits of the byte. Read this off
                             final int $prefixfield = $prefixtag >>> TAG_FIELD_OFFSET;
@@ -321,7 +321,7 @@ class CodecParseMethodGenerator {
 
         sbFunc.append("""
                 // Read the length of packed repeated field data
-                final int length = input.readVarInt(false);
+                final int length = input.readVarIntNoZZ();
                 if (length > $maxSize) {
                     input.setError(PbjReader.PARSE, "$fieldName size " + length + " is greater than max " + $maxSize);
                     return $tempFieldName;
@@ -379,13 +379,13 @@ class CodecParseMethodGenerator {
         if (field.optionalValueType()) {
             sbCase.append("""
                             // Read the message size, it is not needed
-                            final var valueTypeMessageSize = input.readVarInt(false);
+                            final var valueTypeMessageSize = input.readVarIntNoZZ();
                             final $fieldType value;
                             if (valueTypeMessageSize > 0) {
                                 final var beforeLimit = input.limit();
                                 input.limit(input.position() + valueTypeMessageSize);
                                 // read inner tag
-                                final int valueFieldTag = input.readVarInt(false);
+                                final int valueFieldTag = input.readVarIntNoZZ();
                                 // assert tag is as expected; skip if a read error is already pending
                                 assert input.error() != 0 || (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
                                 assert input.error() != 0 || (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
@@ -424,7 +424,7 @@ class CodecParseMethodGenerator {
         } else if (field.type() == Field.FieldType.MESSAGE) {
             // spotless:off
             sbCase.append("""
-                        final var messageLength = input.readVarInt(false);
+                        final var messageLength = input.readVarIntNoZZ();
                         final $fieldType value;
                         if (messageLength == 0) {
                             value = $fieldType.DEFAULT;
@@ -469,7 +469,7 @@ class CodecParseMethodGenerator {
                     generateCaseStatements(sbFunc, mapEntryFields, schemaClassName), "map_entry_", schemaClassName);
             // spotless:off
             sbCase.append("""
-                        final var __map_messageLength = input.readVarInt(false);
+                        final var __map_messageLength = input.readVarIntNoZZ();
 
                         $fieldDefs
                         if (__map_messageLength != 0) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -51,7 +51,7 @@ final class CodecWriteMethodGenerator {
                 if (!data.getUnknownFields().isEmpty()) {
                     data.getUnknownFields().forEach(uf -> {
                         final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
-                        out.writeVarInt(tag, false);
+                        out.writeVarIntNoZZ(tag);
                         uf.bytes().writeTo(out);
                     });
                 }
@@ -177,7 +177,7 @@ final class CodecWriteMethodGenerator {
                                     $V v = pbjMap.get(k);
                                     int size = 0;
                             $fieldSizeOfLines
-                                    out.writeVarInt(size, false);
+                                    out.writeVarIntNoZZ(size);
                             $fieldWriteLines
                                 }
                             }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -89,7 +89,7 @@ public final class ProtoParserTools {
      * @return the read int
      */
     public static int readInt32(PbjReader input) {
-        return input.readVarInt(false);
+        return input.readVarIntNoZZ();
     }
 
     /**
@@ -109,7 +109,7 @@ public final class ProtoParserTools {
      * @return the read long
      */
     public static long readInt64(PbjReader input) {
-        return input.readVarLong(false);
+        return input.readVarLongNoZZ();
     }
 
     /**
@@ -129,7 +129,7 @@ public final class ProtoParserTools {
      * @return the read int
      */
     public static int readUint32(PbjReader input) {
-        return input.readVarInt(false);
+        return input.readVarIntNoZZ();
     }
 
     /**
@@ -149,7 +149,7 @@ public final class ProtoParserTools {
      * @return the read long
      */
     public static long readUint64(PbjReader input) {
-        return input.readVarLong(false);
+        return input.readVarLongNoZZ();
     }
 
     /**
@@ -174,7 +174,7 @@ public final class ProtoParserTools {
      * @return the read boolean
      */
     public static boolean readBool(PbjReader input) {
-        final var i = input.readVarInt(false);
+        final var i = input.readVarIntNoZZ();
         if (i != 1 && i != 0) {
             input.setError(PbjReader.DATA_ENCODING);
         }
@@ -198,7 +198,7 @@ public final class ProtoParserTools {
      * @return the read enum protoc ordinal
      */
     public static int readEnum(PbjReader input) {
-        return input.readVarInt(false);
+        return input.readVarIntNoZZ();
     }
 
     /**
@@ -605,7 +605,7 @@ public final class ProtoParserTools {
      * of InputData
      */
     public static Bytes readBytes(final PbjReader input, final long maxSize) {
-        final int length = input.readVarInt(false);
+        final int length = input.readVarIntNoZZ();
         if (length > maxSize || length < 0) {
             input.setError(PbjReader.PARSE);
             return Bytes.EMPTY;
@@ -868,7 +868,7 @@ public final class ProtoParserTools {
             // The value for "zigZag" when calling varint doesn't matter because we are just reading past
             // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
             // the bytes, not how many of them there are)
-            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLong(false);
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLongNoZZ();
             case WIRE_TYPE_DELIMITED -> {
                 final int length = input.readVarIntNoZZ();
                 if (length < 0) {
@@ -903,7 +903,7 @@ public final class ProtoParserTools {
      * @return the read tag
      */
     public static int readNextFieldNumber(final PbjReader input) {
-        final int tag = input.readVarInt(false);
+        final int tag = input.readVarIntNoZZ();
         return tag >> TAG_FIELD_OFFSET;
     }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -90,7 +90,7 @@ public final class ProtoWriterTools {
      * @param wireType The field wire type to include in tag
      */
     public static void writeTag(PbjWriter out, final FieldDefinition field, final ProtoConstants wireType) {
-        out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
+        out.writeVarIntNoZZ((field.number() << TAG_TYPE_BITS) | wireType.ordinal());
     }
 
     /** Create an unsupported field type exception */
@@ -187,15 +187,15 @@ public final class ProtoWriterTools {
         switch (field.type()) {
             case INT32 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarInt(value, false);
+                out.writeVarIntNoZZ(value);
             }
             case UINT32 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarLong(Integer.toUnsignedLong(value), false);
+                out.writeVarLongNoZZ(Integer.toUnsignedLong(value));
             }
             case SINT32 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarInt(value, true);
+                out.writeVarIntZZ(value);
             }
             case SFIXED32, FIXED32 -> {
                 // The bytes in protobuf are in little-endian order -- backwards for Java.
@@ -286,11 +286,11 @@ public final class ProtoWriterTools {
         switch (field.type()) {
             case INT64, UINT64 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarLong(value, false);
+                out.writeVarLongNoZZ(value);
             }
             case SINT64 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarLong(value, true);
+                out.writeVarLongZZ(value);
             }
             case SFIXED64, FIXED64 -> {
                 // The bytes in protobuf are in little-endian order -- backwards for Java.
@@ -466,7 +466,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-        out.writeVarInt(enumValue.protoOrdinal(), false);
+        out.writeVarIntNoZZ(enumValue.protoOrdinal());
     }
 
     /**
@@ -502,7 +502,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-        out.writeVarInt(protoOrdinal, false);
+        out.writeVarIntNoZZ(protoOrdinal);
     }
 
     /**
@@ -653,7 +653,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(sizeOfStringNoTag(value), false);
+        out.writeVarIntNoZZ(sizeOfStringNoTag(value));
         out.writeStringNoTag(value);
     }
 
@@ -803,7 +803,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(Math.toIntExact(value.length()), false);
+        out.writeVarIntNoZZ(Math.toIntExact(value.length()));
         final long posBefore = out.position();
         out.writeBytes(value);
         final long bytesWritten = out.position() - posBefore;
@@ -928,11 +928,11 @@ public final class ProtoWriterTools {
         // When not a oneOf don't write default value
         if (field.oneOf() && message == null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
-            out.writeVarInt(0, false);
+            out.writeVarIntNoZZ(0);
         } else if (message != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final int size = codec.measureRecord(message);
-            out.writeVarInt(size, false);
+            out.writeVarIntNoZZ(size);
             if (size > 0) {
                 codec.write(message, out);
             }
@@ -977,7 +977,7 @@ public final class ProtoWriterTools {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final int sizeK = sizeOfK.applyAsInt(k);
             final int sizeV = sizeOfV.applyAsInt(v);
-            out.writeVarInt(sizeK + sizeV, false);
+            out.writeVarIntNoZZ(sizeK + sizeV);
             kWriter.write(k, out);
             vWriter.write(v, out);
         }
@@ -1014,7 +1014,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfInteger(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfInteger(newField, value));
             writeInteger(out, newField, value);
         }
     }
@@ -1046,7 +1046,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfLong(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfLong(newField, value));
             writeLong(out, newField, value);
         }
     }
@@ -1078,7 +1078,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfFloat(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfFloat(newField, value));
             writeFloat(out, newField, value);
         }
     }
@@ -1110,7 +1110,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfDouble(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfDouble(newField, value));
             writeDouble(out, newField, value);
         }
     }
@@ -1143,7 +1143,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfBoolean(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfBoolean(newField, value));
             writeBoolean(out, newField, value);
         }
     }
@@ -1177,7 +1177,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfString(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfString(newField, value));
             writeString(out, newField, value);
         }
     }
@@ -1215,7 +1215,7 @@ public final class ProtoWriterTools {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
             final int size = sizeOfBytes(newField, value);
-            out.writeVarInt(size, false);
+            out.writeVarIntNoZZ(size);
             if (size > 0) {
                 writeBytes(out, newField, value);
             }
@@ -1581,10 +1581,10 @@ public final class ProtoWriterTools {
                     size += sizeOfUnsignedVarInt64(val);
                 }
                 writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarInt(size, false);
+                out.writeVarIntNoZZ(size);
                 for (int i = 0; i < listSize; i++) {
                     final long val = list.get(i);
-                    out.writeVarLong(val, false);
+                    out.writeVarLongNoZZ(val);
                 }
             }
             case SINT64 -> {
@@ -1594,17 +1594,17 @@ public final class ProtoWriterTools {
                     size += sizeOfUnsignedVarInt64((val << 1) ^ (val >> 63));
                 }
                 writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarInt(size, false);
+                out.writeVarIntNoZZ(size);
                 for (int i = 0; i < listSize; i++) {
                     final long val = list.get(i);
-                    out.writeVarLong(val, true);
+                    out.writeVarLongZZ(val);
                 }
             }
             case SFIXED64, FIXED64 -> {
                 // The bytes in protobuf are in little-endian order -- backwards for Java.
                 // Smallest byte first.
                 writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarLong((long) list.size() * FIXED64_SIZE, false);
+                out.writeVarLongNoZZ((long) list.size() * FIXED64_SIZE);
                 for (int i = 0; i < listSize; i++) {
                     final long val = list.get(i);
                     out.writeLongLE(val);
@@ -1653,7 +1653,7 @@ public final class ProtoWriterTools {
         }
         final int size = list.size() * FIXED32_SIZE;
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             out.writeFloatLE(list.get(i));
@@ -1699,7 +1699,7 @@ public final class ProtoWriterTools {
         }
         final int size = list.size() * FIXED64_SIZE;
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             out.writeDoubleLE(list.get(i));
@@ -1746,11 +1746,11 @@ public final class ProtoWriterTools {
         }
         // write
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(list.size(), false);
+        out.writeVarIntNoZZ(list.size());
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             final boolean b = list.get(i);
-            out.writeVarInt(b ? 1 : 0, false);
+            out.writeVarIntNoZZ(b ? 1 : 0);
         }
     }
 
@@ -1801,9 +1801,9 @@ public final class ProtoWriterTools {
             size += sizeOfUnsignedVarInt32(list.get(i));
         }
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         for (int i = 0; i < listSize; i++) {
-            out.writeVarInt(list.get(i), false);
+            out.writeVarIntNoZZ(list.get(i));
         }
     }
 
@@ -1970,7 +1970,7 @@ public final class ProtoWriterTools {
     public static void writeDelimited(
             PbjWriter out, final FieldDefinition field, final int size, final Consumer<PbjWriter> writer) {
         writeTag(out, field);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         writer.accept(out);
     }
 


### PR DESCRIPTION
Replaces calls with a compile-time-constant zigzag boolean (readVarInt(false), writeVarInt(value, true)) with dedicated *NoZZ/*ZZ methods across generated code and ProtoParserTools/ProtoWriterTools, removing a per-call branch from the hottest (de)serialization paths. No wire-format change.

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.
