### PR TITLE
feat: PbjReader/PbjWriter Single PR

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/Common.java
@@ -264,7 +264,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.BOOL) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != $modelClassName.DEFAULT.$thatFieldName$suffix) {
-                               result = 31 * result + Boolean.hashCode($prefixFieldName$fieldName);
+                                result = 31 * result + Boolean.hashCode($prefixFieldName$fieldName);
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -275,7 +275,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.FLOAT) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != $modelClassName.DEFAULT.$thatFieldName$suffix) {
-                               result = 31 * result + Float.hashCode($prefixFieldName$fieldName);
+                                result = 31 * result + Float.hashCode($prefixFieldName$fieldName);
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -286,7 +286,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.DOUBLE) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != $modelClassName.DEFAULT.$thatFieldName$suffix) {
-                               result = 31 * result + Double.hashCode($prefixFieldName$fieldName);
+                                result = 31 * result + Double.hashCode($prefixFieldName$fieldName);
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -297,7 +297,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.BYTES) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != null && !$prefixFieldName$fieldName.equals($modelClassName.DEFAULT.$thatFieldName$suffix)) {
-                               result = 31 * result + $prefixFieldName$fieldName.hashCode();
+                                result = 31 * result + $prefixFieldName$fieldName.hashCode();
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -308,7 +308,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.ENUM) {
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != null && !$prefixFieldName$fieldName.equals($modelClassName.DEFAULT.$thatFieldName$suffix)) {
-                               result = 31 * result + Integer.hashCode(EnumWithProtoMetadata.protoOrdinal($prefixFieldName$fieldName));
+                                result = 31 * result + Integer.hashCode(EnumWithProtoMetadata.protoOrdinal($prefixFieldName$fieldName));
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -321,7 +321,7 @@ public final class Common {
                 } else if (f.type() == Field.FieldType.STRING || f.parent() == null) { // process sub message
                     generatedCodeSoFar += ("""
                             if ($prefixFieldName$fieldName != null && !$prefixFieldName$fieldName.equals($modelClassName.DEFAULT.$thatFieldName$suffix)) {
-                               result = 31 * result + $prefixFieldName$fieldName.hashCode();
+                                result = 31 * result + $prefixFieldName$fieldName.hashCode();
                             }
                             """)
                             .replace("$modelClassName", modelClassName)
@@ -451,7 +451,7 @@ public final class Common {
                         } else {
                             result = 31 * result;
                         }
-                   }
+                    }
                 }
                 """)
                 .replace("$prefixFieldName", fieldNamePrefix)

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/SingleField.java
@@ -216,7 +216,7 @@ public record SingleField(
     @Override
     public String parseCode() {
         if (type == FieldType.MESSAGE) {
-            return "%s.PROTOBUF.parse(input, strictMode, parseUnknownFields, maxDepth - 1, maxSize)"
+            return "%s.PROTOBUF.parseNoEx(input, strictMode, parseUnknownFields, maxDepth - 1, maxSize)"
                     .formatted(messageType);
         } else {
             return "input";

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ModelGenerator.java
@@ -53,7 +53,7 @@ public final class ModelGenerator implements Generator {
             hashCode += hashCode << 10;
             hashCode ^= hashCode >>> 24;
             hashCode += hashCode << 30;
-        """.indent(DEFAULT_INDENT * 2);
+        """;
 
     /**
      * {@inheritDoc}
@@ -570,7 +570,7 @@ public final class ModelGenerator implements Generator {
                     // This doesn't have unknown fields, but that one has some. So they are greater:
                     return -1;
                 }
-                """.indent(DEFAULT_INDENT);
+                """.indent(DEFAULT_INDENT * 2);
 
         bodyContent +=
             """
@@ -608,7 +608,7 @@ public final class ModelGenerator implements Generator {
 
         bodyContent +=
         """
-            $equalsBody
+        $equalsBody
         }"""
                 .replace("$equalsBody", generateEqualsBody(fields, javaRecordName, ""))
                 .indent(DEFAULT_INDENT);
@@ -624,7 +624,7 @@ public final class ModelGenerator implements Generator {
         // and calculates the hashcode.
         equalsStatements = Common.getFieldsEqualsStatements(fields, equalsStatements, prefixFieldName);
         // spotless:off
-        String bodyContent = equalsStatements.indent(DEFAULT_INDENT);
+        String bodyContent = equalsStatements;
         bodyContent +=
                 """
                     // Treat null and empty lists as equal
@@ -644,8 +644,7 @@ public final class ModelGenerator implements Generator {
                     }
                     return true;
                 """
-                        .replace("$thatUnknownFields", thatUnknownFields)
-                        .indent(DEFAULT_INDENT);
+                .replace("$thatUnknownFields", thatUnknownFields);
         // spotless:on
         return bodyContent;
     }
@@ -682,9 +681,10 @@ public final class ModelGenerator implements Generator {
                 }
                 return $hashCode;
             }
-            """.replace("$hashCodeManipulation", HASH_CODE_MANIPULATION)
-               .replace("$hashCodeBody", generateHashCodeBody(modelClassName, fields, "").indent(DEFAULT_INDENT))
-                .indent(DEFAULT_INDENT);
+            """
+            .replace("$hashCodeManipulation", HASH_CODE_MANIPULATION)
+            .replace("$hashCodeBody", generateHashCodeBody(modelClassName, fields, "").indent(DEFAULT_INDENT))
+            .indent(DEFAULT_INDENT);
         // spotless:on
         return bodyContent;
     }
@@ -894,7 +894,7 @@ public final class ModelGenerator implements Generator {
             }
         }
         // spotless:on
-        return sb.toString().indent(DEFAULT_INDENT);
+        return sb.toString();
     }
 
     /**

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -210,6 +210,7 @@ public final class ServiceGenerator {
                 methodLambda = "typedReplies -> " + name + "(typedReplies, options)";
             }
 
+            // spotless:off
             return """
                     case $methodName -> Pipelines.<$requestType, $replyType>$kind()
                             .mapRequest(bytes -> parse$simpleRequestType(bytes, options))
@@ -225,9 +226,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$kind", kind);
+            // spotless:on
         }
 
         private String formatUnaryMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -298,9 +301,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         private String formatClientStreamingMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -369,9 +374,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         private String formatServerStreamingMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -429,9 +436,11 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         private String formatBidiStreamingMethodImplementation() {
+            // spotless:off
             return """
                         @Override
                         $methodSignatureWithoutOptions {
@@ -496,6 +505,7 @@ public final class ServiceGenerator {
                     .replace("$replyType", replyType)
                     .replace("$simpleReplyType", replyType.replace(".", ""))
                     .replace("$methodName", name);
+            // spotless:on
         }
 
         String formatMethodImplementation() {
@@ -771,7 +781,7 @@ public final class ServiceGenerator {
                     Objects.requireNonNull(options);
 
                     // not strict, no unknown fields, hard-code maxDepth for now, and use custom maxSize:
-                    return get$simpleRequestTypeCodec(options).parse(message.toReadableSequentialData(), false, false, 16, options.maxMessageSizeBytes());
+                    return get$simpleRequestTypeCodec(options).parse(message, false, false, 16, options.maxMessageSizeBytes());
                 }
                 """
                 .replace("$requestType", requestType)

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -621,6 +621,13 @@ public final class ServiceGenerator {
         writer.addImport("java.util.concurrent.Flow");
         writer.addImport("java.util.concurrent.atomic.AtomicReference");
 
+        // Some generated code uses Codec.Parse Bytes overload.
+        // Some projects may want to use an alternative impl (such as using thread-locals)
+        String pbjUseUtils = System.getProperty("pbj.useUtils");
+        if (pbjUseUtils != null) {
+            writer.addImport(pbjUseUtils);
+        }
+
         rpcList.forEach(rpc -> {
             writer.addImport(rpc.requestTypePackage + "." + rpc.requestType);
             writer.addImport(rpc.replyTypePackage + "." + rpc.replyType);
@@ -773,6 +780,10 @@ public final class ServiceGenerator {
     }
 
     private static String formatParseRequestMethod(final String requestType) {
+        String parseLine = System.getProperty("pbj.useUtils") != null
+                ? "return PbjUtils.parse(get$simpleRequestTypeCodec(options), message, false, false, 16, options.maxMessageSizeBytes());"
+                : "return get$simpleRequestTypeCodec(options).parse(message, false, false, 16, options.maxMessageSizeBytes());";
+
         // spotless:off
         return """
                 @NonNull
@@ -781,9 +792,10 @@ public final class ServiceGenerator {
                     Objects.requireNonNull(options);
 
                     // not strict, no unknown fields, hard-code maxDepth for now, and use custom maxSize:
-                    return get$simpleRequestTypeCodec(options).parse(message, false, false, 16, options.maxMessageSizeBytes());
+                    $parseLine
                 }
                 """
+                .replace("$parseLine", parseLine)
                 .replace("$requestType", requestType)
                 .replace("$simpleRequestType", requestType.replace(".", ""))
                 ;

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/TestGenerator.java
@@ -421,7 +421,9 @@ public final class TestGenerator implements Generator {
                     assertEquals(charBuffer2, charBuffer);
                 
                     // Test JSON Reading
-                    final $modelClassName jsonReadPbj = $modelClassName.JSON.parse(JsonTools.parseJson(charBuffer), false, Integer.MAX_VALUE, Integer.MAX_VALUE);
+                    final var jsonReader = new PbjReader(new byte[0]);
+                    final $modelClassName jsonReadPbj = $modelClassName.JSON.parseNoEx(JsonTools.parseJson(charBuffer), jsonReader, false, Integer.MAX_VALUE, Integer.MAX_VALUE);
+                    jsonReader.throwOnError();
                     assertEquals(modelObj, jsonReadPbj);
                 }
                 

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -58,17 +58,20 @@ class JsonCodecParseMethodGenerator {
                  * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
                  *
                  * @param root The JSON parsed object tree to parse data from
-                 * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
-                 * @return Parsed HashObject model object or null if data input was null or empty
-                 * @throws ParseException If parsing fails
+                 * @param input the {@link PbjReader} used solely to carry error state for this parse; sets
+                 *              {@link PbjReader#PARSE} if the size of a delimited field exceeds the limit
+                 * @return Parsed HashObject model object, or {@code null} if data input was null or empty, or an
+                 *         error was set on {@code input}
                  */
-                protected final @NonNull $modelClassName parseImpl(
+                protected final $modelClassName parseImpl(
                         @Nullable final JSONParser.ObjContext root,
+                        @NonNull final PbjReader input,
                         final boolean strictMode,
                         final int maxDepth,
-                        final int maxSize) throws ParseException {
+                        final int maxSize) {
                     if (maxDepth < 0) {
-                        throw new ParseException("Reached maximum allowed depth of nested messages");
+                        input.setError(PbjReader.MAX_DEPTH_REACHED);
+                        return null;
                     }
                     try {
                         // -- TEMP STATE FIELDS --------------------------------------
@@ -82,7 +85,8 @@ class JsonCodecParseMethodGenerator {
                                 default: {
                                     if (strictMode) {
                                         // Since we are parsing is strict mode, this is an exceptional condition.
-                                        throw new UnknownFieldException(kvPair.STRING().getText());
+                                        input.setError(PbjReader.UNKNOWN_FIELD, kvPair.STRING().getText());
+                                        return null;
                                     }
                                 }
                             }
@@ -90,7 +94,8 @@ class JsonCodecParseMethodGenerator {
 
                         return new $modelClassName($fieldsList);
                     } catch (Exception ex) {
-                        throw new ParseException(ex);
+                        input.setError(PbjReader.PARSE, ex.getMessage());
+                        return null;
                     }
                 }
                 """.replace("$modelClassName", modelClassName)
@@ -150,7 +155,7 @@ class JsonCodecParseMethodGenerator {
         if (field.repeated()) {
             if (field.type() == Field.FieldType.MESSAGE) {
                 sb.append(("parseObjArray(checkSize(\"$fieldName\", $valueGetter.arr().value(), $maxSize), "
-                                + field.messageType() + ".JSON, maxDepth - 1, $maxSize)")
+                                + field.messageType() + ".JSON, input, maxDepth - 1, $maxSize)")
                         .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                         .replace("$fieldName", field.name()));
             } else {
@@ -228,7 +233,7 @@ class JsonCodecParseMethodGenerator {
             switch (field.type()) {
                 case MESSAGE ->
                     sb.append(field.javaFieldType()
-                            + ".JSON.parse($valueGetter.getChild(JSONParser.ObjContext.class, 0), false, maxDepth - 1, $maxSize)"
+                            + ".JSON.parseNoEx($valueGetter.getChild(JSONParser.ObjContext.class, 0), input, false, maxDepth - 1, $maxSize)"
                                     .replace(
                                             "$maxSize",
                                             field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize"));

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/json/JsonCodecParseMethodGenerator.java
@@ -75,13 +75,13 @@ class JsonCodecParseMethodGenerator {
                     }
                     try {
                         // -- TEMP STATE FIELDS --------------------------------------
-                        $fieldDefs
+                $fieldDefs
 
                         // -- EXTRACT VALUES FROM PARSE TREE ---------------------------------------------
 
                         for (JSONParser.PairContext kvPair : root.pair()) {
                             switch (toJsonFieldName(kvPair.STRING().getText())) {
-                                $caseStatements
+                $caseStatements
                                 default: {
                                     if (strictMode) {
                                         // Since we are parsing is strict mode, this is an exceptional condition.
@@ -102,13 +102,19 @@ class JsonCodecParseMethodGenerator {
                 .replace(
                         "$fieldDefs",
                         fields.stream()
-                                .map(field -> "    %s temp_%s = %s;"
+                                .map(field -> "%s temp_%s = %s;"
                                         .formatted(field.javaFieldType(), field.name(), field.javaDefault()))
-                                .collect(Collectors.joining("\n")))
+                                .collect(Collectors.joining("\n"))
+                                .indent(DEFAULT_INDENT * 2)
+                                .stripTrailing())
                 .replace(
                         "$fieldsList",
                         fields.stream().map(field -> "temp_" + field.name()).collect(Collectors.joining(", ")))
-                .replace("$caseStatements", generateCaseStatements(fields))
+                .replace(
+                        "$caseStatements",
+                        generateCaseStatements(fields)
+                                .indent(DEFAULT_INDENT * 4)
+                                .stripTrailing())
                 .indent(DEFAULT_INDENT);
     }
 
@@ -126,11 +132,12 @@ class JsonCodecParseMethodGenerator {
                 for (final Field subField : oneOfField.fields()) {
                     sb.append("case \"" + toJsonFieldName(subField.name()) + "\" /* [" + subField.fieldNumber()
                             + "] */ " + ": temp_"
-                            + oneOfField.name() + " = new %s<>(\n".formatted(oneOfField.className())
-                            + oneOfField.getEnumClassRef().indent(DEFAULT_INDENT)
-                            + "." + Common.camelToUpperSnake(subField.name()) + ", \n".indent(DEFAULT_INDENT));
-                    generateFieldCaseStatement(sb, subField, "kvPair.value()");
-                    sb.append("); break;\n");
+                            + oneOfField.name() + " = new %s<>(\n".formatted(oneOfField.className()));
+                    final StringBuilder valueSb = new StringBuilder();
+                    generateFieldCaseStatement(valueSb, subField, "kvPair.value()");
+                    sb.append((oneOfField.getEnumClassRef() + "." + Common.camelToUpperSnake(subField.name()) + ",\n"
+                                    + valueSb + "); break;\n")
+                            .indent(DEFAULT_INDENT));
                 }
             } else {
                 sb.append("case \"" + toJsonFieldName(field.name()) + "\" /* [" + field.fieldNumber() + "] */ "

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecFastEqualsMethodGenerator.java
@@ -15,6 +15,7 @@ class CodecFastEqualsMethodGenerator {
 
     static String generateFastEqualsMethod(final String modelClassName, final List<Field> fields) {
         // Placeholder implementation, replace faster implementation than full parse if there is one
+        // spotless:off
         return """
                 /**
                  * Compares the given item with the bytes in the input, and returns false if it determines that
@@ -28,11 +29,12 @@ class CodecFastEqualsMethodGenerator {
                  * @return true if the bytes represent the item, false otherwise.
                  * @throws ParseException If parsing fails
                  */
-                public boolean fastEquals(@NonNull $modelClass item, @NonNull final ReadableSequentialData input) throws ParseException {
+                public boolean fastEquals(@NonNull $modelClass item, @NonNull final PbjReader input) throws ParseException {
                     return item.equals(parse(input));
                 }
                 """
                 .replace("$modelClass", modelClassName)
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecGenerator.java
@@ -147,9 +147,9 @@ public final class CodecGenerator implements Generator {
                     /**
                      * Empty constructor
                      */
-                     public $codecClass() {
-                         // no-op
-                     }
+                    public $codecClass() {
+                        // no-op
+                    }
 
                 $unsetOneOfConstants
                 $parseMethod

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureDataMethodGenerator.java
@@ -14,6 +14,7 @@ class CodecMeasureDataMethodGenerator {
 
     static String generateMeasureMethod(final String modelClassName, final List<Field> fields) {
         // Placeholder implementation, replace faster implementation than full parse if there is one
+        // spotless:off
         return """
                 /**
                  * Reads from this data input the length of the data within the input. The implementation may
@@ -24,7 +25,7 @@ class CodecMeasureDataMethodGenerator {
                  * @return The length of the data item in the input
                  * @throws ParseException If parsing fails
                  */
-                public int measure(@NonNull final ReadableSequentialData input) throws ParseException {
+                public int measure(@NonNull final PbjReader input) throws ParseException {
                     final var start = input.position();
                     parse(input);
                     final var end = input.position();
@@ -32,5 +33,6 @@ class CodecMeasureDataMethodGenerator {
                 }
                 """
                 .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecMeasureRecordMethodGenerator.java
@@ -87,27 +87,29 @@ class CodecMeasureRecordMethodGenerator {
                     + switch (field.messageType()) {
                         case "StringValue" -> "size += sizeOfOptionalString(%s, %s);".formatted(fieldDef, getValueCode);
                         case "BoolValue" -> "size += sizeOfOptionalBoolean(%s, %s);".formatted(fieldDef, getValueCode);
-                        case "Int32Value", "UInt32Value" -> "size += sizeOfOptionalInteger(%s, %s);"
-                                .formatted(fieldDef, getValueCode);
-                        case "Int64Value", "UInt64Value" -> "size += sizeOfOptionalLong(%s, %s);"
-                                .formatted(fieldDef, getValueCode);
+                        case "Int32Value", "UInt32Value" ->
+                            "size += sizeOfOptionalInteger(%s, %s);".formatted(fieldDef, getValueCode);
+                        case "Int64Value", "UInt64Value" ->
+                            "size += sizeOfOptionalLong(%s, %s);".formatted(fieldDef, getValueCode);
                         case "FloatValue" -> "size += sizeOfOptionalFloat(%s, %s);".formatted(fieldDef, getValueCode);
                         case "DoubleValue" -> "size += sizeOfOptionalDouble(%s, %s);".formatted(fieldDef, getValueCode);
                         case "BytesValue" -> "size += sizeOfOptionalBytes(%s, %s);".formatted(fieldDef, getValueCode);
-                        default -> throw new UnsupportedOperationException(
-                                "Unhandled optional message type:" + field.messageType());
+                        default ->
+                            throw new UnsupportedOperationException(
+                                    "Unhandled optional message type:" + field.messageType());
                     };
         } else if (field.repeated()) {
             return prefix
                     + switch (field.type()) {
                         case ENUM -> "size += sizeOfEnumList(%s, %s);".formatted(fieldDef, getValueCode);
-                        case MESSAGE -> "size += sizeOfMessageList($fieldDef, $valueCode, $codec);"
-                                .replace("$fieldDef", fieldDef)
-                                .replace("$valueCode", getValueCode)
-                                .replace(
-                                        "$codec",
-                                        ((SingleField) field).messageTypeModelPackage() + "."
-                                                + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
+                        case MESSAGE ->
+                            "size += sizeOfMessageList($fieldDef, $valueCode, $codec);"
+                                    .replace("$fieldDef", fieldDef)
+                                    .replace("$valueCode", getValueCode)
+                                    .replace(
+                                            "$codec",
+                                            ((SingleField) field).messageTypeModelPackage() + "."
+                                                    + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
                         default -> "size += sizeOf%sList(%s, %s);".formatted(writeMethodName, fieldDef, getValueCode);
                     };
         } else if (field.type() == Field.FieldType.MAP) {
@@ -127,7 +129,7 @@ class CodecMeasureRecordMethodGenerator {
                                 final int sizePre = size;
                                 $K k = pbjMap.getSortedKeys().get(i);
                                 $V v = pbjMap.get(k);
-                                $fieldSizeOfLines
+                        $fieldSizeOfLines
                                 size += sizeOfVarInt32(size - sizePre);
                             }
                         }
@@ -137,24 +139,25 @@ class CodecMeasureRecordMethodGenerator {
                     .replace("$javaFieldType", mapField.javaFieldType())
                     .replace("$K", mapField.keyField().type().boxedType)
                     .replace("$V", mapField.valueField().type() == Field.FieldType.MESSAGE ? mapField.valueField().messageType() : mapField.valueField().type().boxedType)
-                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
+                    .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT * 2))
                     ;
             // spotless:on
         } else {
             return prefix
                     + switch (field.type()) {
                         case ENUM -> "size += sizeOfEnum(%s, %s);".formatted(fieldDef, getValueCode);
-                        case STRING -> "size += sizeOfString(%s, %s, %s);"
-                                .formatted(fieldDef, getValueCode, skipDefault);
-                        case MESSAGE -> "size += sizeOfMessage($fieldDef, $valueCode, $codec);"
-                                .replace("$fieldDef", fieldDef)
-                                .replace("$valueCode", getValueCode)
-                                .replace(
-                                        "$codec",
-                                        ((SingleField) field).messageTypeModelPackage() + "."
-                                                + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
-                        case BOOL -> "size += sizeOfBoolean(%s, %s, %s);"
-                                .formatted(fieldDef, getValueCode, skipDefault);
+                        case STRING ->
+                            "size += sizeOfString(%s, %s, %s);".formatted(fieldDef, getValueCode, skipDefault);
+                        case MESSAGE ->
+                            "size += sizeOfMessage($fieldDef, $valueCode, $codec);"
+                                    .replace("$fieldDef", fieldDef)
+                                    .replace("$valueCode", getValueCode)
+                                    .replace(
+                                            "$codec",
+                                            ((SingleField) field).messageTypeModelPackage() + "."
+                                                    + Common.capitalizeFirstLetter(field.messageType()) + ".PROTOBUF");
+                        case BOOL ->
+                            "size += sizeOfBoolean(%s, %s, %s);".formatted(fieldDef, getValueCode, skipDefault);
                         case INT32,
                                 UINT32,
                                 SINT32,
@@ -165,8 +168,9 @@ class CodecMeasureRecordMethodGenerator {
                                 UINT64,
                                 FIXED64,
                                 SFIXED64,
-                                BYTES -> "size += sizeOf%s(%s, %s, %s);"
-                                .formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
+                                BYTES ->
+                            "size += sizeOf%s(%s, %s, %s);"
+                                    .formatted(writeMethodName, fieldDef, getValueCode, skipDefault);
                         default -> "size += sizeOf%s(%s, %s);".formatted(writeMethodName, fieldDef, getValueCode);
                     };
         }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -95,7 +95,7 @@ class CodecParseMethodGenerator {
                 $fieldDefs
                     List<UnknownField> $unknownFields = null;
 
-                    $parseLoop
+                $parseLoop
                 $listFieldsWriteProtection
                     if ($unknownFields != null) {
                         Collections.sort($unknownFields);
@@ -110,29 +110,34 @@ class CodecParseMethodGenerator {
                     return $unknownFields;
                 }
                 """
-        .replace("$cacheableSupport", isCacheable ? generateCacheableSupport(modelClassName, fields) : "return new $modelClassName($fieldsList);")
+        .replace(
+                "$cacheableSupport",
+                isCacheable
+                        ? generateCacheableSupport(modelClassName, fields)
+                        : "return new $modelClassName($fieldsList);".indent(DEFAULT_INDENT).stripTrailing())
         .replace("$modelClassName",modelClassName)
         .replace("$fieldDefs",fields.stream().map(field -> {
             final String javaFieldType = field.type() == Field.FieldType.ENUM ? field.repeated() ? "List" :  "Object" : field.javaFieldType();
             return "%s temp_%s = %s;"
                     .formatted(javaFieldType, field.name(), field.javaDefault());
-        }).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT * 2).stripTrailing())
+        }).collect(Collectors.joining("\n")).indent(DEFAULT_INDENT).stripTrailing())
         .replace("$fieldsList",
                 fields.stream().map(field -> "temp_"+field.name()).collect(Collectors.joining(", "))
                 + (fields.isEmpty() ? "" : ", ") + "$unknownFields"
         )
-        .replace("$parseLoop", parseAndDefaultBodyPair.parseBody().indent(DEFAULT_INDENT * 2).stripTrailing())
+        .replace("$parseLoop", parseAndDefaultBodyPair.parseBody().indent(DEFAULT_INDENT).stripTrailing())
         .replace("$defaultCaseBody", parseAndDefaultBodyPair.defaultBody().indent(DEFAULT_INDENT).stripTrailing())
         .replace("$listFieldsWriteProtection", fields.stream()
                 .filter(Field::repeated)
                 .map(field -> "if (temp_" + field.name() + " instanceof UnmodifiableArrayList ual) ual.makeReadOnly();")
                 .collect(Collectors.joining("\n"))
-                .indent(DEFAULT_INDENT * 2))
+                .indent(DEFAULT_INDENT))
         .indent(DEFAULT_INDENT);
         // spotless:on
     }
 
     static String generateCacheableSupport(String modelClassName, final List<Field> fields) {
+        // spotless:off
         return """
                 final int objectHashCode;
                 {
@@ -154,14 +159,16 @@ class CodecParseMethodGenerator {
                 _theObject = new $modelClassName($fieldsList, objectHashCode);
                 CACHE[objectHashCode & CACHE_KEY_MASK] = _theObject;
                 return _theObject;
-                """.replace("$hashCodeBody", ModelGenerator.generateHashCodeBody(modelClassName, fields, "temp_"))
+                """
+                .replace("$hashCodeBody", ModelGenerator.generateHashCodeBody(modelClassName, fields, "temp_"))
                 .replace(
                         "$equalsBody",
                         ModelGenerator.generateEqualsBody(fields, modelClassName, "temp_")
                                 .replace("return false", "yield false")
                                 .replace("return true", "yield true")
-                                .indent(DEFAULT_INDENT))
-                .indent(DEFAULT_INDENT * 2);
+                                .indent(DEFAULT_INDENT * 2))
+                .indent(DEFAULT_INDENT);
+        // spotless:on
     }
 
     public record ParseAndDefaultBody(String parseBody, String defaultBody) {}
@@ -282,9 +289,9 @@ class CodecParseMethodGenerator {
         // spotless:off
         sbCase.append("case %d /* type=%d [%s] packed-repeated field=%d [%s] */ -> {%n"
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
-        sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
-        sbFunc.append("""
-%s case%d(PbjReader input, int maxSize, %s %s) {""".formatted(fieldType, tag, fieldType, tempFieldName));
+        sbCase.append("    %s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
+        sbFunc.append("    %s case%d(PbjReader input, int maxSize, %s %s) {\n"
+                .formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         int divideAmount = fieldType.equals("List<Integer>") ? 2
             : fieldType.equals("List<Long>") ? 4
@@ -300,10 +307,10 @@ class CodecParseMethodGenerator {
                     Object value = $enumName.fromProtobufOrdinal(enumOrdinal);
                     if (value == $enumName.UNRECOGNIZED) {
                         value = Integer.valueOf(enumOrdinal);
-                    }
-                    
-                    """
-                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true));
+                    }"""
+                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true))
+                    .indent(DEFAULT_INDENT)
+                    .stripTrailing();
         } else {
             preRead = "";
         }
@@ -329,13 +336,16 @@ class CodecParseMethodGenerator {
                 var list = new UnmodifiableArray$fieldType();
                 list.ensureCapacity(length$divideString);
                 while (input.hasRemaining()) {
-                    $preReadlist.add($readMethod);
+                $preRead
+                    list.add($readMethod);
                 }
                 $tempFieldName = list;
                 input.limit(startLimit);
                 if (input.position() != startPosition + length) {
                     input.setError(PbjReader.BUFFER_UNDERFLOW);
-                }"""
+                }
+                return $tempFieldName;
+                """
                 .replace("$tempFieldName", tempFieldName)
                 .replace("$preRead", preRead)
                 .replace("$fieldType", fieldType)
@@ -343,9 +353,9 @@ class CodecParseMethodGenerator {
                 .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                 .replace("$fieldName", field.name())
                 .replace("$divideString", divideAmount == 1 ? "" : "/%d".formatted(divideAmount))
-                .indent(DEFAULT_INDENT));
+                .indent(DEFAULT_INDENT * 2));
         sbCase.append("\n}\n");
-        sbFunc.append("    return %s;\n    }\n".formatted(tempFieldName));
+        sbFunc.append("    }\n");
         // spotless:on
     }
 
@@ -492,7 +502,7 @@ class CodecParseMethodGenerator {
                             "%s temp_%s = %s;".formatted(mapEntryField.javaFieldType(),
                             mapEntryField.name(), mapEntryField.javaDefault())).collect(Collectors.joining("\n")))
                     .replace("$mapParseLoop", parseAndDefaultBodyPair.parseBody()
-                            .indent(DEFAULT_INDENT * 2).stripTrailing())
+                            .indent(DEFAULT_INDENT).stripTrailing())
                     .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                     .indent(DEFAULT_INDENT)
             );

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -289,44 +289,61 @@ class CodecParseMethodGenerator {
         sbFunc.append("""
 %s case%d(PbjReader input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
+        int divideAmount = fieldType.equals("List<Integer>") ? 2
+            : fieldType.equals("List<Long>") ? 4
+            : fieldType.equals("List<Float>") ? 2
+            : fieldType.equals("List<Double>") ? 4
+            : fieldType.equals("List<Boolean>") ? 1
+            : 0;
+
         if (field.type() == Field.FieldType.ENUM) {
+            divideAmount = 1;
             preRead = """
                     final int enumOrdinal = readEnum(input);
                     Object value = $enumName.fromProtobufOrdinal(enumOrdinal);
                     if (value == $enumName.UNRECOGNIZED) {
-                       value = Integer.valueOf(enumOrdinal);
+                        value = Integer.valueOf(enumOrdinal);
                     }
                     
                     """
-                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true))
-            ;
+                    .replace("$enumName", Common.snakeToCamel(field.messageType(), true));
         } else {
             preRead = "";
         }
-        final String loopBody = preRead + "%s = addToList(%s,%s);"
-                .formatted(tempFieldName, tempFieldName, field.type() == Field.FieldType.ENUM ? "value" : readMethod(field));
+
+        if (divideAmount == 0) {
+            throw new RuntimeException("Need to implement");
+        }
+
         sbFunc.append("""
                 // Read the length of packed repeated field data
-                final long length = input.readVarInt(false);
+                final int length = input.readVarInt(false);
                 if (length > $maxSize) {
                     throw new ParseException("$fieldName size " + length + " is greater than max " + $maxSize);
                 }
                 if (input.remaining() < length) {
                     throw new BufferUnderflowException();
                 }
-                final var beforeLimit = input.limit();
-                final long beforePosition = input.position();
+                final var startLimit = input.limit();
+                final long startPosition = input.position();
                 input.limit(input.position() + length);
+                var list = new UnmodifiableArray$fieldType();
+                list.ensureCapacity(length$divideString);
                 while (input.hasRemaining()) {
-                $loopBody
+                    $preReadlist.add($readMethod);
                 }
-                input.limit(beforeLimit);
-                if (input.position() != beforePosition + length) {
+                $tempFieldName = list;
+                input.limit(startLimit);
+                if (input.position() != startPosition + length) {
                     throw new BufferUnderflowException();
                 }"""
-                .replace("$loopBody", loopBody.indent(DEFAULT_INDENT).stripTrailing())
+                .replace("$tempFieldName", tempFieldName)
+                .replace("$preRead", preRead)
+                .replace("$fieldType", fieldType)
+                .replace("$readMethod", field.type() == Field.FieldType.ENUM ? "value" : readMethod(field))
                 .replace("$maxSize", field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
                 .replace("$fieldName", field.name())
+                .replace("$divideString", divideAmount == 1 ? "" : "/%d".formatted(divideAmount))
                 .indent(DEFAULT_INDENT));
         sbCase.append("\n}\n");
         sbFunc.append("    return %s;\n    }\n".formatted(tempFieldName));

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -185,7 +185,7 @@ class CodecParseMethodGenerator {
                         while (input.hasRemaining()) {
                             // Read the "tag" byte which gives us the field number for the next field to read
                             // and the wire type (way it is encoded on the wire).
-                            final int $prefixtag = input.readVarInt(false);
+                            final int $prefixtag = input.readVarIntNoZZ();
 
                             // The field is the top 5 bits of the byte. Read this off
                             final int $prefixfield = $prefixtag >>> TAG_FIELD_OFFSET;
@@ -321,7 +321,7 @@ class CodecParseMethodGenerator {
 
         sbFunc.append("""
                 // Read the length of packed repeated field data
-                final int length = input.readVarInt(false);
+                final int length = input.readVarIntNoZZ();
                 if (length > $maxSize) {
                     input.setError(PbjReader.PARSE, "$fieldName size " + length + " is greater than max " + $maxSize);
                     return $tempFieldName;
@@ -379,13 +379,13 @@ class CodecParseMethodGenerator {
         if (field.optionalValueType()) {
             sbCase.append("""
                             // Read the message size, it is not needed
-                            final var valueTypeMessageSize = input.readVarInt(false);
+                            final var valueTypeMessageSize = input.readVarIntNoZZ();
                             final $fieldType value;
                             if (valueTypeMessageSize > 0) {
                                 final var beforeLimit = input.limit();
                                 input.limit(input.position() + valueTypeMessageSize);
                                 // read inner tag
-                                final int valueFieldTag = input.readVarInt(false);
+                                final int valueFieldTag = input.readVarIntNoZZ();
                                 // assert tag is as expected; skip if a read error is already pending
                                 assert input.error() != 0 || (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
                                 assert input.error() != 0 || (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
@@ -424,7 +424,7 @@ class CodecParseMethodGenerator {
         } else if (field.type() == Field.FieldType.MESSAGE) {
             // spotless:off
             sbCase.append("""
-                        final var messageLength = input.readVarInt(false);
+                        final var messageLength = input.readVarIntNoZZ();
                         final $fieldType value;
                         if (messageLength == 0) {
                             value = $fieldType.DEFAULT;
@@ -469,7 +469,7 @@ class CodecParseMethodGenerator {
                     generateCaseStatements(sbFunc, mapEntryFields, schemaClassName), "map_entry_", schemaClassName);
             // spotless:off
             sbCase.append("""
-                        final var __map_messageLength = input.readVarInt(false);
+                        final var __map_messageLength = input.readVarIntNoZZ();
 
                         $fieldDefs
                         if (__map_messageLength != 0) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -59,7 +59,7 @@ class CodecParseMethodGenerator {
         // spotless:off
         return """
                 /**
-                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
+                 * Parses a $modelClassName object from ProtoBuf bytes in a {@link PbjReader}. Throws if in strict mode ONLY.
                  * <p>
                  * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
                  * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
@@ -83,7 +83,7 @@ class CodecParseMethodGenerator {
                  * @throws ParseException If parsing fails
                  */
                 protected final @NonNull $modelClassName parseImpl(
-                        @NonNull final ReadableSequentialData input,
+                        @NonNull final PbjReader input,
                         final boolean strictMode,
                         final boolean parseUnknownFields,
                         final int maxDepth,
@@ -110,8 +110,8 @@ class CodecParseMethodGenerator {
                         throw new ParseException(anyException);
                     }
                 }
-                
-                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, ReadableSequentialData input, int maxSize) throws ParseException, IOException {
+
+                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, PbjReader input, int maxSize) throws ParseException, IOException {
                 $defaultCaseBody
                     return $unknownFields;
                 }
@@ -182,20 +182,9 @@ class CodecParseMethodGenerator {
                         // -- PARSE LOOP ---------------------------------------------
                         // Continue to parse bytes out of the input stream until we get to the end.
                         while (input.hasRemaining()) {
-                            // Note: ReadableStreamingData.hasRemaining() won't flip to false
-                            // until the end of stream is actually hit with a read operation.
-                            // So we catch this exception here and **only** here, because an EOFException
-                            // anywhere else suggests that we're processing malformed data and so
-                            // we must re-throw the exception then.
-                            final int $prefixtag;
-                            try {
-                                // Read the "tag" byte which gives us the field number for the next field to read
-                                // and the wire type (way it is encoded on the wire).
-                                $prefixtag = input.readVarInt(false);
-                            } catch (EOFException e) {
-                                // There's no more fields. Stop the parsing loop.
-                                break;
-                            }
+                            // Read the "tag" byte which gives us the field number for the next field to read
+                            // and the wire type (way it is encoded on the wire).
+                            final int $prefixtag = input.readVarInt(false);
 
                             // The field is the top 5 bits of the byte. Read this off
                             final int $prefixfield = $prefixtag >>> TAG_FIELD_OFFSET;
@@ -298,7 +287,7 @@ class CodecParseMethodGenerator {
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
         sbFunc.append("""
-%s case%d(ReadableSequentialData input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
+%s case%d(PbjReader input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         if (field.type() == Field.FieldType.ENUM) {
             preRead = """
@@ -371,9 +360,9 @@ class CodecParseMethodGenerator {
                                 input.limit(input.position() + valueTypeMessageSize);
                                 // read inner tag
                                 final int valueFieldTag = input.readVarInt(false);
-                                // assert tag is as expected
-                                assert (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
-                                assert (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
+                                // assert tag is as expected; skip if a read error is already pending
+                                assert input.error() != 0 || (valueFieldTag >>> TAG_FIELD_OFFSET) == 1;
+                                assert input.error() != 0 || (valueFieldTag & TAG_WIRE_TYPE_MASK) == $valueTypeWireType;
                                 // read value
                                 value = $readMethod;
                                 input.limit(beforeLimit);

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecParseMethodGenerator.java
@@ -77,41 +77,35 @@ class CodecParseMethodGenerator {
                  * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
                  * @param parseUnknownFields when {@code true} and strictMode is {@code false}, the parser will collect unknown
                  *                           fields in the unknownFields list in the model; otherwise they'll be simply skipped.
-                 * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
-                 * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
-                 * @return Parsed $modelClassName model object or null if data input was null or empty
-                 * @throws ParseException If parsing fails
+                 * @param maxDepth sets the {@link PbjReader#MAX_DEPTH_REACHED} error if the depth of nested messages exceeds it.
+                 * @param maxSize sets the {@link PbjReader#PARSE} error if the size of a delimited field exceeds the limit
+                 * @return Parsed $modelClassName model object, or {@code null} if an error was set on {@code input}
                  */
-                protected final @NonNull $modelClassName parseImpl(
+                protected final $modelClassName parseImpl(
                         @NonNull final PbjReader input,
                         final boolean strictMode,
                         final boolean parseUnknownFields,
                         final int maxDepth,
-                        final int maxSize) throws ParseException {
+                        final int maxSize) {
                     if (maxDepth < 0) {
-                        throw new ParseException("Reached maximum allowed depth of nested messages");
+                        input.setError(PbjReader.MAX_DEPTH_REACHED);
+                        return null;
                     }
-                    try {
-                        // -- TEMP STATE FIELDS --------------------------------------
+                    // -- TEMP STATE FIELDS --------------------------------------
                 $fieldDefs
-                        List<UnknownField> $unknownFields = null;
+                    List<UnknownField> $unknownFields = null;
 
-                        $parseLoop
+                    $parseLoop
                 $listFieldsWriteProtection
-                        if ($unknownFields != null) {
-                            Collections.sort($unknownFields);
-                            $initialSizeOfUnknownFieldsArray = Math.max($initialSizeOfUnknownFieldsArray, $unknownFields.size());
-                        }
-                $cacheableSupport
-                    } catch (final Exception anyException) {
-                        if (anyException instanceof ParseException parseException) {
-                            throw parseException;
-                        }
-                        throw new ParseException(anyException);
+                    if ($unknownFields != null) {
+                        Collections.sort($unknownFields);
+                        $initialSizeOfUnknownFieldsArray = Math.max($initialSizeOfUnknownFieldsArray, $unknownFields.size());
                     }
+                    if (input.error() > 0) return null;
+                $cacheableSupport
                 }
 
-                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, PbjReader input, int maxSize) throws ParseException, IOException {
+                private List<UnknownField> defaultCase(int tag, int field, FieldDefinition f, boolean strictMode, boolean parseUnknownFields, List<UnknownField> $unknownFields, PbjReader input, int maxSize) {
                 $defaultCaseBody
                     return $unknownFields;
                 }
@@ -204,20 +198,22 @@ class CodecParseMethodGenerator {
                         // handle error cases here, so we do not do if statements in normal loop
                         // Validate the field number is valid (must be > 0)
                         if ($prefixfield == 0) {
-                            throw new IOException("Bad protobuf encoding. We read a field value of "
+                            input.setError(PbjReader.IO_ERROR, "Bad protobuf encoding. We read a field value of "
                                 + $prefixfield);
+                            return $unknownFields;
                         }
                         // Validate the wire type is valid (must be >=0 && <= 5).
                         // Otherwise we cannot parse this.
                         // Note: it is always >= 0 at this point (see code above where it is defined).
                         if (wireType > 5) {
-                            throw new IOException("Cannot understand wire_type of " + wireType);
+                            input.setError(PbjReader.PARSE, "Cannot understand wire_type of " + wireType);
+                            return $unknownFields;
                         }
                         // It may be that the parser subclass doesn't know about this field
                         if ($prefixf == null) {
                             if (strictMode) {
-                                // Since we are parsing is strict mode, this is an exceptional condition.
-                                throw new UnknownFieldException($prefixfield);
+                                input.setError(PbjReader.UNKNOWN_FIELD, String.valueOf($prefixfield));
+                                return $unknownFields;
                             } else if (parseUnknownFields) {
                                 if ($unknownFields == null) {
                                     $unknownFields = new ArrayList<>($initialSizeOfUnknownFieldsArray);
@@ -233,8 +229,9 @@ class CodecParseMethodGenerator {
                                 skipField(input, ProtoConstants.get(wireType), $skipMaxSize);
                             }
                         } else {
-                            throw new IOException("Bad tag [" + $prefixtag + "], field [" + $prefixfield
+                            input.setError(PbjReader.IO_ERROR, "Bad tag [" + $prefixtag + "], field [" + $prefixfield
                                     + "] wireType [" + wireType + "]");
+                            return $unknownFields;
                         }""");
         for (int i = 0; i < list.size(); i++) {
             list.set(i, list.get(i)
@@ -287,7 +284,7 @@ class CodecParseMethodGenerator {
                 .formatted(tag, wireType, field.type(), fieldNum, field.name()));
         sbCase.append("%s = case%d(input, maxSize, %s);%n".formatted(tempFieldName, tag, tempFieldName));
         sbFunc.append("""
-%s case%d(PbjReader input, int maxSize, %s %s) throws ParseException, IOException {""".formatted(fieldType, tag, fieldType, tempFieldName));
+%s case%d(PbjReader input, int maxSize, %s %s) {""".formatted(fieldType, tag, fieldType, tempFieldName));
         final String preRead;
         int divideAmount = fieldType.equals("List<Integer>") ? 2
             : fieldType.equals("List<Long>") ? 4
@@ -319,10 +316,12 @@ class CodecParseMethodGenerator {
                 // Read the length of packed repeated field data
                 final int length = input.readVarInt(false);
                 if (length > $maxSize) {
-                    throw new ParseException("$fieldName size " + length + " is greater than max " + $maxSize);
+                    input.setError(PbjReader.PARSE, "$fieldName size " + length + " is greater than max " + $maxSize);
+                    return $tempFieldName;
                 }
                 if (input.remaining() < length) {
-                    throw new BufferUnderflowException();
+                    input.setError(PbjReader.BUFFER_UNDERFLOW);
+                    return $tempFieldName;
                 }
                 final var startLimit = input.limit();
                 final long startPosition = input.position();
@@ -335,7 +334,7 @@ class CodecParseMethodGenerator {
                 $tempFieldName = list;
                 input.limit(startLimit);
                 if (input.position() != startPosition + length) {
-                    throw new BufferUnderflowException();
+                    input.setError(PbjReader.BUFFER_UNDERFLOW);
                 }"""
                 .replace("$tempFieldName", tempFieldName)
                 .replace("$preRead", preRead)
@@ -421,7 +420,8 @@ class CodecParseMethodGenerator {
                             value = $fieldType.DEFAULT;
                         } else {
                             if (messageLength > $maxSize) {
-                                throw new ParseException("$fieldName size " + messageLength + " is greater than max " + $maxSize);
+                                input.setError(PbjReader.PARSE, "$fieldName size " + messageLength + " is greater than max " + $maxSize);
+                                return null;
                             }
                             final var limitBefore = input.limit();
                             // Make sure that we have enough bytes in the message
@@ -429,18 +429,17 @@ class CodecParseMethodGenerator {
                             // If the buffer is truncated on the boundary of a subObject,
                             // we will not throw.
                             final var startPos = input.position();
-                            try {
-                                if ((startPos + messageLength) > limitBefore) {
-                                    throw new BufferUnderflowException();
-                                }
-                                input.limit(startPos + messageLength);
-                                value = $readMethod;
-                                // Make sure we read the full number of bytes. for the types
-                                if ((startPos + messageLength) != input.position()) {
-                                    throw new BufferOverflowException();
-                                }
-                            } finally {
-                                input.limit(limitBefore);
+                            if ((startPos + messageLength) > limitBefore) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
+                            }
+                            input.limit(startPos + messageLength);
+                            value = $readMethod;
+                            input.limit(limitBefore);
+                            // Make sure we read the full number of bytes. for the types
+                            if ((startPos + messageLength) != input.position()) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
                             }
                         }
                         """
@@ -461,11 +460,12 @@ class CodecParseMethodGenerator {
             // spotless:off
             sbCase.append("""
                         final var __map_messageLength = input.readVarInt(false);
-                        
+
                         $fieldDefs
                         if (__map_messageLength != 0) {
                             if (__map_messageLength > $maxSize) {
-                                throw new ParseException("$fieldName size " + __map_messageLength + " is greater than max " + $maxSize);
+                                input.setError(PbjReader.PARSE, "$fieldName size " + __map_messageLength + " is greater than max " + $maxSize);
+                                return null;
                             }
                             final var __map_limitBefore = input.limit();
                             // Make sure that we have enough bytes in the message
@@ -473,18 +473,17 @@ class CodecParseMethodGenerator {
                             // If the buffer is truncated on the boundary of a subObject,
                             // we will not throw.
                             final var __map_startPos = input.position();
-                            try {
-                                if ((__map_startPos + __map_messageLength) > __map_limitBefore) {
-                                    throw new BufferUnderflowException();
-                                }
-                                input.limit(__map_startPos + __map_messageLength);
+                            if ((__map_startPos + __map_messageLength) > __map_limitBefore) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
+                            }
+                            input.limit(__map_startPos + __map_messageLength);
                         $mapParseLoop
-                                // Make sure we read the full number of bytes. for the types
-                                if ((__map_startPos + __map_messageLength) != input.position()) {
-                                    throw new BufferOverflowException();
-                                }
-                            } finally {
-                                input.limit(__map_limitBefore);
+                            input.limit(__map_limitBefore);
+                            // Make sure we read the full number of bytes. for the types
+                            if ((__map_startPos + __map_messageLength) != input.position()) {
+                                input.setError(PbjReader.BUFFER_UNDERFLOW);
+                                return null;
                             }
                         }
                         """
@@ -525,7 +524,8 @@ class CodecParseMethodGenerator {
             sbCase.append(
                 """
                 if (temp_%s.size() >= %s) {
-                    throw new ParseException("%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                    input.setError(PbjReader.PARSE, "%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                    return null;
                 }
                 temp_%1$s = addToList(temp_%1$s,value);
                 """.formatted(field.name(), field.maxSize() >= 0 ? String.valueOf(field.maxSize()) : "maxSize")
@@ -536,7 +536,8 @@ class CodecParseMethodGenerator {
                 """
                 if (__map_messageLength != 0) {
                     if (temp_%s.size() >= %s) {
-                        throw new ParseException("%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                        input.setError(PbjReader.PARSE, "%1$s size %%d is greater than max %2$s".formatted(temp_%1$s.size()));
+                        return null;
                     }
                     temp_%1$s = addToMap(temp_%1$s, temp_%s, temp_%s);
                 }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteByteArrayMethodGenerator.java
@@ -197,9 +197,9 @@ final class CodecWriteByteArrayMethodGenerator {
                                     $K k = pbjMap.getSortedKeys().get(i);
                                     $V v = pbjMap.get(k);
                                     int size = 0;
-                                    $fieldSizeOfLines
+                            $fieldSizeOfLines
                                     offset += ProtoArrayWriterTools.writeUnsignedVarInt(output, offset, size);
-                                    $fieldWriteLines
+                            $fieldWriteLines
                                 }
                             }
                             """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -44,9 +44,8 @@ final class CodecWriteMethodGenerator {
              *
              * @param data The input model data to write
              * @param out The output stream to write to
-             * @throws IOException If there is a problem writing
              */
-            protected final void writeImpl(@NonNull $modelClass data, @NonNull final WritableSequentialData out) throws IOException {
+            protected final void writeImpl(@NonNull $modelClass data, @NonNull final PbjWriter out) {
                 $fieldWriteLines
                 // Check if not-empty to avoid creating a lambda if there's nothing to write.
                 if (!data.getUnknownFields().isEmpty()) {

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -46,7 +46,7 @@ final class CodecWriteMethodGenerator {
              * @param out The output stream to write to
              */
             protected final void writeImpl(@NonNull $modelClass data, @NonNull final PbjWriter out) {
-                $fieldWriteLines
+            $fieldWriteLines
                 // Check if not-empty to avoid creating a lambda if there's nothing to write.
                 if (!data.getUnknownFields().isEmpty()) {
                     data.getUnknownFields().forEach(uf -> {
@@ -176,9 +176,9 @@ final class CodecWriteMethodGenerator {
                                     $K k = pbjMap.getSortedKeys().get(i);
                                     $V v = pbjMap.get(k);
                                     int size = 0;
-                                    $fieldSizeOfLines
+                            $fieldSizeOfLines
                                     out.writeVarInt(size, false);
-                                    $fieldWriteLines
+                            $fieldWriteLines
                                 }
                             }
                             """

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/CodecWriteMethodGenerator.java
@@ -51,7 +51,7 @@ final class CodecWriteMethodGenerator {
                 if (!data.getUnknownFields().isEmpty()) {
                     data.getUnknownFields().forEach(uf -> {
                         final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
-                        out.writeVarInt(tag, false);
+                        out.writeVarIntNoZZ(tag);
                         uf.bytes().writeTo(out);
                     });
                 }
@@ -177,7 +177,7 @@ final class CodecWriteMethodGenerator {
                                     $V v = pbjMap.get(k);
                                     int size = 0;
                             $fieldSizeOfLines
-                                    out.writeVarInt(size, false);
+                                    out.writeVarIntNoZZ(size);
                             $fieldWriteLines
                                 }
                             }

--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/protobuf/LazyGetProtobufSizeMethodGenerator.java
@@ -50,7 +50,7 @@ public class LazyGetProtobufSizeMethodGenerator {
                 .replace("$fieldSizeOfLines", fieldSizeOfLines.indent(DEFAULT_INDENT))
                 .replace(
                         "$unknownFieldsSizeOfLines",
-                        formatUnknownFieldsSizeOfLines().indent(DEFAULT_INDENT))
+                        formatUnknownFieldsSizeOfLines().indent(DEFAULT_INDENT * 2))
                 .indent(DEFAULT_INDENT);
         // spotless:on
     }
@@ -113,8 +113,6 @@ public class LazyGetProtobufSizeMethodGenerator {
             prefix += "if (" + oneOfField.nameCamelFirstLower() + ".kind() == " + oneOfType + "."
                     + Common.camelToUpperSnake(field.name()) + ")";
             prefix += "\n";
-            // The statement below is the (unbraced) body of the "if" above, so indent it one level
-            // deeper than the "if" itself to make that visually clear.
             statementIndent = " ".repeat(DEFAULT_INDENT);
         }
 
@@ -170,7 +168,7 @@ public class LazyGetProtobufSizeMethodGenerator {
                                 final int sizePre = _size;
                                 $K k = pbjMap.getSortedKeys().get(i);
                                 $V v = pbjMap.get(k);
-                                $fieldSizeOfLines
+                        $fieldSizeOfLines
                                 _size += sizeOfVarInt32(_size - sizePre);
                             }
                         }

--- a/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/main/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCall.java
@@ -242,7 +242,7 @@ public class PbjGrpcCall<RequestT, ReplyT> implements GrpcCall<RequestT, ReplyT>
 
                         try {
                             final ReplyT reply = replyCodec.parse(
-                                    replyBytes.toReadableSequentialData(),
+                                    replyBytes,
                                     false,
                                     false,
                                     Codec.DEFAULT_MAX_DEPTH,

--- a/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
+++ b/pbj-core/pbj-grpc-client-helidon/src/test/java/com/hedera/pbj/grpc/client/helidon/PbjGrpcCallTest.java
@@ -21,7 +21,6 @@ import com.hedera.pbj.runtime.grpc.GrpcException;
 import com.hedera.pbj.runtime.grpc.GrpcStatus;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
@@ -279,12 +278,7 @@ public class PbjGrpcCallTest {
         final Object reply = mock(Object.class);
         doReturn(reply)
                 .when(replyCodec)
-                .parse(
-                        any(ReadableSequentialData.class),
-                        eq(false),
-                        eq(false),
-                        eq(Codec.DEFAULT_MAX_DEPTH),
-                        eq(Codec.DEFAULT_MAX_SIZE));
+                .parse(any(Bytes.class), eq(false), eq(false), eq(Codec.DEFAULT_MAX_DEPTH), eq(Codec.DEFAULT_MAX_SIZE));
 
         runnable.run();
 
@@ -342,12 +336,7 @@ public class PbjGrpcCallTest {
         final ParseException exception = new ParseException("test");
         doThrow(exception)
                 .when(replyCodec)
-                .parse(
-                        any(ReadableSequentialData.class),
-                        eq(false),
-                        eq(false),
-                        eq(Codec.DEFAULT_MAX_DEPTH),
-                        eq(Codec.DEFAULT_MAX_SIZE));
+                .parse(any(Bytes.class), eq(false), eq(false), eq(Codec.DEFAULT_MAX_DEPTH), eq(Codec.DEFAULT_MAX_SIZE));
 
         runnable.run();
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -43,8 +43,7 @@ public abstract class Codec<T> {
      * @see #parse(ReadableSequentialData, boolean, boolean, int, int) for a description
      */
     protected abstract T parseImpl(
-            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
-            throws ParseException;
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize);
 
     /**
      * Parses an object from the {@link PbjReader} and returns it.
@@ -90,8 +89,7 @@ public abstract class Codec<T> {
      * Return value may be null
      */
     public final T parseNoEx(
-            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
-            throws ParseException {
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
         return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
     }
 
@@ -99,7 +97,7 @@ public abstract class Codec<T> {
      * Same as parseStrict, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
      * Return value may be null
      */
-    public final T parseNoEx(@NonNull PbjReader input) throws ParseException {
+    public final T parseNoEx(@NonNull PbjReader input) {
         return parseNoEx(input, true, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -5,6 +5,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -238,6 +239,10 @@ public abstract class Codec<T> {
      */
     public final void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         writeImpl(item, output);
+    }
+
+    public final void write(@NonNull T item, @NonNull PbjWriter output) {
+        // Next commit implements this
     }
 
     /**

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -205,6 +205,12 @@ public abstract class Codec<T> {
             throws ParseException {
         return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
     }
+
+    @NonNull
+    public final T parse(@NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth)
+            throws ParseException {
+        return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
+    }
     /**
      * Temporary for test compatibility
      *
@@ -251,7 +257,45 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
-        return parse(new PbjReader(bytes), strictMode, false, maxDepth, DEFAULT_MAX_SIZE);
+        return parse(bytes, strictMode, false, maxDepth, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Parses an object from the {@link Bytes} and returns it.
+     * <p>
+     * If {@code strictMode} is {@code true}, then throws an exception if fields
+     * have been defined on the encoded object that are not supported by the parser. This
+     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
+     * which is sometimes requires to avoid parsing an object that is newer than the code
+     * parsing it is prepared to handle.
+     * <p>
+     * The {@code maxDepth} specifies the maximum allowed depth of nested messages. The parsing
+     * will fail with a ParseException if the maximum depth is reached.
+     * <p>
+     * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
+     * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
+     * payload can cause the parser to allocate too much memory which can result in OutOfMemory and/or crashes.
+     * It's important to carefully estimate the maximum size limit that a particular protobuf model type should support,
+     * and then pass that value as a parameter. Note that the estimated limit should apply to the **type** as a whole,
+     * rather than to individual instances of the model. In other words, this value should be a constant, or a config
+     * value that is controlled by the application, rather than come from the input that the application reads.
+     * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
+     *
+     * @param input The {@link Bytes} from which to read the data to construct an object
+     * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+     * @param parseUnknownFields when {@code true} and strictMode is {@code false}, the parser will collect unknown
+     *                           fields in the unknownFields list in the model; otherwise they'll be simply skipped.
+     * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
+     * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(
+            @NonNull Bytes input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        return parse(reader, strictMode, parseUnknownFields, maxDepth, maxSize);
     }
 
     /**
@@ -277,7 +321,7 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parse(@NonNull Bytes bytes) throws ParseException {
-        return parse(bytes.toReadableSequentialData());
+        return parse(bytes, false, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
     }
 
     /**
@@ -311,7 +355,7 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parseStrict(@NonNull Bytes bytes) throws ParseException {
-        return parseStrict(bytes.toReadableSequentialData());
+        return parse(bytes, true, DEFAULT_MAX_DEPTH);
     }
 
     /**
@@ -489,7 +533,7 @@ public abstract class Codec<T> {
      * to write to the {@link WritableStreamingData}
      */
     public Bytes toBytes(@NonNull T item) {
-        // TODO: Confirm if this next line is accurate with PbjWriter
+        // TODO: Confirm if this next line is still true with PbjWriter
         // it is cheaper performance wise to measure the size of the object first than grow a buffer as needed
         final byte[] bytes = new byte[measureRecord(item)];
         final PbjWriter writer = new PbjWriter(bytes, 0);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/Codec.java
@@ -3,13 +3,13 @@ package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.BufferedSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 
 /**
  * Encapsulates Serialization, Deserialization and other IO operations.
@@ -38,18 +38,100 @@ public abstract class Codec<T> {
      * consistent entry point. Subclasses implement this method rather than {@code parse} directly, since
      * {@code parse} may perform additional work before and after delegating to this implementation.
      *
+     * The only difference is it's allowed to return null, the parse overloads call throwOnError.
+     *
      * @see #parse(ReadableSequentialData, boolean, boolean, int, int) for a description
      */
-    @NonNull
     protected abstract T parseImpl(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException;
 
     /**
+     * Parses an object from the {@link PbjReader} and returns it.
+     * <p>
+     * If {@code strictMode} is {@code true}, then throws an exception if fields
+     * have been defined on the encoded object that are not supported by the parser. This
+     * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
+     * which is sometimes requires to avoid parsing an object that is newer than the code
+     * parsing it is prepared to handle.
+     * <p>
+     * The {@code maxDepth} specifies the maximum allowed depth of nested messages. The parsing
+     * will fail with a ParseException if the maximum depth is reached.
+     * <p>
+     * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
+     * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
+     * payload can cause the parser to allocate too much memory which can result in OutOfMemory and/or crashes.
+     * It's important to carefully estimate the maximum size limit that a particular protobuf model type should support,
+     * and then pass that value as a parameter. Note that the estimated limit should apply to the **type** as a whole,
+     * rather than to individual instances of the model. In other words, this value should be a constant, or a config
+     * value that is controlled by the application, rather than come from the input that the application reads.
+     * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
+     *
+     * @param input The {@link PbjReader} from which to read the data to construct an object
+     * @param strictMode when {@code true}, the parser errors out on unknown fields; otherwise they'll be simply skipped.
+     * @param parseUnknownFields when {@code true} and strictMode is {@code false}, the parser will collect unknown
+     *                           fields in the unknownFields list in the model; otherwise they'll be simply skipped.
+     * @param maxDepth a ParseException will be thrown if the depth of nested messages exceeds the maxDepth value.
+     * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        T res = parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+        input.throwOnError();
+        return res;
+    }
+
+    /**
+     * Same as parse, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
+     * Return value may be null
+     */
+    public final T parseNoEx(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
+            throws ParseException {
+        return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+    }
+
+    /**
+     * Same as parseStrict, except doesn't throw. Check for error by using input.error() != 0 (or > 0), or input.ok()
+     * Return value may be null
+     */
+    public final T parseNoEx(@NonNull PbjReader input) throws ParseException {
+        return parseNoEx(input, true, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Parses an object from the {@link PbjReader} and returns it, using the default `Codec.DEFAULT_MAX_SIZE` and
+     * `Codec.DEFAULT_MAX_DEPTH` limits, and without strict mode or unknown field collection.
+     *
+     * @param input The {@link PbjReader} from which to read the data to construct an object
+     * @return The parsed object. It must not return null.
+     * @throws ParseException If parsing fails
+     */
+    @NonNull
+    public final T parse(@NonNull PbjReader input) throws ParseException {
+        return parse(input, false, false, DEFAULT_MAX_DEPTH, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Writes the true, logical number of bytes consumed by {@code reader} (which may be less than the number of
+     * bytes {@code reader} has physically buffered ahead from {@code input}) back onto {@code input}'s position,
+     * so that further reads of a {@link BufferedSequentialData}-backed {@code input} continue exactly where the
+     * parsed message ended. A plain stream-backed {@code input} (not a {@link BufferedSequentialData}) cannot be
+     * rewound, so it is left as-is and must be treated as fully consumed by the caller.
+     */
+    private static void syncPosition(@NonNull ReadableSequentialData input, @NonNull PbjReader reader) {
+        if (input instanceof BufferedSequentialData bsd) {
+            bsd.position(reader.position());
+        }
+    }
+
+    /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -87,10 +169,17 @@ public abstract class Codec<T> {
             int maxDepth,
             int maxSize)
             throws ParseException {
-        return parseImpl(input, strictMode, parseUnknownFields, maxDepth, maxSize);
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return parse(reader, strictMode, parseUnknownFields, maxDepth, maxSize);
+        } finally {
+            syncPosition(input, reader);
+        }
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -119,6 +208,8 @@ public abstract class Codec<T> {
         return parse(input, strictMode, parseUnknownFields, maxDepth, DEFAULT_MAX_SIZE);
     }
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      * <p>
      * If {@code strictMode} is {@code true}, then throws an exception if fields
@@ -162,10 +253,12 @@ public abstract class Codec<T> {
      */
     @NonNull
     public final T parse(@NonNull Bytes bytes, final boolean strictMode, final int maxDepth) throws ParseException {
-        return parse(bytes.toReadableSequentialData(), strictMode, maxDepth);
+        return parse(new PbjReader(bytes), strictMode, false, maxDepth, DEFAULT_MAX_SIZE);
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it.
      *
      * @param input The {@link ReadableSequentialData} from which to read the data to construct an object
@@ -190,6 +283,8 @@ public abstract class Codec<T> {
     }
 
     /**
+     * Temporary for test compatibility
+     *
      * Parses an object from the {@link ReadableSequentialData} and returns it. Throws an exception if fields
      * have been defined on the encoded object that are not supported by the parser. This
      * breaks forwards compatibility (an older parser cannot parse a newer encoded object),
@@ -226,23 +321,45 @@ public abstract class Codec<T> {
      * consistent entry point. Subclasses implement this method rather than {@code write} directly, since
      * {@code write} may perform additional work before and after delegating to this implementation.
      *
-     * @see #write(Object, WritableSequentialData) for a description
+     * @see #write(Object, PbjWriter) for a description
      */
-    protected abstract void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException;
+    protected abstract void writeImpl(@NonNull T item, @NonNull PbjWriter output);
 
     /**
+     * Writes an item to the given {@link PbjWriter}.
+     *
+     * @param item The item to write. Must not be null.
+     * @param output The {@link PbjWriter} to write to.
+     */
+    public final void write(@NonNull T item, @NonNull PbjWriter output) {
+        writeImpl(item, output);
+        output.throwOnError();
+    }
+
+    /**
+     * Writes an item to the given {@link PbjWriter}.
+     *
+     * @param item The item to write. Must not be null.
+     * @param output The {@link PbjWriter} to write to.
+     */
+    public final void writeNoEx(@NonNull T item, @NonNull PbjWriter output) {
+        writeImpl(item, output);
+    }
+
+    /**
+     * Temporary for test compatibility
+     *
      * Writes an item to the given {@link WritableSequentialData}.
      *
      * @param item The item to write. Must not be null.
      * @param output The {@link WritableSequentialData} to write to.
      * @throws IOException If the {@link WritableSequentialData} cannot be written to.
      */
-    public final void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
-        writeImpl(item, output);
-    }
-
-    public final void write(@NonNull T item, @NonNull PbjWriter output) {
-        // Next commit implements this
+    public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+        final PbjWriter writer = new PbjWriter(output);
+        writeImpl(item, writer);
+        writer.flush();
+        writer.throwOnError();
     }
 
     /**
@@ -253,7 +370,7 @@ public abstract class Codec<T> {
      * @param output The byte array to write to, this must be large enough to hold the entire item.
      * @param startOffset The offset in the output array to start writing at.
      * @return The number of bytes written to the output array.
-     * @throws UncheckedIOException If the there is a problem writing to the output array.
+     * @throws RuntimeException If there is a problem writing to the output array.
      * @throws IndexOutOfBoundsException If the output array is not large enough to hold the entire item.
      */
     public final int write(@NonNull T item, @NonNull byte[] output, final int startOffset) {
@@ -267,18 +384,18 @@ public abstract class Codec<T> {
      * The actual byte-array writing logic for a specific codec, invoked by the {@link #write(Object, byte[], int)}
      * methods through a single, consistent entry point. Generated codecs override this method with a
      * performance-focused implementation; this default implementation delegates to
-     * {@link #writeImpl(Object, WritableSequentialData)} so that hand-written codecs don't need to provide one.
+     * {@link #writeImpl(Object, PbjWriter)} so that hand-written codecs don't need to provide one.
      *
      * @see #write(Object, byte[], int) for a description
      */
     protected int writeImpl(@NonNull T item, @NonNull byte[] output, final int startOffset) {
-        final BufferedData bufferedData = BufferedData.wrap(output, startOffset, output.length - startOffset);
+        final PbjWriter writer = new PbjWriter(output, startOffset);
         try {
-            write(item, bufferedData);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            writeImpl(item, writer);
+        } finally {
+            writer.flush();
         }
-        return (int) bufferedData.position();
+        return writer.position() - startOffset;
     }
 
     /**
@@ -290,7 +407,31 @@ public abstract class Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    public abstract int measure(@NonNull ReadableSequentialData input) throws ParseException;
+    public abstract int measure(@NonNull PbjReader input) throws ParseException;
+
+    /**
+     * Temporary for test compatibility
+     *
+     * Reads from this data input the length of the data within the input. The implementation may
+     * read all the data, or just some special serialized data, as needed to find out the length of
+     * the data.
+     * <p>
+     * If {@code input} is a {@link BufferedSequentialData} (e.g. {@code BufferedData}), its position is
+     * updated to reflect exactly the bytes consumed by this call. A plain stream-backed input should be
+     * treated as fully consumed afterward.
+     *
+     * @param input The input to use
+     * @return The length of the data item in the input
+     * @throws ParseException If parsing fails
+     */
+    public final int measure(@NonNull ReadableSequentialData input) throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return measure(reader);
+        } finally {
+            syncPosition(input, reader);
+        }
+    }
 
     /**
      * Compute number of bytes that would be written when calling {@code write()} method.
@@ -312,7 +453,34 @@ public abstract class Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public abstract boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException;
+    public abstract boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException;
+
+    /**
+     * Temporary for test compatibility
+     *
+     * Compares the given item with the bytes in the input, and returns false if it determines that
+     * the bytes in the input could not be equal to the given item. Sometimes we need to compare an
+     * item in memory with serialized bytes and don't want to incur the cost of deserializing the
+     * entire object, when we could have determined the bytes do not represent the same object very
+     * cheaply and quickly.
+     * <p>
+     * If {@code input} is a {@link BufferedSequentialData} (e.g. {@code BufferedData}), its position is
+     * updated to reflect exactly the bytes consumed by this call. A plain stream-backed input should be
+     * treated as fully consumed afterward.
+     *
+     * @param item The item to compare. Cannot be null.
+     * @param input The input with the bytes to compare
+     * @return true if the bytes represent the item, false otherwise.
+     * @throws ParseException If parsing fails
+     */
+    public final boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+        final PbjReader reader = new PbjReader(input);
+        try {
+            return fastEquals(item, reader);
+        } finally {
+            syncPosition(input, reader);
+        }
+    }
 
     /**
      * Converts a Record into a Bytes object
@@ -323,13 +491,14 @@ public abstract class Codec<T> {
      * to write to the {@link WritableStreamingData}
      */
     public Bytes toBytes(@NonNull T item) {
+        // TODO: Confirm if this next line is accurate with PbjWriter
         // it is cheaper performance wise to measure the size of the object first than grow a buffer as needed
         final byte[] bytes = new byte[measureRecord(item)];
-        final BufferedData bufferedData = BufferedData.wrap(bytes);
+        final PbjWriter writer = new PbjWriter(bytes, 0);
         try {
-            write(item, bufferedData);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            writeImpl(item, writer);
+        } finally {
+            writer.flush();
         }
         return Bytes.wrap(bytes);
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -21,7 +22,7 @@ public abstract class JsonCodec<T> extends Codec<T> {
     /** {@inheritDoc} */
     @Override
     protected final @NonNull T parseImpl(
-            @NonNull ReadableSequentialData input,
+            @NonNull PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -74,7 +75,19 @@ public abstract class JsonCodec<T> extends Codec<T> {
 
     /** {@inheritDoc} */
     @Override
-    protected final void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+    protected final void writeImpl(@NonNull T item, @NonNull PbjWriter output) {
+        output.writeStringNoTag(toJSON(item));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Writes directly via {@code output.writeUTF8(...)} instead of routing through a {@link PbjWriter}, since some
+     * {@link WritableSequentialData} implementations only support the string-level {@code writeUTF8} hook and not
+     * raw byte writes.
+     */
+    @Override
+    public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         output.writeUTF8(toJSON(item));
     }
     /**
@@ -118,7 +131,8 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * @return The length of the data item in the input
      * @throws ParseException If parsing fails
      */
-    public final int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    @Override
+    public final int measure(@NonNull PbjReader input) throws ParseException {
         final long startPosition = input.position();
         parse(input);
         return (int) (input.position() - startPosition);
@@ -157,7 +171,8 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public final boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    @Override
+    public final boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException {
         return Objects.equals(item, parse(input));
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -90,6 +90,7 @@ public abstract class JsonCodec<T> extends Codec<T> {
     public void write(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
         output.writeUTF8(toJSON(item));
     }
+
     /**
      * Returns JSON string representing an item.
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonCodec.java
@@ -21,36 +21,34 @@ public abstract class JsonCodec<T> extends Codec<T> {
 
     /** {@inheritDoc} */
     @Override
-    protected final @NonNull T parseImpl(
+    protected final T parseImpl(
             @NonNull PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
-            final int maxSize)
-            throws ParseException {
-        try {
-            return parse(JsonTools.parseJson(input), strictMode, maxDepth, maxSize);
-        } catch (IOException ex) {
-            throw new ParseException(ex);
-        }
+            final int maxSize) {
+        return parseImpl(JsonTools.parseJson(input), input, strictMode, maxDepth, maxSize);
     }
 
     /**
-     * The actual parsing logic for a specific codec, invoked by the {@link #parse} methods through a single,
-     * consistent entry point. Subclasses implement this method rather than {@code parse} directly, since
-     * {@code parse} may perform additional work before and after delegating to this implementation.
+     * The actual parsing logic for a specific codec, invoked by the {@link #parseNoEx} methods through a single,
+     * consistent entry point. Subclasses implement this method rather than {@code parseNoEx} directly, since
+     * {@code parseNoEx} may perform additional work before and after delegating to this implementation.
      *
-     * @see #parse(JSONParser.ObjContext, boolean, int, int) for a description of each parameter
-     * @return The parsed object. It must not return null.
-     * @throws ParseException If parsing fails
+     * @see #parseNoEx(JSONParser.ObjContext, PbjReader, boolean, int, int) for a description of each parameter
+     * @return The parsed object, or {@code null} if an error was set on {@code input}
      */
-    @NonNull
     protected abstract T parseImpl(
-            @Nullable final JSONParser.ObjContext root, final boolean strictMode, final int maxDepth, final int maxSize)
-            throws ParseException;
+            @Nullable final JSONParser.ObjContext root,
+            @NonNull final PbjReader input,
+            final boolean strictMode,
+            final int maxDepth,
+            final int maxSize);
 
     /**
-     * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. Throws if in strict mode ONLY.
+     * Parses a HashObject object from JSON parse tree for object JSONParser.ObjContext. Sets an error on
+     * {@code input} in strict mode ONLY. Same as parse, except doesn't throw. Check for error by using
+     * {@code input.error() != 0} (or {@code > 0}), or {@code input.ok()}. Return value may be null.
      * <p>
      * The {@code maxSize} specifies a custom value for the default `Codec.DEFAULT_MAX_SIZE` limit. IMPORTANT:
      * specifying a value larger than the default one can put the application at risk because a maliciously-crafted
@@ -62,15 +60,17 @@ public abstract class JsonCodec<T> extends Codec<T> {
      * When in doubt, use the other overloaded versions of this method that use the default `Codec.DEFAULT_MAX_SIZE`.
      *
      * @param root The JSON parsed object tree to parse data from
-     * @param maxSize a ParseException will be thrown if the size of a delimited field exceeds the limit
-     * @return Parsed HashObject model object or null if data input was null or empty
-     * @throws ParseException If parsing fails
+     * @param input the {@link PbjReader} used solely to carry error state for this parse; sets
+     *              {@link PbjReader#PARSE} if the size of a delimited field exceeds the limit
+     * @return Parsed HashObject model object, or {@code null} if data input was null or empty, or an error was set
      */
-    @NonNull
-    public final T parse(
-            @Nullable final JSONParser.ObjContext root, final boolean strictMode, final int maxDepth, final int maxSize)
-            throws ParseException {
-        return parseImpl(root, strictMode, maxDepth, maxSize);
+    public final T parseNoEx(
+            @Nullable final JSONParser.ObjContext root,
+            @NonNull final PbjReader input,
+            final boolean strictMode,
+            final int maxDepth,
+            final int maxSize) {
+        return parseImpl(root, input, strictMode, maxDepth, maxSize);
     }
 
     /** {@inheritDoc} */

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.jsonparser.JSONLexer;
 import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -88,13 +88,13 @@ public final class JsonTools {
     // Parse Methods
 
     /**
-     * Parse a JSON string in a ReadableSequentialData into a JSON object.
+     * Parse a JSON string in a PbjReader into a JSON object.
      *
-     * @param input the ReadableSequentialData containing the JSON string
+     * @param input the PbjReader containing the JSON string
      * @return the Antlr JSON context object
      * @throws IOException if there was a problem parsing the JSON
      */
-    public static JSONParser.ObjContext parseJson(@NonNull final ReadableSequentialData input) throws IOException {
+    public static JSONParser.ObjContext parseJson(@NonNull final PbjReader input) throws IOException {
         final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
         final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
         final JSONParser.JsonContext jsonContext = parser.json();

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/JsonTools.java
@@ -8,6 +8,7 @@ import com.hedera.pbj.runtime.jsonparser.JSONParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.CharBuffer;
 import java.util.Base64;
 import java.util.List;
@@ -92,14 +93,17 @@ public final class JsonTools {
      *
      * @param input the PbjReader containing the JSON string
      * @return the Antlr JSON context object
-     * @throws IOException if there was a problem parsing the JSON
      */
-    public static JSONParser.ObjContext parseJson(@NonNull final PbjReader input) throws IOException {
-        final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
-        final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
-        final JSONParser.JsonContext jsonContext = parser.json();
-        final JSONParser.ValueContext valueContext = jsonContext.value();
-        return valueContext.obj();
+    public static JSONParser.ObjContext parseJson(@NonNull final PbjReader input) {
+        try {
+            final JSONLexer lexer = new JSONLexer(CharStreams.fromStream(input.asInputStream()));
+            final JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
+            final JSONParser.JsonContext jsonContext = parser.json();
+            final JSONParser.ValueContext valueContext = jsonContext.value();
+            return valueContext.obj();
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     /**
@@ -158,19 +162,18 @@ public final class JsonTools {
      *
      * @param list the JSON list to parse
      * @param codec the JsonCodec to use to parse the objects
+     * @param input the {@link PbjReader} used solely to carry error state for this parse
      * @return the list of parsed objects
      * @param <T> the type of the objects to parse
      */
     public static <T> List<T> parseObjArray(
-            List<JSONParser.ValueContext> list, JsonCodec<T> codec, final int maxDepth, final int maxSize) {
+            List<JSONParser.ValueContext> list,
+            JsonCodec<T> codec,
+            @NonNull final PbjReader input,
+            final int maxDepth,
+            final int maxSize) {
         return list.stream()
-                .map(v -> {
-                    try {
-                        return codec.parse(v.obj(), false, maxDepth - 1, maxSize);
-                    } catch (ParseException e) {
-                        throw new UncheckedParseException(e);
-                    }
-                })
+                .map(v -> codec.parseNoEx(v.obj(), input, false, maxDepth - 1, maxSize))
                 .toList();
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ParseException.java
@@ -16,4 +16,12 @@ public class ParseException extends Exception {
     public ParseException(String message) {
         super(message);
     }
+
+    public ParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ParseException(Throwable cause, boolean skipStackTag) {
+        super(null, cause, true, false);
+    }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -3,6 +3,7 @@ package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
@@ -82,12 +83,32 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf int32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readInt32(PbjReader input) {
+        return input.readVarInt(false);
+    }
+
+    /**
      * Read a protobuf int64(long) from input
      *
      * @param input The input data to read from
      * @return the read long
      */
     public static long readInt64(final ReadableSequentialData input) {
+        return input.readVarLong(false);
+    }
+
+    /**
+     * Read a protobuf int64(long) from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readInt64(PbjReader input) {
         return input.readVarLong(false);
     }
 
@@ -102,12 +123,32 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf uint32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readUint32(PbjReader input) {
+        return input.readVarInt(false);
+    }
+
+    /**
      * Read a protobuf uint64 from input
      *
      * @param input The input data to read from
      * @return the read long
      */
     public static long readUint64(final ReadableSequentialData input) {
+        return input.readVarLong(false);
+    }
+
+    /**
+     * Read a protobuf uint64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readUint64(PbjReader input) {
         return input.readVarLong(false);
     }
 
@@ -127,12 +168,36 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf bool from input
+     *
+     * @param input The input data to read from
+     * @return the read boolean
+     */
+    public static boolean readBool(PbjReader input) {
+        final var i = input.readVarInt(false);
+        if (i != 1 && i != 0) {
+            input.setError(PbjReader.DATA_ENCODING);
+        }
+        return i == 1;
+    }
+
+    /**
      * Read a protobuf enum from input
      *
      * @param input The input data to read from
      * @return the read enum protoc ordinal
      */
     public static int readEnum(final ReadableSequentialData input) {
+        return input.readVarInt(false);
+    }
+
+    /**
+     * Read a protobuf enum from input
+     *
+     * @param input The input data to read from
+     * @return the read enum protoc ordinal
+     */
+    public static int readEnum(PbjReader input) {
         return input.readVarInt(false);
     }
 
@@ -147,6 +212,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf sint32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readSignedInt32(PbjReader input) {
+        return input.readVarIntZZ();
+    }
+
+    /**
      * Read a protobuf uint64(long) from input
      *
      * @param input The input data to read from
@@ -154,6 +229,16 @@ public final class ProtoParserTools {
      */
     public static long readSignedInt64(final ReadableSequentialData input) {
         return input.readVarLong(true);
+    }
+
+    /**
+     * Read a protobuf sint64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readSignedInt64(PbjReader input) {
+        return input.readVarLongZZ();
     }
 
     /**
@@ -167,6 +252,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf sfixed32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readSignedFixed32(PbjReader input) {
+        return input.readIntLE();
+    }
+
+    /**
      * Read a protobuf fixed32 from input
      *
      * @param input The input data to read from
@@ -174,6 +269,16 @@ public final class ProtoParserTools {
      */
     public static int readFixed32(final ReadableSequentialData input) {
         return input.readInt(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a protobuf fixed32 from input
+     *
+     * @param input The input data to read from
+     * @return the read int
+     */
+    public static int readFixed32(PbjReader input) {
+        return input.readIntLE();
     }
 
     /**
@@ -187,6 +292,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a protobuf float from input
+     *
+     * @param input The input data to read from
+     * @return the read float
+     */
+    public static float readFloat(PbjReader input) {
+        return input.readFloatLE();
+    }
+
+    /**
      * Read a protobuf sfixed64 from input
      *
      * @param input The input data to read from
@@ -194,6 +309,16 @@ public final class ProtoParserTools {
      */
     public static long readSignedFixed64(final ReadableSequentialData input) {
         return input.readLong(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a protobuf sfixed64 from input
+     *
+     * @param input The input data to read from
+     * @return the read long
+     */
+    public static long readSignedFixed64(final PbjReader input) {
+        return input.readLongLE();
     }
 
     /**
@@ -207,6 +332,16 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a fixed 64, which is a fixed size encoded long
+     *
+     * @param input the input to read from
+     * @return read long
+     */
+    public static long readFixed64(PbjReader input) {
+        return input.readLongLE();
+    }
+
+    /**
      * Read a double from input data
      *
      * @param input the input to read from
@@ -214,6 +349,16 @@ public final class ProtoParserTools {
      */
     public static double readDouble(final ReadableSequentialData input) {
         return input.readDouble(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Read a double from input data
+     *
+     * @param input the input to read from
+     * @return read double
+     */
+    public static double readDouble(PbjReader input) {
+        return input.readDoubleLE();
     }
 
     /**
@@ -228,6 +373,10 @@ public final class ProtoParserTools {
         } catch (ParseException ex) {
             throw new UncheckedParseException(ex);
         }
+    }
+
+    public static String readString(final PbjReader input) {
+        return readString(input, Long.MAX_VALUE);
     }
 
     /**
@@ -265,6 +414,17 @@ public final class ProtoParserTools {
         } catch (CharacterCodingException e) {
             throw new MalformedProtobufException("Malformed UTF-8 string encountered", e);
         }
+    }
+
+    /**
+     * Read a String field from data input
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return Read string
+     */
+    public static String readString(final PbjReader input, final long maxSize) {
+        return input.readString(maxSize);
     }
 
     private static int fromUTF8Tail(char[] dst, int di, byte[] src, int i, int endPos) {
@@ -436,6 +596,24 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Read a Bytes field from data input, setting an error on {@code input} if the Bytes in the input
+     * is longer than the maxSize.
+     *
+     * @param input the input to read from
+     * @param maxSize the maximum allowed size
+     * @return read Bytes object, this can be a copy or a direct reference to inputs data. So it has same life span
+     * of InputData
+     */
+    public static Bytes readBytes(final PbjReader input, final long maxSize) {
+        final int length = input.readVarInt(false);
+        if (length > maxSize || length < 0) {
+            input.setError(PbjReader.PARSE);
+            return Bytes.EMPTY;
+        }
+        return input.readBytes(length);
+    }
+
+    /**
      * Reads a requested length-delimited protobuf field from the input and returns it as a
      * {@link Bytes} object. If the requested field is repeated or not length-delimited, this
      * method throws an {@link IllegalArgumentException}. .
@@ -494,6 +672,49 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Reads a requested length-delimited protobuf field from the input and returns it as a
+     * {@link Bytes} object. If the requested field is repeated or not length-delimited, this
+     * method throws an {@link IllegalArgumentException}. .
+     *
+     * <p>The input must contain valid protobuf encoded bytes. If the field is not found in
+     * the input {@code null} is returned. If the field occurs multiple time in the input, bytes
+     * for the first occurrence are returned.
+     *
+     * <p>The returned Bytes object, if not null, will not contain the tag or the length.
+     *
+     * @param input The input to read from
+     * @param field Field definition to extract bytes for
+     * @return Field bytes without tag or length, or {@code null} if the field is not found
+     *      in the input
+     */
+    @Nullable
+    public static Bytes extractFieldBytes(@NonNull final PbjReader input, @NonNull final FieldDefinition field) {
+        Objects.requireNonNull(input);
+        Objects.requireNonNull(field);
+        if (field.repeated()) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a repeated field: " + field);
+        }
+        if (ProtoWriterTools.wireType(field) != ProtoConstants.WIRE_TYPE_DELIMITED) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a non-length-delimited field: " + field);
+        }
+        while (input.hasRemaining()) {
+            final int tag = input.readVarIntNoZZ();
+            final int fieldNum = tag >> TAG_FIELD_OFFSET;
+            final ProtoConstants wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+            if (fieldNum == field.number()) {
+                if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    input.setError(PbjReader.PARSE);
+                }
+                final int length = input.readVarIntNoZZ();
+                return input.readBytes(length);
+            } else {
+                skipField(input, wireType);
+            }
+        }
+        return null;
+    }
+
+    /**
      * Extract the bytes in a stream for a given wire type. Assumes you have already read tag.
      *
      * @param input The input to move ahead
@@ -531,6 +752,50 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Extract the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     * @param maxSize the maximum allowed size for repeated/length-encoded fields
+     * @return the extracted bytes
+     */
+    public static Bytes extractField(final PbjReader input, final ProtoConstants wireType, final long maxSize) {
+        return switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.readBytes(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.readBytes(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLongBytes();
+            case WIRE_TYPE_DELIMITED -> {
+                final Bytes lenBytes = input.readVarLongBytes();
+                final int length = lenBytes.getVarInt(0, false);
+                if (length < 0) {
+                    input.setError(PbjReader.IO_ERROR);
+                    yield Bytes.EMPTY;
+                }
+                if (length > maxSize) {
+                    input.setError(PbjReader.PARSE);
+                    yield Bytes.EMPTY;
+                }
+                yield Bytes.merge(lenBytes, input.readBytes(length));
+            }
+            case WIRE_TYPE_GROUP_START -> {
+                input.setError(PbjReader.UNSUPPORTED);
+                yield Bytes.EMPTY;
+            }
+            case WIRE_TYPE_GROUP_END -> {
+                input.setError(PbjReader.UNSUPPORTED);
+                yield Bytes.EMPTY;
+            }
+            default -> {
+                input.setError(PbjReader.IO_ERROR);
+                yield Bytes.EMPTY;
+            }
+        };
+    }
+
+    /**
      * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
      *
      * @param input The input to move ahead
@@ -543,6 +808,16 @@ public final class ProtoParserTools {
         } catch (ParseException ex) {
             throw new UncheckedParseException(ex);
         }
+    }
+
+    /**
+     * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     */
+    public static void skipField(final PbjReader input, final ProtoConstants wireType) {
+        skipField(input, wireType, Long.MAX_VALUE);
     }
 
     /**
@@ -580,12 +855,54 @@ public final class ProtoParserTools {
     }
 
     /**
+     * Skip over the bytes in a stream for a given wire type. Assumes you have already read tag.
+     *
+     * @param input The input to move ahead
+     * @param wireType The wire type of field to skip
+     * @param maxSize the maximum allowed size for repeated/length-encoded fields
+     */
+    public static void skipField(final PbjReader input, final ProtoConstants wireType, final long maxSize) {
+        switch (wireType) {
+            case WIRE_TYPE_FIXED_64_BIT -> input.skip(8);
+            case WIRE_TYPE_FIXED_32_BIT -> input.skip(4);
+            // The value for "zigZag" when calling varint doesn't matter because we are just reading past
+            // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
+            // the bytes, not how many of them there are)
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLong(false);
+            case WIRE_TYPE_DELIMITED -> {
+                final int length = input.readVarIntNoZZ();
+                if (length < 0) {
+                    input.setError(PbjReader.IO_ERROR);
+                }
+                if (length > maxSize) {
+                    input.setError(PbjReader.PARSE);
+                }
+                input.skip(length);
+            }
+            case WIRE_TYPE_GROUP_START -> input.setError(PbjReader.UNSUPPORTED);
+            case WIRE_TYPE_GROUP_END -> input.setError(PbjReader.UNSUPPORTED);
+            default -> input.setError(PbjReader.IO_ERROR);
+        }
+    }
+
+    /**
      * Read the next field number from the input
      *
      * @param input The input data to read from
      * @return the read tag
      */
     public static int readNextFieldNumber(final ReadableSequentialData input) {
+        final int tag = input.readVarInt(false);
+        return tag >> TAG_FIELD_OFFSET;
+    }
+
+    /**
+     * Read the next field number from the input
+     *
+     * @param input The input data to read from
+     * @return the read tag
+     */
+    public static int readNextFieldNumber(final PbjReader input) {
         final int tag = input.readVarInt(false);
         return tag >> TAG_FIELD_OFFSET;
     }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -280,7 +280,9 @@ public final class ProtoParserTools {
             int b = src[i + 1];
             if ((a & 0xE0) == 0xC0) {
                 if ((b & 0xC0) == 0x80) {
-                    dst[di++] = (char) (((a & 0x1F) << 6) | (b & 0x3F));
+                    int codepoint = ((a & 0x1F) << 6) | (b & 0x3F);
+                    if (codepoint < 0x80) return -1; // Overlong encoding
+                    dst[di++] = (char) codepoint;
                     i += 2;
                     continue;
                 } else {
@@ -295,6 +297,7 @@ public final class ProtoParserTools {
             if ((a & 0xF0) == 0xE0) {
                 if ((b & 0xC0) == 0x80 && (c & 0xC0) == 0x80) {
                     codepoint = ((a & 0xF) << 12) | ((b & 0x3F) << 6) | (c & 0x3F);
+                    if (codepoint < 0x800) return -1; // Overlong encoding
                     i += 3;
                 } else {
                     return -1; // Bad encoding
@@ -304,6 +307,7 @@ public final class ProtoParserTools {
                 int d = src[i + 3];
                 if ((a & 0xF8) == 0xF0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80 && (d & 0xC0) == 0x80) {
                     codepoint = ((a & 7) << 18) | ((b & 0x3F) << 12) | ((c & 0x3F) << 6) | (d & 0x3F);
+                    if (codepoint < 0x10000) return -1; // Overlong encoding
                     i += 4;
                 } else {
                     return -1; // Bad encoding
@@ -355,7 +359,9 @@ public final class ProtoParserTools {
             }
             int b = src[i + 1];
             if ((a & 0xE0) == 0xC0 && (b & 0xC0) == 0x80) {
-                dst[di++] = (char) (((a & 0x1F) << 6) | (b & 0x3F));
+                int codepoint = ((a & 0x1F) << 6) | (b & 0x3F);
+                if (codepoint < 0x80) return -1; // Overlong encoding
+                dst[di++] = (char) codepoint;
                 i += 2;
                 continue;
             }
@@ -363,11 +369,13 @@ public final class ProtoParserTools {
             int codepoint = -1;
             if ((a & 0xF0) == 0xE0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80) {
                 codepoint = ((a & 0xF) << 12) | ((b & 0x3F) << 6) | (c & 0x3F);
+                if (codepoint < 0x800) return -1; // Overlong encoding
                 i += 3;
             } else {
                 int d = src[i + 3];
                 if ((a & 0xF8) == 0xF0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80 && (d & 0xC0) == 0x80) {
                     codepoint = ((a & 7) << 18) | ((b & 0x3F) << 12) | ((c & 0x3F) << 6) | (d & 0x3F);
+                    if (codepoint < 0x10000) return -1; // Overlong encoding
                     i += 4;
                 }
             }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -89,7 +89,7 @@ public final class ProtoParserTools {
      * @return the read int
      */
     public static int readInt32(PbjReader input) {
-        return input.readVarInt(false);
+        return input.readVarIntNoZZ();
     }
 
     /**
@@ -109,7 +109,7 @@ public final class ProtoParserTools {
      * @return the read long
      */
     public static long readInt64(PbjReader input) {
-        return input.readVarLong(false);
+        return input.readVarLongNoZZ();
     }
 
     /**
@@ -129,7 +129,7 @@ public final class ProtoParserTools {
      * @return the read int
      */
     public static int readUint32(PbjReader input) {
-        return input.readVarInt(false);
+        return input.readVarIntNoZZ();
     }
 
     /**
@@ -149,7 +149,7 @@ public final class ProtoParserTools {
      * @return the read long
      */
     public static long readUint64(PbjReader input) {
-        return input.readVarLong(false);
+        return input.readVarLongNoZZ();
     }
 
     /**
@@ -174,7 +174,7 @@ public final class ProtoParserTools {
      * @return the read boolean
      */
     public static boolean readBool(PbjReader input) {
-        final var i = input.readVarInt(false);
+        final var i = input.readVarIntNoZZ();
         if (i != 1 && i != 0) {
             input.setError(PbjReader.DATA_ENCODING);
         }
@@ -198,7 +198,7 @@ public final class ProtoParserTools {
      * @return the read enum protoc ordinal
      */
     public static int readEnum(PbjReader input) {
-        return input.readVarInt(false);
+        return input.readVarIntNoZZ();
     }
 
     /**
@@ -605,7 +605,7 @@ public final class ProtoParserTools {
      * of InputData
      */
     public static Bytes readBytes(final PbjReader input, final long maxSize) {
-        final int length = input.readVarInt(false);
+        final int length = input.readVarIntNoZZ();
         if (length > maxSize || length < 0) {
             input.setError(PbjReader.PARSE);
             return Bytes.EMPTY;
@@ -868,7 +868,7 @@ public final class ProtoParserTools {
             // The value for "zigZag" when calling varint doesn't matter because we are just reading past
             // the varint, we don't care how to interpret it (zigzag is only used for interpretation of
             // the bytes, not how many of them there are)
-            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLong(false);
+            case WIRE_TYPE_VARINT_OR_ZIGZAG -> input.readVarLongNoZZ();
             case WIRE_TYPE_DELIMITED -> {
                 final int length = input.readVarIntNoZZ();
                 if (length < 0) {
@@ -903,7 +903,7 @@ public final class ProtoParserTools {
      * @return the read tag
      */
     public static int readNextFieldNumber(final PbjReader input) {
-        final int tag = input.readVarInt(false);
+        final int tag = input.readVarIntNoZZ();
         return tag >> TAG_FIELD_OFFSET;
     }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoParserTools.java
@@ -267,6 +267,126 @@ public final class ProtoParserTools {
         }
     }
 
+    private static int fromUTF8Tail(char[] dst, int di, byte[] src, int i, int endPos) {
+        while (i < endPos) {
+            int a = src[i];
+            if ((a & 0x80) == 0) {
+                dst[di++] = (char) a;
+                i++;
+                continue;
+            }
+            if (i + 1 >= endPos) return -1;
+
+            int b = src[i + 1];
+            if ((a & 0xE0) == 0xC0) {
+                if ((b & 0xC0) == 0x80) {
+                    dst[di++] = (char) (((a & 0x1F) << 6) | (b & 0x3F));
+                    i += 2;
+                    continue;
+                } else {
+                    return -1; // Bad encoding
+                }
+            }
+
+            if (i + 2 >= endPos) return -1;
+
+            int c = src[i + 2];
+            int codepoint = -1;
+            if ((a & 0xF0) == 0xE0) {
+                if ((b & 0xC0) == 0x80 && (c & 0xC0) == 0x80) {
+                    codepoint = ((a & 0xF) << 12) | ((b & 0x3F) << 6) | (c & 0x3F);
+                    i += 3;
+                } else {
+                    return -1; // Bad encoding
+                }
+            } else {
+                if (i + 3 >= endPos) return -1;
+                int d = src[i + 3];
+                if ((a & 0xF8) == 0xF0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80 && (d & 0xC0) == 0x80) {
+                    codepoint = ((a & 7) << 18) | ((b & 0x3F) << 12) | ((c & 0x3F) << 6) | (d & 0x3F);
+                    i += 4;
+                } else {
+                    return -1; // Bad encoding
+                }
+            }
+
+            if (codepoint <= 0xFFFF) {
+                if (codepoint < 0 || (codepoint >= 0xD800 && codepoint < 0xE000)) return -1; // [D800, E000) is illegal
+                dst[di++] = (char) codepoint;
+                continue;
+            }
+
+            if (codepoint > 0x10FFFF) return -1; // Illegal range
+            int v = codepoint - 0x10000;
+            dst[di + 0] = (char) (0xD800 + ((v >> 10) & 0x3FF));
+            dst[di + 1] = (char) (0xDC00 + (v & 0x3FF));
+            di += 2;
+        }
+        return di;
+    }
+
+    /**
+     * Decodes UTF-8 bytes from {@code src} into the {@code char[]} destination, supporting all
+     * four UTF-8 byte widths (1–4 bytes). Codepoints above U+FFFF are written as surrogate pairs.
+     * Prefer using the simpler {@link #readString} function.
+     *
+     * <p>Decoding starts at {@code src[offset + pos]} and continues until {@code src[offset + length]}.
+     * The main loop keeps a 4-byte lookahead (exits when fewer than 5 bytes remain), delegating
+     * the final bytes to {@link #fromUTF8Tail}. Any unrecognised byte sequence returns {@code -1}.
+     *
+     * @param dst    the destination char array, written starting at index {@code pos}
+     * @param src    the source byte array containing UTF-8 data
+     * @param offset the base index within {@code src} where the UTF-8 region begins
+     * @param pos    bytes already decoded by the ASCII fast path; doubles as the read offset
+     *               (relative to {@code offset}) and the initial write index in {@code dst}
+     * @param length the total byte length of the UTF-8 region in {@code src} starting at {@code offset}
+     * @return the total number of {@code char}s written to {@code dst}, or {@code -1} if the
+     *         input contains an illegal byte sequence (surrogate range or out-of-range codepoint)
+     */
+    public static int fromUTF8(char[] dst, byte[] src, int offset, int pos, int length) {
+        int i = offset + pos;
+        int di = pos;
+        while (i + 4 < offset + length) {
+            int a = src[i];
+            if ((a & 0x80) == 0) {
+                dst[di++] = (char) a;
+                i++;
+                continue;
+            }
+            int b = src[i + 1];
+            if ((a & 0xE0) == 0xC0 && (b & 0xC0) == 0x80) {
+                dst[di++] = (char) (((a & 0x1F) << 6) | (b & 0x3F));
+                i += 2;
+                continue;
+            }
+            int c = src[i + 2];
+            int codepoint = -1;
+            if ((a & 0xF0) == 0xE0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80) {
+                codepoint = ((a & 0xF) << 12) | ((b & 0x3F) << 6) | (c & 0x3F);
+                i += 3;
+            } else {
+                int d = src[i + 3];
+                if ((a & 0xF8) == 0xF0 && (b & 0xC0) == 0x80 && (c & 0xC0) == 0x80 && (d & 0xC0) == 0x80) {
+                    codepoint = ((a & 7) << 18) | ((b & 0x3F) << 12) | ((c & 0x3F) << 6) | (d & 0x3F);
+                    i += 4;
+                }
+            }
+
+            if (codepoint <= 0xFFFF) {
+                if (codepoint < 0 || (codepoint >= 0xD800 && codepoint < 0xE000)) return -1; // [D800, E000) is illegal
+                dst[di++] = (char) codepoint;
+                continue;
+            }
+
+            if (codepoint > 0x10FFFF) return -1; // illegal range
+            int v = codepoint - 0x10000;
+            dst[di + 0] = (char) (0xD800 + ((v >> 10) & 0x3FF));
+            dst[di + 1] = (char) (0xDC00 + (v & 0x3FF));
+            di += 2;
+        }
+        return i == offset + length ? di : fromUTF8Tail(dst, di, src, i, offset + length);
+    }
+
     /**
      * Read a Bytes field from data input
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
@@ -1,27 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.PbjWriter;
-import java.io.IOException;
 
 /**
- * Interface for referencing the static write method from generated writer classes.
+ * Interface for referencing the static write method from generated writer classes
  *
  * @param <T> The model object that is being written
  */
 public interface ProtoWriter<T> {
 
     /**
-     * Write out a {@code T} model to output stream in protobuf format.
+     * Write out a {@code T} model to a {@link PbjWriter} in protobuf format.
      *
      * @param data The input model data to write
-     * @param out The output stream to write to
-     * @throws IOException If there is a problem writing
+     * @param writer The writer to write to
      */
-    void write(T data, WritableSequentialData out) throws IOException;
-
-    default void write(T data, PbjWriter out) {
-        // Next commit implements this
-    }
+    void write(T data, PbjWriter writer);
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriter.java
@@ -2,6 +2,7 @@
 package com.hedera.pbj.runtime;
 
 import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import java.io.IOException;
 
 /**
@@ -19,4 +20,8 @@ public interface ProtoWriter<T> {
      * @throws IOException If there is a problem writing
      */
     void write(T data, WritableSequentialData out) throws IOException;
+
+    default void write(T data, PbjWriter out) {
+        // Next commit implements this
+    }
 }

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -1340,7 +1340,7 @@ public final class ProtoWriterTools {
      * @param value string value to get encoded size for
      * @return the number of bytes for encoded value
      */
-    static int sizeOfStringNoTag(String value) {
+    public static int sizeOfStringNoTag(String value) {
         // When not a oneOf don't write default value
         if ((value == null || value.isEmpty())) {
             return 0;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -5,6 +5,7 @@ import static com.hedera.pbj.runtime.ProtoConstants.*;
 
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.RandomAccessData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -60,6 +61,16 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a protobuf tag to the output. Field wire format is calculated based on field type.
+     *
+     * @param out The data output to write to
+     * @param field The field to write the tag for
+     */
+    public static void writeTag(PbjWriter out, final FieldDefinition field) {
+        writeTag(out, field, wireType(field));
+    }
+
+    /**
      * Write a protobuf tag to the output.
      *
      * @param out The data output to write to
@@ -68,6 +79,17 @@ public final class ProtoWriterTools {
      */
     public static void writeTag(
             final WritableSequentialData out, final FieldDefinition field, final ProtoConstants wireType) {
+        out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
+    }
+
+    /**
+     * Write a protobuf tag to the output.
+     *
+     * @param out The data output to write to
+     * @param field The field to include in tag
+     * @param wireType The field wire type to include in tag
+     */
+    public static void writeTag(PbjWriter out, final FieldDefinition field, final ProtoConstants wireType) {
         out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
     }
 
@@ -87,6 +109,17 @@ public final class ProtoWriterTools {
      * @param value the int value to write
      */
     public static void writeInteger(WritableSequentialData out, FieldDefinition field, int value) {
+        writeInteger(out, field, value, true);
+    }
+
+    /**
+     * Write a integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     */
+    public static void writeInteger(PbjWriter out, FieldDefinition field, int value) {
         writeInteger(out, field, value, true);
     }
 
@@ -133,6 +166,47 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the int value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeInteger(PbjWriter out, FieldDefinition field, int value, boolean skipDefault) {
+        assert switch (field.type()) {
+                    case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
+                    default -> false;
+                }
+                : "Not an integer type " + field;
+        assert !field.repeated() : "Use writeIntegerList with repeated types";
+
+        if (skipDefault && !field.oneOf() && value == 0) {
+            return;
+        }
+        switch (field.type()) {
+            case INT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarInt(value, false);
+            }
+            case UINT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(Integer.toUnsignedLong(value), false);
+            }
+            case SINT32 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarInt(value, true);
+            }
+            case SFIXED32, FIXED32 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
+                out.writeIntLE(value);
+            }
+            default -> throw unsupported();
+        }
+    }
+    /**
      * Write a long to data output
      *
      * @param out The data output to write to
@@ -140,6 +214,17 @@ public final class ProtoWriterTools {
      * @param value the long value to write
      */
     public static void writeLong(WritableSequentialData out, FieldDefinition field, long value) {
+        writeLong(out, field, value, true);
+    }
+
+    /**
+     * Write a long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the long value to write
+     */
+    public static void writeLong(PbjWriter out, FieldDefinition field, long value) {
         writeLong(out, field, value, true);
     }
 
@@ -181,6 +266,43 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the long value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeLong(PbjWriter out, FieldDefinition field, long value, boolean skipDefault) {
+        assert switch (field.type()) {
+                    case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> true;
+                    default -> false;
+                }
+                : "Not a long type " + field;
+        assert !field.repeated() : "Use writeLongList with repeated types";
+        if (skipDefault && !field.oneOf() && value == 0) {
+            return;
+        }
+        switch (field.type()) {
+            case INT64, UINT64 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(value, false);
+            }
+            case SINT64 -> {
+                writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+                out.writeVarLong(value, true);
+            }
+            case SFIXED64, FIXED64 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_FIXED_64_BIT);
+                out.writeLongLE(value);
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a float to data output
      *
      * @param out The data output to write to
@@ -196,6 +318,24 @@ public final class ProtoWriterTools {
         }
         writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
         out.writeFloat(value, ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Write a float to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the float value to write
+     */
+    public static void writeFloat(PbjWriter out, FieldDefinition field, float value) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert !field.repeated() : "Use writeFloatList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_FIXED_32_BIT);
+        out.writeFloatLE(value);
     }
 
     /**
@@ -217,6 +357,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a double to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the double value to write
+     */
+    public static void writeDouble(PbjWriter out, FieldDefinition field, double value) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert !field.repeated() : "Use writeDoubleList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && value == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_FIXED_64_BIT);
+        out.writeDoubleLE(value);
+    }
+
+    /**
      * Write a boolean to data output
      *
      * @param out The data output to write to
@@ -224,6 +382,17 @@ public final class ProtoWriterTools {
      * @param value the boolean value to write
      */
     public static void writeBoolean(WritableSequentialData out, FieldDefinition field, boolean value) {
+        writeBoolean(out, field, value, true);
+    }
+
+    /**
+     * Write a boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
+     */
+    public static void writeBoolean(PbjWriter out, FieldDefinition field, boolean value) {
         writeBoolean(out, field, value, true);
     }
 
@@ -247,6 +416,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the boolean value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeBoolean(PbjWriter out, FieldDefinition field, boolean value, boolean skipDefault) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert !field.repeated() : "Use writeBooleanList with repeated types";
+        // In the case of oneOf we write the value even if it is default value of false
+        if (value || field.oneOf() || !skipDefault) {
+            writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+            out.writeByte(value ? (byte) 1 : 0);
+        }
+    }
+
+    /**
      * Write a enum to data output
      *
      * @param out The data output to write to
@@ -254,6 +441,24 @@ public final class ProtoWriterTools {
      * @param enumValue the enum value to write
      */
     public static void writeEnum(WritableSequentialData out, FieldDefinition field, EnumWithProtoMetadata enumValue) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert !field.repeated() : "Use writeEnumList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (enumValue == null || enumValue.protoOrdinal() == 0)) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        out.writeVarInt(enumValue.protoOrdinal(), false);
+    }
+
+    /**
+     * Write a enum to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param enumValue the enum value to write
+     */
+    public static void writeEnum(PbjWriter out, FieldDefinition field, EnumWithProtoMetadata enumValue) {
         assert field.type() == FieldType.ENUM : "Not an enum type " + field;
         assert !field.repeated() : "Use writeEnumList with repeated types";
         // When not a oneOf don't write default value
@@ -283,6 +488,24 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a enum protoOrdinal to data output.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param protoOrdinal the enum value to write
+     */
+    public static void writeEnumProtoOrdinal(PbjWriter out, FieldDefinition field, int protoOrdinal) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert !field.repeated() : "Use writeEnumList with repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && protoOrdinal == 0) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
+        out.writeVarInt(protoOrdinal, false);
+    }
+
+    /**
      * Write a string to data output, assuming the field is non-repeated.
      *
      * @param out The data output to write to
@@ -301,12 +524,38 @@ public final class ProtoWriterTools {
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing, the field must be non-repeated
      * @param value the string value to write
+     */
+    public static void writeString(PbjWriter out, final FieldDefinition field, final String value) {
+        writeString(out, field, value, true);
+    }
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
      * @param skipDefault default value results in no-op for non-oneOf
      * @throws IOException If a I/O error occurs
      */
     public static void writeString(
             final WritableSequentialData out, final FieldDefinition field, final String value, boolean skipDefault)
             throws IOException {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert !field.repeated() : "Use writeStringList with repeated types";
+        writeStringNoChecks(out, field, value, skipDefault);
+    }
+
+    /**
+     * Write a string to data output, assuming the field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeString(
+            PbjWriter out, final FieldDefinition field, final String value, boolean skipDefault) {
         assert field.type() == FieldType.STRING : "Not a string type " + field;
         assert !field.repeated() : "Use writeStringList with repeated types";
         writeStringNoChecks(out, field, value, skipDefault);
@@ -330,7 +579,22 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a integer to data output - no validation checks.
+     * Write a string to data output, assuming the field is repeated. Usually this method is called multiple
+     * times, one for every repeated value. If all values are available immediately, {@link #writeStringList(
+     * PbjWriter, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be non-repeated
+     * @param value the string value to write
+     */
+    public static void writeOneRepeatedString(PbjWriter out, final FieldDefinition field, final String value) {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "writeOneRepeatedString can only be used with repeated fields";
+        writeStringNoChecks(out, field, value);
+    }
+
+    /**
+     * Write a string to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -343,7 +607,18 @@ public final class ProtoWriterTools {
     }
 
     /**
-     * Write a integer to data output - no validation checks.
+     * Write a string to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     */
+    private static void writeStringNoChecks(PbjWriter out, final FieldDefinition field, final String value) {
+        writeStringNoChecks(out, field, value, true);
+    }
+
+    /**
+     * Write a string to data output - no validation checks.
      *
      * @param out The data output to write to
      * @param field the descriptor for the field we are writing
@@ -364,6 +639,25 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a string to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the string value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    private static void writeStringNoChecks(
+            PbjWriter out, final FieldDefinition field, final String value, boolean skipDefault) {
+        // When not a oneOf don't write default value
+        if (skipDefault && !field.oneOf() && (value == null || value.isEmpty())) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(sizeOfStringNoTag(value), false);
+        out.writeStringNoTag(value);
+    }
+
+    /**
      * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
      * is any delimited: bytes, string, or message.
      *
@@ -375,6 +669,18 @@ public final class ProtoWriterTools {
     public static void writeBytes(
             final WritableSequentialData out, final FieldDefinition field, final RandomAccessData value)
             throws IOException {
+        writeBytes(out, field, value, true);
+    }
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     */
+    public static void writeBytes(PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
         writeBytes(out, field, value, true);
     }
 
@@ -400,6 +706,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a bytes to data output, assuming the corresponding field is non-repeated, and field type
+     * is any delimited: bytes, string, or message.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param value the bytes value to write
+     * @param skipDefault default value results in no-op for non-oneOf
+     */
+    public static void writeBytes(
+            PbjWriter out, final FieldDefinition field, final RandomAccessData value, boolean skipDefault) {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert !field.repeated() : "Use writeBytesList with repeated types";
+        writeBytesNoChecks(out, field, value, skipDefault);
+    }
+
+    /**
      * Write a bytes to data output, assuming the corresponding field is repeated, and field type
      * is any delimited: bytes, string, or message. Usually this method is called multiple times, one
      * for every repeated value. If all values are available immediately, {@link #writeBytesList(
@@ -413,6 +735,22 @@ public final class ProtoWriterTools {
     public static void writeOneRepeatedBytes(
             final WritableSequentialData out, final FieldDefinition field, final RandomAccessData value)
             throws IOException {
+        assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
+        assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
+        writeBytesNoChecks(out, field, value, true);
+    }
+
+    /**
+     * Write a bytes to data output, assuming the corresponding field is repeated, and field type
+     * is any delimited: bytes, string, or message. Usually this method is called multiple times, one
+     * for every repeated value. If all values are available immediately, {@link #writeBytesList(
+     * PbjWriter, FieldDefinition, List)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param value the bytes value to write
+     */
+    public static void writeOneRepeatedBytes(PbjWriter out, final FieldDefinition field, final RandomAccessData value) {
         assert field.type() == FieldType.BYTES : "Not a byte[] type " + field;
         assert field.repeated() : "writeOneRepeatedBytes can only be used with repeated fields";
         writeBytesNoChecks(out, field, value, true);
@@ -448,6 +786,35 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a bytes to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the bytes value to write
+     * @param skipZeroLength this is true for normal single bytes and false for repeated lists
+     */
+    private static void writeBytesNoChecks(
+            final PbjWriter out,
+            final FieldDefinition field,
+            final RandomAccessData value,
+            final boolean skipZeroLength) {
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && (skipZeroLength && (value.length() == 0))) {
+            return;
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(Math.toIntExact(value.length()), false);
+        final long posBefore = out.position();
+        out.writeBytes(value);
+        final long bytesWritten = out.position() - posBefore;
+        if (bytesWritten != value.length()) {
+            out.setError(
+                    PbjWriter.IO_ERROR,
+                    "Wrote less bytes [" + bytesWritten + "] than expected [" + value.length() + "]");
+        }
+    }
+
+    /**
      * Write a message to data output, assuming the corresponding field is non-repeated.
      *
      * @param out The data output to write to
@@ -460,6 +827,22 @@ public final class ProtoWriterTools {
     public static <T> void writeMessage(
             final WritableSequentialData out, final FieldDefinition field, final T message, final Codec<T> codec)
             throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert !field.repeated() : "Use writeMessageList with repeated types";
+        writeMessageNoChecks(out, field, message, codec);
+    }
+
+    /**
+     * Write a message to data output, assuming the corresponding field is non-repeated.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must not be repeated
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    public static <T> void writeMessage(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert !field.repeated() : "Use writeMessageList with repeated types";
         writeMessageNoChecks(out, field, message, codec);
@@ -481,6 +864,24 @@ public final class ProtoWriterTools {
     public static <T> void writeOneRepeatedMessage(
             final WritableSequentialData out, final FieldDefinition field, final T message, final Codec<T> codec)
             throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "writeOneRepeatedMessage can only be used with repeated fields";
+        writeMessageNoChecks(out, field, message, codec);
+    }
+
+    /**
+     * Write a message to data output, assuming the corresponding field is repeated. Usually this method is
+     * called multiple times, one for every repeated value. If all values are available immediately, {@link
+     * #writeMessageList(PbjWriter, FieldDefinition, List, Codec)} should be used instead.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing, the field must be repeated
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    public static <T> void writeOneRepeatedMessage(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert field.repeated() : "writeOneRepeatedMessage can only be used with repeated fields";
         writeMessageNoChecks(out, field, message, codec);
@@ -513,15 +914,52 @@ public final class ProtoWriterTools {
         }
     }
 
+    /**
+     * Write a message to data output - no validation checks.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param message the message to write
+     * @param codec the codec for the given message type
+     * @param <T> type of message
+     */
+    private static <T> void writeMessageNoChecks(
+            PbjWriter out, final FieldDefinition field, final T message, final Codec<T> codec) {
+        // When not a oneOf don't write default value
+        if (field.oneOf() && message == null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            out.writeVarInt(0, false);
+        } else if (message != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final int size = codec.measureRecord(message);
+            out.writeVarInt(size, false);
+            if (size > 0) {
+                codec.write(message, out);
+            }
+        }
+    }
+
+    /**
+     * Write a map field to data output.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param map the map to write
+     * @param kWriter writer for the map key type
+     * @param vWriter writer for the map value type
+     * @param sizeOfK function that computes the encoded size of a key
+     * @param sizeOfV function that computes the encoded size of a value
+     * @param <K> type of map key
+     * @param <V> type of map value
+     */
     public static <K, V> void writeMap(
-            final WritableSequentialData out,
+            PbjWriter out,
             final FieldDefinition field,
             @NonNull final PbjMap<K, V> map,
             final ProtoWriter<K> kWriter,
             final ProtoWriter<V> vWriter,
             final ToIntFunction<K> sizeOfK,
-            final ToIntFunction<V> sizeOfV)
-            throws IOException {
+            final ToIntFunction<V> sizeOfV) {
         // https://protobuf.dev/programming-guides/proto3/#maps
         // On the wire, a map is equivalent to:
         //    message MapFieldEntry {
@@ -566,6 +1004,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional integer to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional integer value to write
+     */
+    public static void writeOptionalInteger(PbjWriter out, FieldDefinition field, @Nullable Integer value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfInteger(newField, value), false);
+            writeInteger(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional long to data output
      *
      * @param out The data output to write to
@@ -573,6 +1027,22 @@ public final class ProtoWriterTools {
      * @param value the optional long value to write
      */
     public static void writeOptionalLong(WritableSequentialData out, FieldDefinition field, @Nullable Long value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfLong(newField, value), false);
+            writeLong(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional long to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional long value to write
+     */
+    public static void writeOptionalLong(PbjWriter out, FieldDefinition field, @Nullable Long value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -598,6 +1068,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional float to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional float value to write
+     */
+    public static void writeOptionalFloat(PbjWriter out, FieldDefinition field, @Nullable Float value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfFloat(newField, value), false);
+            writeFloat(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional double to data output
      *
      * @param out The data output to write to
@@ -605,6 +1091,22 @@ public final class ProtoWriterTools {
      * @param value the optional double value to write
      */
     public static void writeOptionalDouble(WritableSequentialData out, FieldDefinition field, @Nullable Double value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfDouble(newField, value), false);
+            writeDouble(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional double to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional double value to write
+     */
+    public static void writeOptionalDouble(PbjWriter out, FieldDefinition field, @Nullable Double value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -622,6 +1124,22 @@ public final class ProtoWriterTools {
      */
     public static void writeOptionalBoolean(
             WritableSequentialData out, FieldDefinition field, @Nullable Boolean value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfBoolean(newField, value), false);
+            writeBoolean(out, newField, value);
+        }
+    }
+
+    /**
+     * Write an optional boolean to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional boolean value to write
+     */
+    public static void writeOptionalBoolean(PbjWriter out, FieldDefinition field, @Nullable Boolean value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -649,6 +1167,22 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write an optional string to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional string value to write
+     */
+    public static void writeOptionalString(PbjWriter out, FieldDefinition field, @Nullable String value) {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            out.writeVarInt(sizeOfString(newField, value), false);
+            writeString(out, newField, value);
+        }
+    }
+
+    /**
      * Write an optional bytes to data output
      *
      * @param out The data output to write to
@@ -658,6 +1192,25 @@ public final class ProtoWriterTools {
      */
     public static void writeOptionalBytes(WritableSequentialData out, FieldDefinition field, @Nullable Bytes value)
             throws IOException {
+        if (value != null) {
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            final var newField = field.type().optionalFieldDefinition;
+            final int size = sizeOfBytes(newField, value);
+            out.writeVarInt(size, false);
+            if (size > 0) {
+                writeBytes(out, newField, value);
+            }
+        }
+    }
+
+    /**
+     * Write an optional bytes to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param value the optional bytes value to write
+     */
+    public static void writeOptionalBytes(PbjWriter out, FieldDefinition field, @Nullable Bytes value) {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
@@ -748,6 +1301,81 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of integers to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of integers value to write
+     */
+    public static void writeIntegerList(PbjWriter out, FieldDefinition field, List<Integer> list) {
+        assert switch (field.type()) {
+                    case INT32, UINT32, SINT32, FIXED32, SFIXED32 -> true;
+                    default -> false;
+                }
+                : "Not an integer type " + field;
+        assert field.repeated() : "Use writeInteger with non-repeated types";
+
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+
+        final int listSize = list.size();
+        switch (field.type()) {
+            case INT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfVarInt32(val);
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarInt(val, false);
+                }
+            }
+            case UINT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(Integer.toUnsignedLong(val));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarLong(Integer.toUnsignedLong(val), false);
+                }
+            }
+            case SINT32 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(((long) val << 1) ^ ((long) val >> 63));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeVarInt(val, true);
+                }
+            }
+            case SFIXED32, FIXED32 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarLong((long) list.size() * FIXED32_SIZE, false);
+                for (int i = 0; i < listSize; i++) {
+                    final int val = list.get(i);
+                    out.writeIntLE(val);
+                }
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a list of longs to data output
      *
      * @param out The data output to write to
@@ -810,6 +1438,68 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of longs to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of longs value to write
+     */
+    public static void writeLongList(PbjWriter out, FieldDefinition field, List<Long> list) {
+        assert switch (field.type()) {
+                    case INT64, UINT64, SINT64, FIXED64, SFIXED64 -> true;
+                    default -> false;
+                }
+                : "Not a long type " + field;
+        assert field.repeated() : "Use writeLong with non-repeated types";
+
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+
+        final int listSize = list.size();
+        switch (field.type()) {
+            case INT64, UINT64 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    size += sizeOfUnsignedVarInt64(val);
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeVarLong(val, false);
+                }
+            }
+            case SINT64 -> {
+                int size = 0;
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    size += sizeOfUnsignedVarInt64((val << 1) ^ (val >> 63));
+                }
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarInt(size, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeVarLong(val, true);
+                }
+            }
+            case SFIXED64, FIXED64 -> {
+                // The bytes in protobuf are in little-endian order -- backwards for Java.
+                // Smallest byte first.
+                writeTag(out, field, WIRE_TYPE_DELIMITED);
+                out.writeVarLong((long) list.size() * FIXED64_SIZE, false);
+                for (int i = 0; i < listSize; i++) {
+                    final long val = list.get(i);
+                    out.writeLongLE(val);
+                }
+            }
+            default -> throw unsupported();
+        }
+    }
+
+    /**
      * Write a list of floats to data output
      *
      * @param out The data output to write to
@@ -829,6 +1519,29 @@ public final class ProtoWriterTools {
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             out.writeFloat(list.get(i), ByteOrder.LITTLE_ENDIAN);
+        }
+    }
+
+    /**
+     * Write a list of floats to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of floats value to write
+     */
+    public static void writeFloatList(PbjWriter out, FieldDefinition field, List<Float> list) {
+        assert field.type() == FieldType.FLOAT : "Not a float type " + field;
+        assert field.repeated() : "Use writeFloat with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int size = list.size() * FIXED32_SIZE;
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            out.writeFloatLE(list.get(i));
         }
     }
 
@@ -856,6 +1569,29 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of doubles to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of doubles value to write
+     */
+    public static void writeDoubleList(PbjWriter out, FieldDefinition field, List<Double> list) {
+        assert field.type() == FieldType.DOUBLE : "Not a double type " + field;
+        assert field.repeated() : "Use writeDouble with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int size = list.size() * FIXED64_SIZE;
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            out.writeDoubleLE(list.get(i));
+        }
+    }
+
+    /**
      * Write a list of booleans to data output
      *
      * @param out The data output to write to
@@ -863,6 +1599,30 @@ public final class ProtoWriterTools {
      * @param list the list of booleans value to write
      */
     public static void writeBooleanList(WritableSequentialData out, FieldDefinition field, List<Boolean> list) {
+        assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
+        assert field.repeated() : "Use writeBoolean with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        // write
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(list.size(), false);
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            final boolean b = list.get(i);
+            out.writeVarInt(b ? 1 : 0, false);
+        }
+    }
+
+    /**
+     * Write a list of booleans to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of booleans value to write
+     */
+    public static void writeBooleanList(PbjWriter out, FieldDefinition field, List<Boolean> list) {
         assert field.type() == FieldType.BOOL : "Not a boolean type " + field;
         assert field.repeated() : "Use writeBoolean with non-repeated types";
         // When not a oneOf don't write default value
@@ -907,6 +1667,32 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of enums to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of enums value to write
+     */
+    public static void writeEnumListProtoOrdinals(PbjWriter out, FieldDefinition field, List<Integer> list) {
+        assert field.type() == FieldType.ENUM : "Not an enum type " + field;
+        assert field.repeated() : "Use writeEnum with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            size += sizeOfUnsignedVarInt32(list.get(i));
+        }
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
+        out.writeVarInt(size, false);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarInt(list.get(i), false);
+        }
+    }
+
+    /**
      * Write a list of strings to data output
      *
      * @param out The data output to write to
@@ -932,6 +1718,28 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of strings to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of strings value to write
+     */
+    public static void writeStringList(PbjWriter out, FieldDefinition field, List<String> list) {
+        assert field.type() == FieldType.STRING : "Not a string type " + field;
+        assert field.repeated() : "Use writeString with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            final String value = list.get(i);
+            writeTag(out, field, WIRE_TYPE_DELIMITED);
+            out.writeStringWithTag(value);
+        }
+    }
+
+    /**
      * Write a list of messages to data output
      *
      * @param out The data output to write to
@@ -943,6 +1751,28 @@ public final class ProtoWriterTools {
      */
     public static <T> void writeMessageList(
             WritableSequentialData out, FieldDefinition field, List<T> list, Codec<T> codec) throws IOException {
+        assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
+        assert field.repeated() : "Use writeMessage with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            writeMessageNoChecks(out, field, list.get(i), codec);
+        }
+    }
+
+    /**
+     * Write a list of messages to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of messages value to write
+     * @param codec the codec for the message type
+     * @param <T> type of message
+     */
+    public static <T> void writeMessageList(PbjWriter out, FieldDefinition field, List<T> list, Codec<T> codec) {
         assert field.type() == FieldType.MESSAGE : "Not a message type " + field;
         assert field.repeated() : "Use writeMessage with non-repeated types";
         // When not a oneOf don't write default value
@@ -979,6 +1809,26 @@ public final class ProtoWriterTools {
     }
 
     /**
+     * Write a list of bytes objects to data output
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param list the list of bytes objects value to write
+     */
+    public static void writeBytesList(PbjWriter out, FieldDefinition field, List<? extends RandomAccessData> list) {
+        assert field.type() == FieldType.BYTES : "Not a message type " + field;
+        assert field.repeated() : "Use writeBytes with non-repeated types";
+        // When not a oneOf don't write default value
+        if (!field.oneOf() && list.isEmpty()) {
+            return;
+        }
+        final int listSize = list.size();
+        for (int i = 0; i < listSize; i++) {
+            writeBytesNoChecks(out, field, list.get(i), false);
+        }
+    }
+
+    /**
      * Write a generic delimited field by delegating to a supplied `writer` to write the actual elements.
      *
      * @param out The data output to write to
@@ -989,6 +1839,21 @@ public final class ProtoWriterTools {
      */
     public static <T extends WritableSequentialData> void writeDelimited(
             final T out, final FieldDefinition field, final int size, final Consumer<T> writer) {
+        writeTag(out, field);
+        out.writeVarInt(size, false);
+        writer.accept(out);
+    }
+
+    /**
+     * Write a generic delimited field by delegating to a supplied `writer` to write the actual elements.
+     *
+     * @param out The data output to write to
+     * @param field the descriptor for the field we are writing
+     * @param size the size of all the elements together, in bytes
+     * @param writer the Consumer that accepts the `out` and writes the actual elements
+     */
+    public static void writeDelimited(
+            PbjWriter out, final FieldDefinition field, final int size, final Consumer<PbjWriter> writer) {
         writeTag(out, field);
         out.writeVarInt(size, false);
         writer.accept(out);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -1320,58 +1320,173 @@ public final class ProtoWriterTools {
             return;
         }
 
-        final int listSize = list.size();
+        writeTag(out, field, WIRE_TYPE_DELIMITED);
         switch (field.type()) {
-            case INT32 -> {
-                int size = 0;
-                for (int i = 0; i < listSize; i++) {
-                    final int val = list.get(i);
-                    size += sizeOfVarInt32(val);
-                }
-                writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarInt(size, false);
-                for (int i = 0; i < listSize; i++) {
-                    final int val = list.get(i);
-                    out.writeVarInt(val, false);
-                }
-            }
-            case UINT32 -> {
-                int size = 0;
-                for (int i = 0; i < listSize; i++) {
-                    final int val = list.get(i);
-                    size += sizeOfUnsignedVarInt64(Integer.toUnsignedLong(val));
-                }
-                writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarInt(size, false);
-                for (int i = 0; i < listSize; i++) {
-                    final int val = list.get(i);
-                    out.writeVarLong(Integer.toUnsignedLong(val), false);
-                }
-            }
-            case SINT32 -> {
-                int size = 0;
-                for (int i = 0; i < listSize; i++) {
-                    final int val = list.get(i);
-                    size += sizeOfUnsignedVarInt64(((long) val << 1) ^ ((long) val >> 63));
-                }
-                writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarInt(size, false);
-                for (int i = 0; i < listSize; i++) {
-                    final int val = list.get(i);
-                    out.writeVarInt(val, true);
-                }
-            }
-            case SFIXED32, FIXED32 -> {
-                // The bytes in protobuf are in little-endian order -- backwards for Java.
-                // Smallest byte first.
-                writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarLong((long) list.size() * FIXED32_SIZE, false);
-                for (int i = 0; i < listSize; i++) {
-                    final int val = list.get(i);
-                    out.writeIntLE(val);
-                }
-            }
+            case INT32 -> writeInt32List(out, list);
+            case UINT32 -> writeUInt32List(out, list);
+            case SINT32 -> writeSInt32List(out, list);
+            case SFIXED32, FIXED32 -> writeFixed32List(out, list);
             default -> throw unsupported();
+        }
+    }
+
+    private static void writeInt32List(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        if (listSize > 0x7F) {
+            writeInt32ListLarge(out, list);
+            return;
+        }
+        out.reserveRel(0x7F * 10 + 2); // worst case
+        int pos = out.position();
+        out.placehold(1);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarIntNoZZ(list.get(i));
+        }
+        int size = out.position() - pos - 1;
+        if (size <= 0x7F) {
+            out.writeAtUnsafe(pos, (byte) size);
+        } else {
+            out.reinsertVarInt(pos);
+        }
+    }
+
+    private static void writeInt32ListTwoPass(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            int val = list.get(i);
+            size += ((val & ~0x7FL) == 0) ? 1 : sizeOfVarInt32(val);
+        }
+        out.writeVarIntNoZZ(size);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarIntNoZZ(list.get(i));
+        }
+    }
+
+    private static void writeInt32ListLarge(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        if (listSize > 1638) {
+            // 1639+ elements * 10 bytes worst case exceeds 16k buffer; fall back to two-pass
+            writeInt32ListTwoPass(out, list);
+            return;
+        }
+        out.reserveRel(listSize * 10 + 2);
+        int pos = out.position();
+        out.placehold(2);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarIntNoZZ(list.get(i));
+        }
+        int size = out.position() - pos - 2;
+        out.writeAtUnsafe(pos, (byte) ((size & 0x7F) | 0x80));
+        out.writeAtUnsafe(pos + 1, (byte) (size >>> 7));
+    }
+
+    private static void writeUInt32List(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        if (listSize > 0x7F) {
+            writeUInt32ListLarge(out, list);
+            return;
+        }
+        out.reserveRel(0x7F * 5 + 2); // worst case
+        int pos = out.position();
+        out.placehold(1);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarLongNoZZ(Integer.toUnsignedLong(list.get(i)));
+        }
+        int size = out.position() - pos - 1;
+        if (size <= 0x7F) {
+            out.writeAtUnsafe(pos, (byte) size);
+        } else {
+            out.reinsertVarInt(pos);
+        }
+    }
+
+    private static void writeUInt32ListTwoPass(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            size += sizeOfUnsignedVarInt64(Integer.toUnsignedLong(list.get(i)));
+        }
+        out.writeVarIntNoZZ(size);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarLongNoZZ(Integer.toUnsignedLong(list.get(i)));
+        }
+    }
+
+    private static void writeUInt32ListLarge(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        if (listSize > 3276) {
+            // 3277+ elements * 5 bytes worst case exceeds 16k buffer
+            writeUInt32ListTwoPass(out, list);
+            return;
+        }
+        out.reserveRel(listSize * 5 + 2);
+        int pos = out.position();
+        out.placehold(2);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarLongNoZZ(Integer.toUnsignedLong(list.get(i)));
+        }
+        int size = out.position() - pos - 2;
+        out.writeAtUnsafe(pos, (byte) ((size & 0x7F) | 0x80));
+        out.writeAtUnsafe(pos + 1, (byte) (size >>> 7));
+    }
+
+    private static void writeSInt32List(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        if (listSize > 0x7F) {
+            writeSInt32ListLarge(out, list);
+            return;
+        }
+        out.reserveRel(0x7F * 5 + 2); // worst case
+        int pos = out.position();
+        out.placehold(1);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarIntZZ(list.get(i));
+        }
+        int size = out.position() - pos - 1;
+        if (size <= 0x7F) {
+            out.writeAtUnsafe(pos, (byte) size);
+        } else {
+            out.reinsertVarInt(pos);
+        }
+    }
+
+    private static void writeSInt32ListTwoPass(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        int size = 0;
+        for (int i = 0; i < listSize; i++) {
+            final int val = list.get(i);
+            size += sizeOfUnsignedVarInt64(((long) val << 1) ^ ((long) val >> 63));
+        }
+        out.writeVarIntNoZZ(size);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarIntZZ(list.get(i));
+        }
+    }
+
+    private static void writeSInt32ListLarge(PbjWriter out, List<Integer> list) {
+        int listSize = list.size();
+        if (listSize > 3276) {
+            // 3277+ elements * 5 bytes worst case exceeds 16k buffer
+            writeSInt32ListTwoPass(out, list);
+            return;
+        }
+        out.reserveRel(listSize * 5 + 2);
+        int pos = out.position();
+        out.placehold(2);
+        for (int i = 0; i < listSize; i++) {
+            out.writeVarIntZZ(list.get(i));
+        }
+        int size = out.position() - pos - 2;
+        out.writeAtUnsafe(pos, (byte) ((size & 0x7F) | 0x80));
+        out.writeAtUnsafe(pos + 1, (byte) (size >>> 7));
+    }
+
+    private static void writeFixed32List(PbjWriter out, List<Integer> list) {
+        // The bytes in protobuf are in little-endian order -- backwards for Java.
+        out.writeVarLongNoZZ((long) list.size() * FIXED32_SIZE);
+        for (int i = 0; i < list.size(); i++) {
+            out.writeIntLE(list.get(i));
         }
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/ProtoWriterTools.java
@@ -90,7 +90,7 @@ public final class ProtoWriterTools {
      * @param wireType The field wire type to include in tag
      */
     public static void writeTag(PbjWriter out, final FieldDefinition field, final ProtoConstants wireType) {
-        out.writeVarInt((field.number() << TAG_TYPE_BITS) | wireType.ordinal(), false);
+        out.writeVarIntNoZZ((field.number() << TAG_TYPE_BITS) | wireType.ordinal());
     }
 
     /** Create an unsupported field type exception */
@@ -187,15 +187,15 @@ public final class ProtoWriterTools {
         switch (field.type()) {
             case INT32 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarInt(value, false);
+                out.writeVarIntNoZZ(value);
             }
             case UINT32 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarLong(Integer.toUnsignedLong(value), false);
+                out.writeVarLongNoZZ(Integer.toUnsignedLong(value));
             }
             case SINT32 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarInt(value, true);
+                out.writeVarIntZZ(value);
             }
             case SFIXED32, FIXED32 -> {
                 // The bytes in protobuf are in little-endian order -- backwards for Java.
@@ -286,11 +286,11 @@ public final class ProtoWriterTools {
         switch (field.type()) {
             case INT64, UINT64 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarLong(value, false);
+                out.writeVarLongNoZZ(value);
             }
             case SINT64 -> {
                 writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-                out.writeVarLong(value, true);
+                out.writeVarLongZZ(value);
             }
             case SFIXED64, FIXED64 -> {
                 // The bytes in protobuf are in little-endian order -- backwards for Java.
@@ -466,7 +466,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-        out.writeVarInt(enumValue.protoOrdinal(), false);
+        out.writeVarIntNoZZ(enumValue.protoOrdinal());
     }
 
     /**
@@ -502,7 +502,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_VARINT_OR_ZIGZAG);
-        out.writeVarInt(protoOrdinal, false);
+        out.writeVarIntNoZZ(protoOrdinal);
     }
 
     /**
@@ -653,7 +653,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(sizeOfStringNoTag(value), false);
+        out.writeVarIntNoZZ(sizeOfStringNoTag(value));
         out.writeStringNoTag(value);
     }
 
@@ -803,7 +803,7 @@ public final class ProtoWriterTools {
             return;
         }
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(Math.toIntExact(value.length()), false);
+        out.writeVarIntNoZZ(Math.toIntExact(value.length()));
         final long posBefore = out.position();
         out.writeBytes(value);
         final long bytesWritten = out.position() - posBefore;
@@ -928,11 +928,11 @@ public final class ProtoWriterTools {
         // When not a oneOf don't write default value
         if (field.oneOf() && message == null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
-            out.writeVarInt(0, false);
+            out.writeVarIntNoZZ(0);
         } else if (message != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final int size = codec.measureRecord(message);
-            out.writeVarInt(size, false);
+            out.writeVarIntNoZZ(size);
             if (size > 0) {
                 codec.write(message, out);
             }
@@ -977,7 +977,7 @@ public final class ProtoWriterTools {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final int sizeK = sizeOfK.applyAsInt(k);
             final int sizeV = sizeOfV.applyAsInt(v);
-            out.writeVarInt(sizeK + sizeV, false);
+            out.writeVarIntNoZZ(sizeK + sizeV);
             kWriter.write(k, out);
             vWriter.write(v, out);
         }
@@ -1014,7 +1014,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfInteger(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfInteger(newField, value));
             writeInteger(out, newField, value);
         }
     }
@@ -1046,7 +1046,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfLong(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfLong(newField, value));
             writeLong(out, newField, value);
         }
     }
@@ -1078,7 +1078,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfFloat(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfFloat(newField, value));
             writeFloat(out, newField, value);
         }
     }
@@ -1110,7 +1110,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfDouble(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfDouble(newField, value));
             writeDouble(out, newField, value);
         }
     }
@@ -1143,7 +1143,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfBoolean(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfBoolean(newField, value));
             writeBoolean(out, newField, value);
         }
     }
@@ -1177,7 +1177,7 @@ public final class ProtoWriterTools {
         if (value != null) {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
-            out.writeVarInt(sizeOfString(newField, value), false);
+            out.writeVarIntNoZZ(sizeOfString(newField, value));
             writeString(out, newField, value);
         }
     }
@@ -1215,7 +1215,7 @@ public final class ProtoWriterTools {
             writeTag(out, field, WIRE_TYPE_DELIMITED);
             final var newField = field.type().optionalFieldDefinition;
             final int size = sizeOfBytes(newField, value);
-            out.writeVarInt(size, false);
+            out.writeVarIntNoZZ(size);
             if (size > 0) {
                 writeBytes(out, newField, value);
             }
@@ -1581,10 +1581,10 @@ public final class ProtoWriterTools {
                     size += sizeOfUnsignedVarInt64(val);
                 }
                 writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarInt(size, false);
+                out.writeVarIntNoZZ(size);
                 for (int i = 0; i < listSize; i++) {
                     final long val = list.get(i);
-                    out.writeVarLong(val, false);
+                    out.writeVarLongNoZZ(val);
                 }
             }
             case SINT64 -> {
@@ -1594,17 +1594,17 @@ public final class ProtoWriterTools {
                     size += sizeOfUnsignedVarInt64((val << 1) ^ (val >> 63));
                 }
                 writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarInt(size, false);
+                out.writeVarIntNoZZ(size);
                 for (int i = 0; i < listSize; i++) {
                     final long val = list.get(i);
-                    out.writeVarLong(val, true);
+                    out.writeVarLongZZ(val);
                 }
             }
             case SFIXED64, FIXED64 -> {
                 // The bytes in protobuf are in little-endian order -- backwards for Java.
                 // Smallest byte first.
                 writeTag(out, field, WIRE_TYPE_DELIMITED);
-                out.writeVarLong((long) list.size() * FIXED64_SIZE, false);
+                out.writeVarLongNoZZ((long) list.size() * FIXED64_SIZE);
                 for (int i = 0; i < listSize; i++) {
                     final long val = list.get(i);
                     out.writeLongLE(val);
@@ -1653,7 +1653,7 @@ public final class ProtoWriterTools {
         }
         final int size = list.size() * FIXED32_SIZE;
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             out.writeFloatLE(list.get(i));
@@ -1699,7 +1699,7 @@ public final class ProtoWriterTools {
         }
         final int size = list.size() * FIXED64_SIZE;
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             out.writeDoubleLE(list.get(i));
@@ -1746,11 +1746,11 @@ public final class ProtoWriterTools {
         }
         // write
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(list.size(), false);
+        out.writeVarIntNoZZ(list.size());
         final int listSize = list.size();
         for (int i = 0; i < listSize; i++) {
             final boolean b = list.get(i);
-            out.writeVarInt(b ? 1 : 0, false);
+            out.writeVarIntNoZZ(b ? 1 : 0);
         }
     }
 
@@ -1801,9 +1801,9 @@ public final class ProtoWriterTools {
             size += sizeOfUnsignedVarInt32(list.get(i));
         }
         writeTag(out, field, WIRE_TYPE_DELIMITED);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         for (int i = 0; i < listSize; i++) {
-            out.writeVarInt(list.get(i), false);
+            out.writeVarIntNoZZ(list.get(i));
         }
     }
 
@@ -1970,7 +1970,7 @@ public final class ProtoWriterTools {
     public static void writeDelimited(
             PbjWriter out, final FieldDefinition field, final int size, final Consumer<PbjWriter> writer) {
         writeTag(out, field);
-        out.writeVarInt(size, false);
+        out.writeVarIntNoZZ(size);
         writer.accept(out);
     }
 

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -485,6 +485,11 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
         return new RandomAccessSequenceAdapter(this);
     }
 
+    @NonNull
+    public void resetPbjReader(@NonNull PbjReader reader) {
+        reader.resetWith(buffer, start, start + length);
+    }
+
     /**
      * Exposes this {@link Bytes} as an {@link InputStream}. This is a zero-copy operation.
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -373,6 +373,15 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
     }
 
     /**
+     * A helper method to copy buffer data into PbjWriter
+     *
+     * @param writer the PbjWriter to copy into
+     */
+    public void writeTo(@NonNull final PbjWriter writer) {
+        writer.writeBytes(buffer, start, length);
+    }
+
+    /**
      * A helper method for efficient copy of our data into an WritableSequentialData without creating a defensive copy
      * of the data. The implementation relies on a well-behaved WritableSequentialData that doesn't modify the buffer data.
      * The destination object may receive a direct reference to the underlying byte array, and it MUST NOT modify it.

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/Bytes.java
@@ -494,6 +494,16 @@ public final class Bytes implements RandomAccessData, Comparable<Bytes> {
         return new RandomAccessSequenceAdapter(this);
     }
 
+    /**
+     * Create and return a new {@link PbjReader} that is backed by this {@link Bytes}.
+     *
+     * @return A {@link PbjReader} backed by this {@link Bytes}.
+     */
+    @NonNull
+    public PbjReader toPbjReader() {
+        return new PbjReader(this);
+    }
+
     @NonNull
     public void resetPbjReader(@NonNull PbjReader reader) {
         reader.resetWith(buffer, start, start + length);

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -109,7 +109,7 @@ public class PbjReader implements AutoCloseable {
         if (seq != null) {
             rsd = seq;
             absoluteLimit = seq.limit();
-            offset = (int) seq.position();
+            offset = seq.position();
         } else if (inputStream != null) {
             stream = inputStream;
         }
@@ -129,7 +129,7 @@ public class PbjReader implements AutoCloseable {
             rsd = seq;
             stream = null;
             absoluteLimit = seq.limit();
-            offset = (int) seq.position();
+            offset = seq.position();
         } else if (inputStream != null) {
             rsd = null;
             stream = inputStream;
@@ -197,7 +197,7 @@ public class PbjReader implements AutoCloseable {
         resetWith(bb.array(), position, position + bb.remaining());
     }
 
-    private void bufferMore(int relAmount) {
+    private void bufferMore() {
         if (err != 0) return;
         offset += pos;
         if (pos < end && pos != 0) {
@@ -232,7 +232,7 @@ public class PbjReader implements AutoCloseable {
     // still small, but less likely to hit this case in steaming, and only once when not streaming
     private boolean hasRemainingInternal() {
         if (seenEOF) return false;
-        bufferMore(1);
+        bufferMore();
         return pos < relLimit;
     }
 
@@ -294,8 +294,8 @@ public class PbjReader implements AutoCloseable {
         count -= skippedInBuffer;
         pos = relLimit;
         offset += count;
-        if (stream != null) {
-            try {
+        try {
+            if (stream != null) {
                 long remaining = count;
                 while (remaining > 0) {
                     long skipped = stream.skip(remaining);
@@ -311,11 +311,11 @@ public class PbjReader implements AutoCloseable {
                 if (remaining != 0) {
                     setError(BUFFER_UNDERFLOW);
                 }
-            } catch (IOException e) {
-                setError(IO_ERROR);
+            } else {
+                rsd.skip(count);
             }
-        } else {
-            rsd.skip(count); // may throw
+        } catch (IOException e) {
+            setError(IO_ERROR);
         }
     }
 
@@ -432,7 +432,7 @@ public class PbjReader implements AutoCloseable {
         byte[] bytes = new byte[10];
         if (pos + 10 <= relLimit) {
             for (int i = 0; i < 10; i++) {
-                bytes[i] = readByte();
+                bytes[i] = buf[pos++];
                 if (bytes[i] >= 0) {
                     return Bytes.wrap(bytes, 0, i + 1);
                 }
@@ -592,7 +592,7 @@ public class PbjReader implements AutoCloseable {
 
     private int bufferedInternal(int count) {
         if (count <= buf.length) {
-            bufferMore(count);
+            bufferMore();
             if (pos + count <= relLimit) {
                 int origPos = pos;
                 pos += count;
@@ -772,7 +772,7 @@ public class PbjReader implements AutoCloseable {
     }
 
     private int readIntBEInternal() {
-        bufferMore(4);
+        bufferMore();
         if (pos + 4 > relLimit) {
             setError(BUFFER_UNDERFLOW);
             return 0;
@@ -786,7 +786,7 @@ public class PbjReader implements AutoCloseable {
     }
 
     private int readIntLEInternal() {
-        bufferMore(4);
+        bufferMore();
         if (pos + 4 > relLimit) {
             setError(BUFFER_UNDERFLOW);
             return 0;
@@ -827,7 +827,7 @@ public class PbjReader implements AutoCloseable {
     }
 
     private long readLongBEInternal() {
-        bufferMore(8);
+        bufferMore();
         if (pos + 8 > relLimit) {
             setError(BUFFER_UNDERFLOW);
             return 0;
@@ -859,7 +859,7 @@ public class PbjReader implements AutoCloseable {
     }
 
     private long readLongLEInternal() {
-        bufferMore(8);
+        bufferMore();
         if (pos + 8 > relLimit) {
             setError(BUFFER_UNDERFLOW);
             return 0;
@@ -946,7 +946,7 @@ public class PbjReader implements AutoCloseable {
 
     private byte readByteInternal() {
         if (pos + 1 > relLimit) {
-            bufferMore(1);
+            bufferMore();
             if (pos + 1 > relLimit) {
                 setError(BUFFER_UNDERFLOW);
                 return 0;
@@ -975,6 +975,7 @@ public class PbjReader implements AutoCloseable {
         if (bufPos >= 0) {
             data = buf;
         } else {
+            // larger than internal buffer
             data = new byte[length];
             int copiedLen = readBytesInternalCopy(data, 0, length);
             if (copiedLen < length) {
@@ -985,8 +986,12 @@ public class PbjReader implements AutoCloseable {
         }
 
         if (charArray == null || length > charArray.length) {
-            int power2Capacity = 2 << (63 - Long.numberOfLeadingZeros(Math.max(2048, length)));
-            charArray = new char[power2Capacity];
+            long power2Capacity = 2 << (63 - Long.numberOfLeadingZeros(Math.max(2048, length)));
+            if (power2Capacity < 0 || power2Capacity > Integer.MAX_VALUE) {
+                setError(ILLEGAL_ARGUMENT, "length larger than int max");
+                return "";
+            }
+            charArray = new char[(int) power2Capacity];
         }
 
         int i = 0;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -1,0 +1,1024 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.ProtoParserTools;
+import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.DataEncodingException;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+
+/**
+ * A buffer-backed reader for decoding data. Not thread safe.
+ *
+ * <p>PbjReader maintains an internal byte buffer and reads from a {@link ReadableSequentialData},
+ * {@link InputStream}, or a byte array. When backed by a stream the internal buffer is refilled
+ * on demand as data is consumed. A stream will never be read past its limit.
+ *
+ * <p>Errors are tracked internally rather than thrown immediately. Call {@link #error()} to check
+ * for a pending error code, or {@link #throwOnError()} to surface it as a {@link ParseException}.
+ * Once an error is set it is sticky — subsequent reads return default values (zero or empty).
+ * EOF is not an error and will return 0 when error() is called.
+ * ByteBuffer using a direct buffer is not supported
+ */
+public class PbjReader implements AutoCloseable {
+    private byte[] buf;
+    private int pos, end;
+    private int relLimit, err;
+    private long absoluteLimit = Long.MAX_VALUE, offset;
+    private ReadableSequentialData rsd;
+    private InputStream stream;
+    private Exception cause;
+    private boolean seenEOF, includeCause;
+    private byte[] ownedBuf;
+
+    private char[] charArray;
+    private static final boolean useStacktrace =
+            !"false".equalsIgnoreCase(System.getProperty("pbj.ReaderWriter.useStackTrace"));
+
+    public static final int EOF = -1,
+            CLOSED = -2,
+            DATA_ENCODING = 1,
+            BUFFER_UNDERFLOW = 2,
+            PARSE = 3,
+            ILLEGAL_ARGUMENT = 4,
+            IO_ERROR = 5,
+            UNSUPPORTED = 6, // used with WIRE_TYPE_GROUP_START, WIRE_TYPE_GROUP_END
+            USAGE_ERROR = 9,
+            UNKNOWN_FIELD = 10,
+            BUFFER_OVERFLOW = 11,
+            MAX_DEPTH_REACHED = 12,
+            MALFORM_STRING = 13;
+
+    private static final UnknownFieldException premadeUnknown;
+    private static final BufferUnderflowException premadeUnderflow;
+    private static final BufferOverflowException premadeOverflow;
+    private static final RuntimeException premadeRuntime, premadeUnsupported;
+    private static final DataEncodingException premadeDataEncoding;
+    private static final IllegalArgumentException premadeIllegal;
+    private static final ParseException premadeParseEmpty, premadeParseUnknown, premadeMaxDepth;
+
+    static {
+        premadeUnknown = new UnknownFieldException("");
+        premadeUnderflow = new BufferUnderflowException();
+        premadeOverflow = new BufferOverflowException();
+        premadeRuntime = new RuntimeException();
+        premadeUnsupported = new RuntimeException("Hit an unsupported feature");
+        premadeDataEncoding = new DataEncodingException("");
+        premadeIllegal = new IllegalArgumentException("");
+
+        premadeParseEmpty = new ParseException("parse error");
+        premadeParseUnknown = new ParseException("parse error", premadeUnknown);
+        premadeMaxDepth = new ParseException("Reached maximum allowed depth");
+    }
+
+    private void construct(byte[] buffer, int position, int endPosition) {
+        buf = buffer;
+        pos = position;
+        end = endPosition;
+        relLimit = end;
+        absoluteLimit = end;
+        seenEOF = true;
+        err = EOF;
+    }
+
+    /**
+     * Resets this reader to read from the given byte array slice, discarding any previous state.
+     *
+     * @param buffer      the backing byte array
+     * @param position    the inclusive start index within {@code buffer}
+     * @param endPosition the exclusive end index within {@code buffer}
+     */
+    public void resetWith(byte[] buffer, int position, int endPosition) {
+        err = 0;
+        offset = 0;
+        cause = null;
+        includeCause = false;
+        rsd = null;
+        stream = null;
+        construct(buffer, position, endPosition);
+    }
+
+    private void construct(ReadableSequentialData seq, InputStream inputStream) {
+        if (seq != null) {
+            rsd = seq;
+            absoluteLimit = seq.limit();
+            offset = (int) seq.position();
+        } else if (inputStream != null) {
+            stream = inputStream;
+        }
+        ownedBuf = buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+    }
+
+    private void resetWith(ReadableSequentialData seq, InputStream inputStream) {
+        err = 0;
+        cause = null;
+        includeCause = false;
+        if ((seq == null && inputStream == null) || (seq != null && inputStream != null)) {
+            setError(USAGE_ERROR);
+            return;
+        }
+
+        if (seq != null) {
+            rsd = seq;
+            stream = null;
+            absoluteLimit = seq.limit();
+            offset = (int) seq.position();
+        } else if (inputStream != null) {
+            rsd = null;
+            stream = inputStream;
+            absoluteLimit = Long.MAX_VALUE;
+            offset = 0;
+        }
+        if (ownedBuf == null) {
+            ownedBuf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        }
+        buf = ownedBuf;
+        pos = 0;
+        end = 0;
+        relLimit = 0;
+        seenEOF = false;
+    }
+
+    /** Creates a reader backed by the given {@link ReadableSequentialData}. */
+    public PbjReader(ReadableSequentialData seq) {
+        construct(seq, null);
+    }
+    /** Creates a reader backed by the given {@link InputStream}. */
+    public PbjReader(InputStream inputStream) {
+        construct(null, inputStream);
+    }
+    /** Creates a reader backed by the given byte array. */
+    public PbjReader(byte[] data) {
+        construct(data, 0, data.length);
+    }
+    /**
+     * Creates a reader backed by the given byte array slice.
+     *
+     * @param data   the backing byte array
+     * @param offset the inclusive start index
+     * @param end    the exclusive end index
+     */
+    public PbjReader(byte[] data, int offset, int end) {
+        construct(data, offset, end);
+    }
+    /** Creates a reader backed by the given {@link ByteBuffer}. */
+    public PbjReader(ByteBuffer bb) {
+        int position = bb.arrayOffset() + bb.position();
+        construct(bb.array(), position, position + bb.remaining());
+    }
+
+    /** Creates a reader backed by the given {@link Bytes}. */
+    public PbjReader(Bytes bytes) {
+        bytes.resetPbjReader(this);
+    }
+
+    /** Resets this reader to read from the given {@link ReadableSequentialData}. */
+    public void resetWith(ReadableSequentialData seq) {
+        resetWith(seq, null);
+    }
+    /** Resets this reader to read from the given {@link InputStream}. */
+    public void resetWith(InputStream inputStream) {
+        resetWith(null, inputStream);
+    }
+    /** Resets this reader to read from the given byte array. */
+    public void resetWith(byte[] data) {
+        resetWith(data, 0, data.length);
+    }
+    /** Resets this reader to read from the given {@link ByteBuffer}. */
+    public void resetWith(ByteBuffer bb) {
+        int position = bb.arrayOffset() + bb.position();
+        resetWith(bb.array(), position, position + bb.remaining());
+    }
+
+    private void bufferMore(int relAmount) {
+        if (err != 0) return;
+        offset += pos;
+        if (pos < end && pos != 0) {
+            int moveLen = end - pos;
+            System.arraycopy(buf, pos, buf, 0, end - pos);
+            end = moveLen;
+        } else if (pos == end) {
+            end = 0;
+        }
+        pos = 0;
+        int rdlen = readFromInput(buf, end, buf.length - end);
+        end += rdlen;
+        relLimit = (int) Math.min(absoluteLimit - offset, end);
+        if (rdlen == 0) {
+            seenEOF = true;
+            err = EOF;
+        }
+    }
+
+    /**
+     * Returns {@code true} if there are bytes remaining to be read.
+     * For streaming readers, triggers a buffer refill if the local buffer is exhausted.
+     *
+     * @return {@code true} if at least one byte can be read
+     */
+    public boolean hasRemaining() {
+        // small and likely to inline
+        if (pos < relLimit) return true;
+        if (offset + pos == absoluteLimit) return false;
+        return hasRemainingInternal();
+    }
+    // still small, but less likely to hit this case in steaming, and only once when not streaming
+    private boolean hasRemainingInternal() {
+        if (seenEOF) return false;
+        bufferMore(1);
+        return pos < relLimit;
+    }
+
+    /**
+     * Returns the absolute byte limit beyond which reading is not permitted.
+     *
+     * @return the absolute limit position
+     */
+    public long limit() {
+        return absoluteLimit;
+    }
+
+    /**
+     * Sets the absolute byte limit beyond which reading is not permitted.
+     * If using a stream, it will not read past that limit
+     *
+     * @param limit the new limit position
+     */
+    public void limit(long limit) {
+        absoluteLimit = limit;
+        if (rsd != null) {
+            rsd.limit(limit);
+        }
+        if (err > 0) return; // keep relLimit -1 in error state
+        relLimit = (int) Math.min(absoluteLimit - offset, end);
+    }
+
+    /**
+     * Returns the current absolute read position, accounting for any bytes already consumed
+     * from the internal buffer plus any previously buffered data.
+     *
+     * @return the current read position
+     */
+    public long position() {
+        return pos + offset;
+    }
+
+    /**
+     * Skips over {@code count} bytes, advancing the read position without returning the data.
+     * Sets {@link #BUFFER_UNDERFLOW} if there are fewer than {@code count} bytes remaining.
+     *
+     * @param count the number of bytes to skip
+     */
+    public void skip(int count) {
+        if (count >= 0 && pos + count <= relLimit) {
+            pos += count;
+            return;
+        }
+        skipInternal(count);
+    }
+
+    private void skipInternal(int count) {
+        if (seenEOF) {
+            setError(BUFFER_UNDERFLOW);
+            return;
+        }
+
+        int skippedInBuffer = relLimit - pos;
+        count -= skippedInBuffer;
+        pos = relLimit;
+        offset += count;
+        if (stream != null) {
+            try {
+                long remaining = count;
+                while (remaining > 0) {
+                    long skipped = stream.skip(remaining);
+                    if (skipped > 0) {
+                        remaining -= skipped;
+                    } else {
+                        // Docs suggest skup can return 0 w/o reaching EOF
+                        int b = stream.read();
+                        if (b == -1) break;
+                        remaining--;
+                    }
+                }
+                if (remaining != 0) {
+                    setError(BUFFER_UNDERFLOW);
+                }
+            } catch (IOException e) {
+                setError(IO_ERROR);
+            }
+        } else {
+            rsd.skip(count); // may throw
+        }
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as an {@code int} (no zigzag decoding).
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @return the decoded integer value
+     */
+    public int readVarIntNoZZ() {
+        return (int) readVarLongNoZZ();
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as an {@code int}, with optional zigzag decoding.
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @param zigZag if {@code true}, decodes using zigzag: {@code (n >>> 1) ^ -(n & 1)}
+     * @return the decoded integer value
+     */
+    public int readVarInt(boolean zigZag) {
+        return (int) readVarLong(zigZag);
+    }
+
+    /**
+     * Reads a base-128 varint and returns its zigzag-decoded value as an {@code int}.
+     * Zigzag decoding maps the raw unsigned value {@code n} to {@code (n >>> 1) ^ -(n & 1)}.
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @return the decoded integer value
+     */
+    public int readVarIntZZ() {
+        return (int) readVarLongZZ();
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as a {@code long}.
+     * On a malformed varint (more than 10 bytes), sets {@link #DATA_ENCODING} and returns
+     * {@code -1}; however, {@code -1} is also a valid decoded value, so callers must check
+     * {@link #error()} to distinguish an error from a legitimate result.
+     *
+     * @param zigZag if {@code true}, decodes using zigzag: {@code (n >>> 1) ^ -(n & 1)}
+     * @return the decoded long value
+     */
+    public long readVarLong(boolean zigZag) {
+        long value = readVarLongNoZZ();
+        return zigZag ? (value >>> 1) ^ -(value & 1) : value;
+    }
+
+    /**
+     * Reads a base-128 varint and returns its zigzag-decoded value as a {@code long}.
+     * Zigzag decoding maps the raw unsigned value {@code n} to {@code (n >>> 1) ^ -(n & 1)}.
+     * On a malformed varint, sets the error flag and returns {@code -1}; however,
+     * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
+     * distinguish an error from a legitimate result.
+     *
+     * @return the decoded long value
+     */
+    public long readVarLongZZ() {
+        long value = readVarLongNoZZ();
+        return (value >>> 1) ^ -(value & 1);
+    }
+
+    /**
+     * Reads a base-128 varint and returns its value as a {@code long} (no zigzag decoding).
+     * On a malformed varint (more than 10 bytes), sets {@link #DATA_ENCODING} and returns
+     * {@code -1}; however, {@code -1} is also a valid decoded value, so callers must check
+     * {@link #error()} to distinguish an error from a legitimate result.
+     *
+     * @return the decoded long value
+     */
+    public long readVarLongNoZZ() {
+        if (pos + 10 <= relLimit) {
+            long value = 0;
+            for (int i = 0; i < 10; i++) {
+                byte b = buf[pos++];
+                value |= (long) (b & 0x7F) << (i * 7);
+                if (b >= 0) {
+                    return value;
+                }
+            }
+            setError(DATA_ENCODING);
+            return -1;
+        }
+        return readVarLongNoZZInternal();
+    }
+
+    private long readVarLongNoZZInternal() {
+        long value = 0;
+        for (int i = 0; i < 10; i++) {
+            byte b = readByte();
+            value |= (long) (b & 0x7F) << (i * 7);
+            if (b >= 0) {
+                return value;
+            }
+        }
+        setError(DATA_ENCODING);
+        return -1;
+    }
+
+    /**
+     * Reads a base-128 varint and returns the raw encoded bytes without decoding them.
+     * Sets {@link #DATA_ENCODING} if the varint is malformed.
+     *
+     * @return the raw varint bytes, or {@link Bytes#EMPTY} on error
+     */
+    public Bytes readVarLongBytes() {
+        byte[] bytes = new byte[10];
+        if (pos + 10 <= relLimit) {
+            for (int i = 0; i < 10; i++) {
+                bytes[i] = readByte();
+                if (bytes[i] >= 0) {
+                    return Bytes.wrap(bytes, 0, i + 1);
+                }
+            }
+            setError(DATA_ENCODING);
+            return Bytes.EMPTY;
+        }
+        return readVarLongBytesInternal(bytes);
+    }
+
+    private Bytes readVarLongBytesInternal(byte[] bytes) {
+        for (int i = 0; i < 10; i++) {
+            bytes[i] = readByte();
+            if (bytes[i] >= 0) {
+                return Bytes.wrap(bytes, 0, i + 1);
+            }
+        }
+        setError(DATA_ENCODING);
+        return Bytes.EMPTY;
+    }
+
+    /**
+     * Records an error on this reader with no message. Once an error is recorded
+     * subsequent reads return default values (zero or empty).
+     *
+     * @param errorKind one of the error-code constants ({@link #DATA_ENCODING}, {@link #BUFFER_UNDERFLOW}, etc.)
+     */
+    public void setError(int errorKind) {
+        setError(errorKind, "");
+    }
+
+    /**
+     * Records an error on this reader if no previous error is set. Once an error is recorded
+     * subsequent reads return default values (zero or empty).
+     *
+     * @param errorKind one of the error-code constants ({@link #DATA_ENCODING}, {@link #BUFFER_UNDERFLOW}, etc.)
+     * @param message   a detail message associated with the error
+     */
+    public void setError(int errorKind, String message) {
+        if (err > 0) return; // if an error exists, don't overwrite
+        err = errorKind;
+        relLimit = -1;
+        seenEOF = true;
+        // TODO simplify when exceptions are not required
+        includeCause = true;
+        if (useStacktrace) {
+            if (errorKind == UNKNOWN_FIELD) {
+                cause = new UnknownFieldException(message);
+            } else if (errorKind == BUFFER_UNDERFLOW) {
+                cause = new BufferUnderflowException();
+            } else if (errorKind == BUFFER_OVERFLOW) {
+                cause = new BufferOverflowException();
+            } else if (errorKind == PARSE) {
+                cause = new RuntimeException(message);
+                includeCause = false;
+            } else {
+                cause = new RuntimeException(message);
+            }
+        } else {
+            if (errorKind == UNKNOWN_FIELD) {
+                cause = premadeUnknown;
+            } else if (errorKind == BUFFER_UNDERFLOW) {
+                cause = premadeUnderflow;
+            } else if (errorKind == BUFFER_OVERFLOW) {
+                cause = premadeOverflow;
+            } else if (errorKind == PARSE) {
+                cause = premadeParseEmpty;
+                includeCause = false;
+            } else {
+                cause = premadeRuntime;
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if no error is set; otherwise throws a {@link ParseException}.
+     *
+     * @return {@code true} if no error has occurred
+     * @throws ParseException if an error is set
+     */
+    public boolean throwOnErrorOrTrue() throws ParseException {
+        if (err <= 0) return true;
+        throw throwOnErrorImpl();
+    }
+
+    /**
+     * Throws a {@link ParseException} if an error is set; otherwise does nothing.
+     *
+     * @throws ParseException if {@link #error()} is non-zero
+     */
+    public void throwOnError() throws ParseException {
+        if (err <= 0) return;
+        throw throwOnErrorImpl();
+    }
+
+    private ParseException throwOnErrorImpl() throws ParseException {
+        if (useStacktrace) {
+            switch (err) {
+                case DATA_ENCODING:
+                    throw new DataEncodingException("throwOnError", cause);
+                case ILLEGAL_ARGUMENT:
+                    throw new IllegalArgumentException("throwOnError", cause);
+                case UNSUPPORTED:
+                    throw new RuntimeException("Hit an unsupported feature", cause);
+                case MAX_DEPTH_REACHED:
+                    throw new ParseException("Reached maximum allowed depth");
+                case PARSE:
+                default:
+                    if (includeCause) throw new ParseException(cause);
+                    ParseException ex = new ParseException("");
+                    ex.setStackTrace(cause.getStackTrace());
+                    throw ex;
+            }
+        } else {
+            switch (err) {
+                case DATA_ENCODING:
+                    throw premadeDataEncoding;
+                case ILLEGAL_ARGUMENT:
+                    throw premadeIllegal;
+                case UNSUPPORTED:
+                    throw premadeUnsupported;
+                case MAX_DEPTH_REACHED:
+                    throw premadeMaxDepth;
+                case PARSE:
+                default:
+                    if (includeCause) {
+                        throw new ParseException(cause, true);
+                    }
+                    throw premadeParseEmpty;
+            }
+        }
+    }
+
+    /**
+     * Like {@link #throwOnError()}, but throws an {@link IOException} for {@link #UNSUPPORTED}
+     * errors instead of a {@link ParseException}. Intended for tests that expect checked I/O
+     * exceptions.
+     *
+     * @throws ParseException if a parse error is set
+     * @throws IOException    if an unsupported-feature error is set
+     */
+    public void throwOnError2() throws ParseException, IOException {
+        if (err == UNSUPPORTED) {
+            throw new IOException("Hit an unsupported feature", cause);
+        }
+        throwOnError();
+    }
+
+    /**
+     * Returns the current error code, or {@code 0} if no error has occurred.
+     *
+     * @return a positive error-code constant, or {@code 0} for no error
+     */
+    public int error() {
+        return err > 0 ? err : 0;
+    }
+
+    private int bufferedInternal(int count) {
+        if (count <= buf.length) {
+            bufferMore(count);
+            if (pos + count <= relLimit) {
+                int origPos = pos;
+                pos += count;
+                return origPos;
+            }
+        }
+        return -1;
+    }
+
+    private int buffered(int count) {
+        if (pos + count <= relLimit) {
+            int origPos = pos;
+            pos += count;
+            return origPos;
+        }
+        return bufferedInternal(count);
+    }
+
+    private int readFromInput(@NonNull byte[] dst, int off, int len) {
+        if (stream != null) {
+            int total = 0;
+            try {
+                while (total < len) {
+                    int n = stream.read(dst, off + total, len - total);
+                    if (n < 0) break;
+                    total += n;
+                }
+            } catch (IOException e) {
+                setError(IO_ERROR);
+            }
+            return total;
+        }
+        long remaining = rsd.remaining();
+        if (remaining <= 0) return 0;
+        len = (int) Math.min(len, remaining); // a test requires not buffering past limit
+        return (int) rsd.readBytes(dst, off, len);
+    }
+
+    private int readBytesInternalCopy(@NonNull byte[] dst, int dstOffset, int count) {
+        if (err > 0) return -1;
+        int copiedLen = Math.min(count, relLimit - pos);
+        System.arraycopy(buf, pos, dst, dstOffset, copiedLen);
+        pos += copiedLen;
+        if (copiedLen == count || err != 0) return copiedLen;
+
+        offset += pos;
+        relLimit = pos = end = 0;
+        int rdlen = readFromInput(dst, dstOffset + copiedLen, count - copiedLen);
+        if (rdlen == 0) {
+            seenEOF = true;
+            err = EOF;
+        }
+        offset += rdlen;
+        return copiedLen + rdlen;
+    }
+
+    /**
+     * Reads up to {@code dst.length} bytes into the given array. If fewer bytes are available
+     * the array is partially filled. The number of bytes copied is returned.
+     * Returns {@code -1} on an error
+     *
+     * @param dst the destination array
+     * @return the number of bytes read, or {@code -1} if a pre-existing error is set
+     */
+    public long readBytes(@NonNull final byte[] dst) {
+        return readBytesInternalCopy(dst, 0, dst.length);
+    }
+
+    /**
+     * Reads up to {@code length} bytes into the given array starting at {@code offset}. If fewer
+     * bytes are available the array is partially filled. The number of bytes copied is returned.
+     * Returns {@code -1} on an error
+     *
+     * @param dst    the destination array
+     * @param offset the start index within {@code dst}
+     * @param length the number of bytes to read
+     * @return the number of bytes read, or {@code -1} if a pre-existing error is set
+     */
+    public long readBytes(@NonNull final byte[] dst, int offset, int length) {
+        return readBytesInternalCopy(dst, offset, length);
+    }
+
+    /**
+     * Reads bytes into the given {@link ByteBuffer}, advancing its position by the number of
+     * bytes read. If fewer bytes are available than the buffer's remaining capacity, the buffer
+     * is partially filled, and the number of bytes copied is returned.
+     * Returns {@code -1} on an error
+     *
+     * @param dst the destination buffer; bytes are written starting at its current position
+     * @return the number of bytes actually read, or {@code -1} if a pre-existing error is set
+     */
+    public long readBytes(@NonNull ByteBuffer dst) {
+        int len = readBytesInternalCopy(dst.array(), dst.arrayOffset() + dst.position(), dst.remaining());
+        if (len > 0) { // handles error case (which sets len == -1)
+            dst.position(dst.position() + len);
+        }
+        return len;
+    }
+
+    /**
+     * Reads exactly {@code length} bytes and returns them as a {@link Bytes} instance.
+     * Sets {@link #BUFFER_UNDERFLOW} and returns {@link Bytes#EMPTY} if fewer bytes are available.
+     *
+     * @param length the number of bytes to read
+     * @return the read bytes, or {@link Bytes#EMPTY} on error
+     */
+    public @NonNull Bytes readBytes(int length) {
+        if (length <= relLimit - pos && err <= 0) {
+            byte[] dst = new byte[length];
+            System.arraycopy(buf, pos, dst, 0, length);
+            pos += length;
+            return Bytes.wrap(dst);
+        }
+        return readBytesInternal(length);
+    }
+
+    @NonNull
+    private Bytes readBytesInternal(int length) {
+        if (length == 0 || err > 0) {
+            return Bytes.EMPTY;
+        } else if (length < 0) {
+            setError(ILLEGAL_ARGUMENT);
+            return Bytes.EMPTY;
+        }
+        byte[] dst = new byte[length];
+        int copiedLen = readBytesInternalCopy(dst, 0, length);
+        if (copiedLen < length) {
+            setError(BUFFER_UNDERFLOW);
+            return Bytes.EMPTY;
+        }
+        return Bytes.wrap(dst);
+    }
+
+    /**
+     * Reads a 32-bit integer in big-endian byte order. Alias for {@link #readIntBE()}.
+     *
+     * @return the integer value
+     */
+    public int readInt() {
+        return readIntBE();
+    }
+
+    /**
+     * Reads a 32-bit integer in big-endian byte order.
+     * Sets {@link #BUFFER_UNDERFLOW} and returns {@code 0} if fewer than 4 bytes are available.
+     *
+     * @return the integer value
+     */
+    public int readIntBE() {
+        if (pos + 4 <= relLimit) {
+            int v = 0;
+            for (int i = 0; i < 4; i++) {
+                v |= (buf[pos + 3 - i] & 255) << (i * 8);
+            }
+            pos += 4;
+            return v;
+        }
+        return readIntBEInternal();
+    }
+
+    /**
+     * Reads a 32-bit integer in little-endian byte order.
+     * Sets {@link #BUFFER_UNDERFLOW} and returns {@code 0} if fewer than 4 bytes are available.
+     *
+     * @return the integer value
+     */
+    public int readIntLE() {
+        if (pos + 4 <= relLimit) {
+            int v = 0;
+            for (int i = 0; i < 4; i++) {
+                v |= (buf[pos + i] & 255) << (i * 8);
+            }
+            pos += 4;
+            return v;
+        }
+        return readIntLEInternal();
+    }
+
+    private int readIntBEInternal() {
+        bufferMore(4);
+        if (pos + 4 > relLimit) {
+            setError(BUFFER_UNDERFLOW);
+            return 0;
+        }
+        int v = 0;
+        for (int i = 0; i < 4; i++) {
+            v |= (buf[pos + 3 - i] & 255) << (i * 8);
+        }
+        pos += 4;
+        return v;
+    }
+
+    private int readIntLEInternal() {
+        bufferMore(4);
+        if (pos + 4 > relLimit) {
+            setError(BUFFER_UNDERFLOW);
+            return 0;
+        }
+        int v = 0;
+        for (int i = 0; i < 4; i++) {
+            v |= (buf[pos + i] & 255) << (i * 8);
+        }
+        pos += 4;
+        return v;
+    }
+
+    /**
+     * Reads a 64-bit integer in big-endian byte order. Alias for {@link #readLongBE()}.
+     *
+     * @return the long value
+     */
+    public long readLong() {
+        return readLongBE();
+    }
+
+    /**
+     * Reads a 64-bit integer in big-endian byte order.
+     * Sets {@link #BUFFER_UNDERFLOW} and returns {@code 0} if fewer than 8 bytes are available.
+     *
+     * @return the long value
+     */
+    public long readLongBE() {
+        if (pos + 8 <= relLimit) {
+            long v = 0;
+            for (int i = 0; i < 8; i++) {
+                v |= (long) (buf[pos + 7 - i] & 255) << (i * 8);
+            }
+            pos += 8;
+            return v;
+        }
+        return readLongBEInternal();
+    }
+
+    private long readLongBEInternal() {
+        bufferMore(8);
+        if (pos + 8 > relLimit) {
+            setError(BUFFER_UNDERFLOW);
+            return 0;
+        }
+        long v = 0;
+        for (int i = 0; i < 8; i++) {
+            v |= (long) (buf[pos + 7 - i] & 255) << (i * 8);
+        }
+        pos += 8;
+        return v;
+    }
+
+    /**
+     * Reads a 64-bit integer in little-endian byte order.
+     * Sets {@link #BUFFER_UNDERFLOW} and returns {@code 0} if fewer than 8 bytes are available.
+     *
+     * @return the long value
+     */
+    public long readLongLE() {
+        if (pos + 8 <= relLimit) {
+            long v = 0;
+            for (int i = 0; i < 8; i++) {
+                v |= (long) (buf[pos + i] & 255) << (i * 8);
+            }
+            pos += 8;
+            return v;
+        }
+        return readLongLEInternal();
+    }
+
+    private long readLongLEInternal() {
+        bufferMore(8);
+        if (pos + 8 > relLimit) {
+            setError(BUFFER_UNDERFLOW);
+            return 0;
+        }
+        long v = 0;
+        for (int i = 0; i < 8; i++) {
+            v |= (long) (buf[pos + i] & 255) << (i * 8);
+        }
+        pos += 8;
+        return v;
+    }
+
+    /**
+     * Reads a 32-bit float in big-endian byte order.
+     *
+     * @return the float value
+     */
+    public float readFloat() {
+        return Float.intBitsToFloat(readInt());
+    }
+
+    /**
+     * Reads a 32-bit float in little-endian byte order.
+     *
+     * @return the float value
+     */
+    public float readFloatLE() {
+        return Float.intBitsToFloat(readIntLE());
+    }
+
+    /**
+     * Reads a 64-bit double in big-endian byte order.
+     *
+     * @return the double value
+     */
+    public double readDouble() {
+        return Double.longBitsToDouble(readLong());
+    }
+
+    /**
+     * Reads a 64-bit double in little-endian byte order.
+     *
+     * @return the double value
+     */
+    public double readDoubleLE() {
+        return Double.longBitsToDouble(readLongLE());
+    }
+
+    /**
+     * Returns an {@link InputStream} view of the remaining data in this reader.
+     * For streaming readers, returns the underlying stream directly. For byte-array readers,
+     * returns a {@link ByteArrayInputStream} over the buffered data.
+     *
+     * @return an {@code InputStream} over the unread bytes
+     * @throws UnsupportedOperationException if the reader is in a partially-buffered streaming state
+     */
+    public InputStream asInputStream() {
+        if (end == 0) return stream != null ? stream : rsd.asInputStream();
+        if (seenEOF && offset == 0) {
+            return new ByteArrayInputStream(buf, pos, end - pos);
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Reads a single byte and returns {@code true} if it is non-zero, {@code false} otherwise.
+     *
+     * @return the boolean value
+     */
+    public boolean readBoolean() {
+        return readByte() != 0;
+    }
+
+    /**
+     * Reads and returns a single signed byte, advancing the position by 1.
+     * Sets {@link #BUFFER_UNDERFLOW} and returns {@code 0} if no bytes remain.
+     *
+     * @return the byte value
+     */
+    public byte readByte() {
+        if (pos + 1 <= relLimit) return buf[pos++];
+        return readByteInternal();
+    }
+
+    private byte readByteInternal() {
+        if (pos + 1 > relLimit) {
+            bufferMore(1);
+            if (pos + 1 > relLimit) {
+                setError(BUFFER_UNDERFLOW);
+                return 0;
+            }
+        }
+        return buf[pos++];
+    }
+
+    /**
+     * Reads a length-prefixed UTF-8 string. The length is read as a base-128 varint followed
+     * by that many UTF-8 bytes. Sets {@link #PARSE} and returns {@code ""} if the length exceeds
+     * {@code maxSize}, is negative, or if the UTF-8 bytes are malformed.
+     *
+     * @param maxSize the maximum allowed string byte length
+     * @return the decoded string, or {@code ""} on error
+     */
+    public String readString(final long maxSize) {
+        final int length = readVarIntNoZZ();
+        if (length > maxSize || length < 0) {
+            setError(PbjReader.PARSE);
+            return "";
+        }
+
+        int bufPos = buffered(length);
+        byte[] data = null;
+        if (bufPos >= 0) {
+            data = buf;
+        } else {
+            data = new byte[length];
+            int copiedLen = readBytesInternalCopy(data, 0, length);
+            if (copiedLen < length) {
+                setError(BUFFER_UNDERFLOW);
+                return "";
+            }
+            bufPos = 0;
+        }
+
+        if (charArray == null || length > charArray.length) {
+            int power2Capacity = 2 << (63 - Long.numberOfLeadingZeros(Math.max(2048, length)));
+            charArray = new char[power2Capacity];
+        }
+
+        int i = 0;
+        // Ascii fast path
+        {
+            for (; i < length; i++) {
+                byte b = data[bufPos + i];
+                if ((b & 0x80) != 0) break;
+                charArray[i] = (char) b;
+            }
+            if (i == length) {
+                return new String(charArray, 0, length);
+            }
+        }
+        int utf16Len = ProtoParserTools.fromUTF8(charArray, data, bufPos, i, length);
+        if (utf16Len >= 0) {
+            return new String(charArray, 0, utf16Len);
+        }
+        setError(PbjReader.PARSE);
+        return "";
+    }
+
+    @Override
+    public void close() {
+        if (stream == null) return;
+        try {
+            stream.close();
+        } catch (IOException ex) {
+            setError(IO_ERROR, ex.getMessage());
+        }
+        if (err == 0) {
+            err = CLOSED;
+        }
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -219,6 +219,10 @@ public class PbjReader implements AutoCloseable {
         int position = bb.arrayOffset() + bb.position();
         resetWith(bb.array(), position, position + bb.remaining());
     }
+    /** Resets this reader to read from the given {@link Bytes}. */
+    public void resetWith(Bytes bytes) {
+        bytes.resetPbjReader(this);
+    }
 
     /*
      * fills the buffer from the stream repecting the set limit

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -38,7 +38,17 @@ public class PbjReader implements AutoCloseable {
     private boolean seenEOF, includeCause;
     private byte[] ownedBuf;
 
+    /*
+     * readString() needs a buffer when decoding a UTF8 string.
+     * The string constructor needs one large array.
+     * PbjReader has a thread-local storage cache in some projects,
+     * making this reused until the thread shutsdown
+     */
     private char[] charArray;
+    /*
+     * If a project doesn't care about stacktraces, setting pbj.ReaderWriter.useStackTrace to false
+     * will throw a premade exceptions that doesn't have the correct stacktrace. It's fast and good against DOS attacks
+     */
     private static final boolean useStacktrace =
             !"false".equalsIgnoreCase(System.getProperty("pbj.ReaderWriter.useStackTrace"));
 
@@ -64,6 +74,10 @@ public class PbjReader implements AutoCloseable {
     private static final IllegalArgumentException premadeIllegal;
     private static final ParseException premadeParseEmpty, premadeParseUnknown, premadeMaxDepth;
 
+    /*
+     * Some projects may not want exceptions, but their test expects them.
+     * Here are premade exceptions that are created once and thrown potentially many times
+     */
     static {
         premadeUnknown = new UnknownFieldException("");
         premadeUnderflow = new BufferUnderflowException();
@@ -78,6 +92,9 @@ public class PbjReader implements AutoCloseable {
         premadeMaxDepth = new ParseException("Reached maximum allowed depth");
     }
 
+    /*
+     * resetWith can't call constructors, so this is a private function
+     */
     private void construct(byte[] buffer, int position, int endPosition) {
         buf = buffer;
         pos = position;
@@ -86,6 +103,20 @@ public class PbjReader implements AutoCloseable {
         absoluteLimit = end;
         seenEOF = true;
         err = EOF;
+    }
+    /*
+     * resetWith doesn't call this, but it does accept these two as a parameter.
+     * I think having this would be consistent than having these two constructors the only two not calling another method
+     */
+    private void construct(ReadableSequentialData seq, InputStream inputStream) {
+        if (seq != null) {
+            rsd = seq;
+            absoluteLimit = seq.limit();
+            offset = (int) seq.position();
+        } else if (inputStream != null) {
+            stream = inputStream;
+        }
+        ownedBuf = buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
     }
 
     /**
@@ -105,17 +136,9 @@ public class PbjReader implements AutoCloseable {
         construct(buffer, position, endPosition);
     }
 
-    private void construct(ReadableSequentialData seq, InputStream inputStream) {
-        if (seq != null) {
-            rsd = seq;
-            absoluteLimit = seq.limit();
-            offset = seq.position();
-        } else if (inputStream != null) {
-            stream = inputStream;
-        }
-        ownedBuf = buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
-    }
-
+    /*
+     * An objected construct with bytes can be resetWith a stream object. However, these two constructions are very different
+     */
     private void resetWith(ReadableSequentialData seq, InputStream inputStream) {
         err = 0;
         cause = null;
@@ -197,6 +220,9 @@ public class PbjReader implements AutoCloseable {
         resetWith(bb.array(), position, position + bb.remaining());
     }
 
+    /*
+     * fills the buffer from the stream repecting the set limit
+     */
     private void bufferMore() {
         if (err != 0) return;
         offset += pos;
@@ -227,10 +253,12 @@ public class PbjReader implements AutoCloseable {
         // small and likely to inline
         if (pos < relLimit) return true;
         if (offset + pos == absoluteLimit) return false;
-        return hasRemainingInternal();
+        return hasRemaining_cold();
     }
-    // still small, but less likely to hit this case in steaming, and only once when not streaming
-    private boolean hasRemainingInternal() {
+    /*
+     * still small, but less likely to hit this case in steaming, and only once when not streaming
+     */
+    private boolean hasRemaining_cold() {
         if (seenEOF) return false;
         bufferMore();
         return pos < relLimit;
@@ -281,10 +309,13 @@ public class PbjReader implements AutoCloseable {
             pos += count;
             return;
         }
-        skipInternal(count);
+        skip_cold(count);
     }
 
-    private void skipInternal(int count) {
+    /*
+     * Skips data, and will call skip from a stream if it's using one, to avoid copying
+     */
+    private void skip_cold(int count) {
         if (seenEOF) {
             setError(BUFFER_UNDERFLOW);
             return;
@@ -320,6 +351,8 @@ public class PbjReader implements AutoCloseable {
     }
 
     /**
+     * Same as readVarInt(false), but avoids an if statement
+     *
      * Reads a base-128 varint and returns its value as an {@code int} (no zigzag decoding).
      * On a malformed varint, sets the error flag and returns {@code -1}; however,
      * {@code -1} is also a valid decoded value, so callers must check {@link #error()} to
@@ -345,6 +378,8 @@ public class PbjReader implements AutoCloseable {
     }
 
     /**
+     * Same as readVarInt(true), but avoids an if statement
+     *
      * Reads a base-128 varint and returns its zigzag-decoded value as an {@code int}.
      * Zigzag decoding maps the raw unsigned value {@code n} to {@code (n >>> 1) ^ -(n & 1)}.
      * On a malformed varint, sets the error flag and returns {@code -1}; however,
@@ -406,10 +441,15 @@ public class PbjReader implements AutoCloseable {
             setError(DATA_ENCODING);
             return -1;
         }
-        return readVarLongNoZZInternal();
+        // Do not inline readVarLongNoZZInternal. The above is hot and very likely to be inlined,
+        // the below includes a call to readByte which calls bufferMore which would not be inlined.
+        return readVarLongNoZZ_cold();
     }
 
-    private long readVarLongNoZZInternal() {
+    /*
+     * this indirectly calls bufferMore which won't be inlined. This is the slow path while public version is fast
+     */
+    private long readVarLongNoZZ_cold() {
         long value = 0;
         for (int i = 0; i < 10; i++) {
             byte b = readByte();
@@ -440,10 +480,13 @@ public class PbjReader implements AutoCloseable {
             setError(DATA_ENCODING);
             return Bytes.EMPTY;
         }
-        return readVarLongBytesInternal(bytes);
+        return readVarLongBytes_cold(bytes);
     }
 
-    private Bytes readVarLongBytesInternal(byte[] bytes) {
+    /*
+     * slow path, see bottom of readVarLongNoZZ for the reason
+     */
+    private Bytes readVarLongBytes_cold(byte[] bytes) {
         for (int i = 0; i < 10; i++) {
             bytes[i] = readByte();
             if (bytes[i] >= 0) {
@@ -528,6 +571,9 @@ public class PbjReader implements AutoCloseable {
         throw throwOnErrorImpl();
     }
 
+    /*
+     * split from public function so public function is more likely to be inlined
+     */
     private ParseException throwOnErrorImpl() throws ParseException {
         if (useStacktrace) {
             switch (err) {
@@ -590,7 +636,24 @@ public class PbjReader implements AutoCloseable {
         return err > 0 ? err : 0;
     }
 
-    private int bufferedInternal(int count) {
+    /**
+     * Returns true if all operations has been successful
+     *
+     * @return {@code true} if no error has occurred
+     */
+    public boolean ok() {
+        return err <= 0;
+    }
+
+    /*
+     * only used through readString, which only wants bufferred data if it fits
+     */
+    private int buffered(int count) {
+        if (pos + count <= relLimit) {
+            int origPos = pos;
+            pos += count;
+            return origPos;
+        }
         if (count <= buf.length) {
             bufferMore();
             if (pos + count <= relLimit) {
@@ -602,15 +665,9 @@ public class PbjReader implements AutoCloseable {
         return -1;
     }
 
-    private int buffered(int count) {
-        if (pos + count <= relLimit) {
-            int origPos = pos;
-            pos += count;
-            return origPos;
-        }
-        return bufferedInternal(count);
-    }
-
+    /*
+     * there's two input streams, and this is called indirectly from the readBytes methods (and readString via buffered above)
+     */
     private int readFromInput(@NonNull byte[] dst, int off, int len) {
         if (stream != null) {
             int total = 0;
@@ -631,6 +688,9 @@ public class PbjReader implements AutoCloseable {
         return (int) rsd.readBytes(dst, off, len);
     }
 
+    /*
+     * a consistent way to read data from the multiple readBytes methods
+     */
     private int readBytesInternalCopy(@NonNull byte[] dst, int dstOffset, int count) {
         if (err > 0) return -1;
         int copiedLen = Math.min(count, relLimit - pos);
@@ -706,11 +766,14 @@ public class PbjReader implements AutoCloseable {
             pos += length;
             return Bytes.wrap(dst);
         }
-        return readBytesInternal(length);
+        return readBytes_cold(length);
     }
 
+    /*
+     * Slow path of readBytes, although I'm not sure if any readBytes will be inlined
+     */
     @NonNull
-    private Bytes readBytesInternal(int length) {
+    private Bytes readBytes_cold(int length) {
         if (length == 0 || err > 0) {
             return Bytes.EMPTY;
         } else if (length < 0) {
@@ -750,7 +813,7 @@ public class PbjReader implements AutoCloseable {
             pos += 4;
             return v;
         }
-        return readIntBEInternal();
+        return readIntBE_cold();
     }
 
     /**
@@ -768,10 +831,12 @@ public class PbjReader implements AutoCloseable {
             pos += 4;
             return v;
         }
-        return readIntLEInternal();
+        // Don't inline the below. The above is very likely to inline
+        // while the below is not (and calls large methods like bufferMore())
+        return readIntLE_cold();
     }
 
-    private int readIntBEInternal() {
+    private int readIntBE_cold() {
         bufferMore();
         if (pos + 4 > relLimit) {
             setError(BUFFER_UNDERFLOW);
@@ -785,7 +850,7 @@ public class PbjReader implements AutoCloseable {
         return v;
     }
 
-    private int readIntLEInternal() {
+    private int readIntLE_cold() {
         bufferMore();
         if (pos + 4 > relLimit) {
             setError(BUFFER_UNDERFLOW);
@@ -823,10 +888,12 @@ public class PbjReader implements AutoCloseable {
             pos += 8;
             return v;
         }
-        return readLongBEInternal();
+        // Don't inline the below. The above is very likely to inline
+        // while the below is not (and calls large methods like bufferMore())
+        return readLongBE_cold();
     }
 
-    private long readLongBEInternal() {
+    private long readLongBE_cold() {
         bufferMore();
         if (pos + 8 > relLimit) {
             setError(BUFFER_UNDERFLOW);
@@ -855,10 +922,10 @@ public class PbjReader implements AutoCloseable {
             pos += 8;
             return v;
         }
-        return readLongLEInternal();
+        return readLongLE_cold();
     }
 
-    private long readLongLEInternal() {
+    private long readLongLE_cold() {
         bufferMore();
         if (pos + 8 > relLimit) {
             setError(BUFFER_UNDERFLOW);
@@ -941,10 +1008,11 @@ public class PbjReader implements AutoCloseable {
      */
     public byte readByte() {
         if (pos + 1 <= relLimit) return buf[pos++];
-        return readByteInternal();
+        // seperated so the above is likely to inline
+        return readByte_cold();
     }
 
-    private byte readByteInternal() {
+    private byte readByte_cold() {
         if (pos + 1 > relLimit) {
             bufferMore();
             if (pos + 1 > relLimit) {

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -299,6 +299,15 @@ public class PbjReader implements AutoCloseable {
     }
 
     /**
+     * Returns the number of bytes remaining before the limit. This is not the byte length since a stream may return MAX_VALUE as its limit
+     *
+     * @return the number of bytes remaining
+     */
+    public long remaining() {
+        return limit() - position();
+    }
+
+    /**
      * Skips over {@code count} bytes, advancing the read position without returning the data.
      * Sets {@link #BUFFER_UNDERFLOW} if there are fewer than {@code count} bytes remaining.
      *

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjWriter.java
@@ -1,0 +1,1067 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.isSurrogatePair;
+import static java.lang.Character.toCodePoint;
+
+import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A buffer-backed writer for encoding protobuf data. Not thread safe.
+ *
+ * <p>PbjWriter maintains an internal byte buffer and writes to an {@link OutputStream},
+ * {@link WritableSequentialData}, or a fixed byte array. When backed by an output stream the
+ * buffer is flushed automatically when full. When not backed by a stream the buffer grows as
+ * needed (unless constructed with {@code mayGrow = false}).
+ *
+ * <p>Errors are tracked internally rather than thrown immediately. Call {@link #error()} to check
+ * for a pending error code, or {@link #throwOnError()} to surface it as an exception. Once an
+ * error is set it is sticky — subsequent write calls become no-ops.
+ *
+ * <p>Implements {@link AutoCloseable}: closing flushes pending bytes to the underlying stream.
+ */
+public class PbjWriter implements AutoCloseable {
+    private byte[] buf;
+    private int pos, cap;
+    private int offset, err;
+    private RuntimeException cause;
+    private OutputStream output;
+    private boolean reuseable;
+    private boolean mayGrow = true;
+
+    private static final boolean useStacktrace =
+            !"false".equalsIgnoreCase(System.getProperty("pbj.ReaderWriter.useStackTrace"));
+    public static final int EOF = PbjReader.EOF,
+            DATA_ENCODING = PbjReader.DATA_ENCODING,
+            BUFFER_UNDERFLOW = PbjReader.BUFFER_UNDERFLOW,
+            PARSE = PbjReader.PARSE,
+            ILLEGAL_ARGUMENT = PbjReader.ILLEGAL_ARGUMENT,
+            IO_ERROR = PbjReader.IO_ERROR,
+            UNSUPPORTED = PbjReader.UNSUPPORTED,
+            USAGE_ERROR = PbjReader.USAGE_ERROR,
+            UNKNOWN_FIELD = PbjReader.UNKNOWN_FIELD,
+            BUFFER_OVERFLOW = PbjReader.BUFFER_OVERFLOW,
+            MAX_DEPTH_REACHED = PbjReader.MAX_DEPTH_REACHED,
+            // For PbjWriter
+            CLOSED = PbjReader.CLOSED,
+            MALFORM_STRING = PbjReader.MALFORM_STRING;
+
+    private static final RuntimeException premadeRuntimeException;
+
+    static {
+        premadeRuntimeException = new RuntimeException("Stacktrace not enabled in PbjWriter");
+    }
+
+    /**
+     * Creates a writer that streams output to the given {@link OutputStream}.
+     * An internal 16 KB buffer is used; the buffer is flushed to the stream when full.
+     *
+     * @param output the output stream to write to
+     */
+    public PbjWriter(@NonNull OutputStream output) {
+        this.output = output;
+        buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        cap = buf.length;
+        reuseable = true;
+    }
+
+    /**
+     * Creates a writer backed by a {@link ByteBuffer}.
+     *
+     * <p>If the buffer has a backing array it is used directly. Otherwise an internal 16 KB
+     * streaming buffer is used and bytes are forwarded to the {@link ByteBuffer} on flush.
+     *
+     * @param buffer the target byte buffer
+     */
+    public PbjWriter(ByteBuffer buffer) {
+        if (buffer.hasArray()) {
+            buf = buffer.array();
+            pos = buffer.arrayOffset() + buffer.position();
+            cap = buffer.arrayOffset() + buffer.limit();
+        } else {
+            this.output = new OutputStream() {
+                @Override
+                public void write(int b) {
+                    buffer.put((byte) b);
+                }
+
+                @Override
+                public void write(@NonNull byte[] b, int off, int len) {
+                    buffer.put(b, off, len);
+                }
+            };
+            buf = new byte[16 << 10];
+            cap = buf.length;
+            reuseable = true;
+        }
+    }
+
+    /**
+     * Creates a writer that writes directly into the given byte array starting at {@code pos},
+     * writing up to the end of the array. No flushing or growing occurs.
+     *
+     * @param buffer the backing byte array
+     * @param pos    the starting write position within the array
+     */
+    public PbjWriter(byte[] buffer, int pos) {
+        this.buf = buffer;
+        this.pos = pos;
+        this.cap = buffer.length;
+    }
+
+    /**
+     * Creates a writer that streams output to the given {@link WritableSequentialData}.
+     * An internal 16 KB buffer is used; the buffer is flushed to the target when full.
+     *
+     * @param output the writable sequential data target
+     */
+    public PbjWriter(@NonNull WritableSequentialData output) {
+        this(new OutputStream() {
+            @Override
+            public void write(int b) {
+                output.writeByte((byte) b);
+            }
+
+            @Override
+            public void write(@NonNull byte[] b, int off, int len) {
+                output.writeBytes(b, off, len);
+            }
+        });
+    }
+
+    /**
+     * Creates a standalone, growable writer with an initial 16 KB internal buffer.
+     * No backing output stream is attached; use {@link #toByteArray()} to retrieve the written bytes.
+     */
+    public PbjWriter() {
+        buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        cap = buf.length;
+        reuseable = true;
+    }
+
+    /**
+     * Creates a growable (or fixed-size) standalone writer with the specified initial capacity.
+     *
+     * @param reserveSize the initial buffer capacity in bytes; if {@code mayGrow} is {@code true}
+     *                    the capacity is at least 16 KB regardless of this value
+     * @param mayGrow     {@code true} to allow the internal buffer to grow automatically;
+     *                    {@code false} to keep the buffer fixed at {@code reserveSize} bytes
+     */
+    public PbjWriter(int reserveSize, boolean mayGrow) {
+        if (mayGrow) buf = new byte[Math.max(reserveSize, 16 << 10)]; // 16k is friendly to x86-64 L1 cache
+        else {
+            buf = new byte[reserveSize];
+        }
+        cap = buf.length;
+        reuseable = true;
+        this.mayGrow = mayGrow;
+    }
+
+    /**
+     * Ensures that at least {@code len} bytes of space are available starting at the current
+     * position, flushing or growing the internal buffer if necessary.
+     *
+     * @param len the number of bytes to reserve
+     */
+    public void reserveRel(int len) {
+        if (pos + len <= cap) return;
+        flushOrGrow(len);
+    }
+
+    /**
+     * Advances the write position by {@code len} bytes without writing any data.
+     * Used to reserve placeholder space that will be filled in later via {@link #writeAtUnsafe}.
+     *
+     * @param len the number of bytes to skip over
+     */
+    public void placehold(int len) {
+        pos += len;
+    }
+
+    /**
+     * Returns the current absolute write position, accounting for any bytes already flushed
+     * to the underlying output stream.
+     *
+     * @return the current write position as a non-negative integer
+     */
+    public int position() {
+        return offset + pos;
+    }
+
+    /**
+     * Overwrites a single byte at the given absolute position without advancing the write cursor.
+     * Used to patch in placeholder bytes reserved earlier via {@link #placehold}.
+     *
+     * @param pos   the absolute write position to patch
+     * @param value the byte value to write
+     */
+    public void writeAtUnsafe(int pos, byte value) {
+        buf[pos - offset] = value;
+    }
+
+    /**
+     * Expands a 1-byte varint placeholder at the given absolute position into a 2-byte varint
+     * and shifts all subsequent bytes forward by one. The placeholder must have been reserved
+     * via {@link #placehold(int)}.
+     *
+     * @param position the absolute position of the 1-byte placeholder
+     */
+    public void reinsertVarInt(int position) {
+        int relPos = position - offset;
+        int len = this.pos - relPos - 1;
+        System.arraycopy(buf, relPos + 1, buf, relPos + 2, len);
+        buf[relPos] = (byte) ((len & 0x7F) | 0x80);
+        buf[relPos + 1] = (byte) (len >>> 7);
+        this.pos++;
+    }
+
+    /**
+     * Writes a boolean as a single byte ({@code 1} for {@code true}, {@code 0} for {@code false}).
+     *
+     * @param b the boolean value to write
+     */
+    public void writeBoolean(boolean b) {
+        writeByte((byte) (b ? 1 : 0));
+    }
+
+    /**
+     * Writes a single signed byte.
+     *
+     * @param b the byte to write
+     */
+    public void writeByte(byte b) {
+        if (pos < cap) {
+            buf[pos++] = b;
+            return;
+        }
+        writeByteInternal(b);
+    }
+
+    private void writeByteInternal(byte b) {
+        flushOrGrow(1);
+        buf[pos++] = b;
+    }
+
+    /**
+     * Writes two bytes in sequence.
+     *
+     * @param b1 the first byte
+     * @param b2 the second byte
+     */
+    public void writeByte2(byte b1, byte b2) {
+        if (pos + 2 <= cap) {
+            buf[pos] = b1;
+            buf[pos + 1] = b2;
+            pos += 2;
+            return;
+        }
+        writeByte2Internal(b1, b2);
+    }
+
+    private void writeByte2Internal(byte b1, byte b2) {
+        flushOrGrow(2);
+        buf[pos] = b1;
+        buf[pos + 1] = b2;
+        pos += 2;
+    }
+
+    /**
+     * Writes three bytes in sequence.
+     *
+     * @param b1 the first byte
+     * @param b2 the second byte
+     * @param b3 the third byte
+     */
+    public void writeByte3(byte b1, byte b2, byte b3) {
+        if (pos + 3 <= cap) {
+            buf[pos] = b1;
+            buf[pos + 1] = b2;
+            buf[pos + 2] = b3;
+            pos += 3;
+            return;
+        }
+        writeByte3Internal(b1, b2, b3);
+    }
+
+    private void writeByte3Internal(byte b1, byte b2, byte b3) {
+        flushOrGrow(3);
+        buf[pos] = b1;
+        buf[pos + 1] = b2;
+        buf[pos + 2] = b3;
+        pos += 3;
+    }
+
+    /**
+     * Writes four bytes in sequence.
+     *
+     * @param b1 the first byte
+     * @param b2 the second byte
+     * @param b3 the third byte
+     * @param b4 the fourth byte
+     */
+    public void writeByte4(byte b1, byte b2, byte b3, byte b4) {
+        if (pos + 4 <= cap) {
+            buf[pos] = b1;
+            buf[pos + 1] = b2;
+            buf[pos + 2] = b3;
+            buf[pos + 3] = b4;
+            pos += 4;
+            return;
+        }
+        writeByte4Internal(b1, b2, b3, b4);
+    }
+
+    private void writeByte4Internal(byte b1, byte b2, byte b3, byte b4) {
+        flushOrGrow(4);
+        buf[pos] = b1;
+        buf[pos + 1] = b2;
+        buf[pos + 2] = b3;
+        buf[pos + 3] = b4;
+        pos += 4;
+    }
+
+    /**
+     * Writes all remaining bytes from the given {@link BufferedData}, advancing its position.
+     *
+     * @param src the source buffer; all {@link BufferedData#remaining()} bytes are written
+     */
+    public void writeBytes(@NonNull final BufferedData src) {
+        int len = (int) src.remaining();
+        if (len <= 0) return;
+        long srcPos = src.position();
+        if (pos + len <= cap) {
+            src.getBytes(srcPos, buf, pos, len);
+            src.skip(len);
+            pos += len;
+            return;
+        }
+        writeBytesBDInternal(src, len, srcPos);
+    }
+
+    private void writeBytesBDInternal(BufferedData src, int len, long srcPos) {
+        if (output == null) {
+            flushOrGrow(len); // to grow at least to pos + len
+            src.getBytes(srcPos, buf, pos, len);
+            src.skip(len);
+            pos += len;
+        } else {
+            int remaining = len;
+            while (remaining > 0) {
+                if (pos == cap) {
+                    try {
+                        output.write(buf, 0, pos);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    offset += pos;
+                    pos = 0;
+                }
+                int chunk = Math.min(remaining, cap - pos);
+                src.getBytes(srcPos, buf, pos, chunk);
+                pos += chunk;
+                srcPos += chunk;
+                remaining -= chunk;
+            }
+            src.skip(len);
+        }
+    }
+
+    /**
+     * Writes all bytes from the given array.
+     *
+     * @param src the source byte array
+     */
+    public void writeBytes(@NonNull byte[] src) {
+        writeBytes(src, 0, src.length);
+    }
+
+    /**
+     * Writes {@code length} bytes from the given array starting at {@code offset}.
+     *
+     * @param src    the source byte array
+     * @param offset the start index within {@code src}
+     * @param length the number of bytes to write
+     */
+    public void writeBytes(@NonNull byte[] src, int offset, int length) {
+        if (length <= 0) return;
+        if (pos + length <= cap && (output == null || length < 2048)) {
+            System.arraycopy(src, offset, buf, pos, length);
+            pos += length;
+            return;
+        }
+        writeBytesInternal(src, offset, length);
+    }
+
+    private void writeBytesInternal(byte[] src, int srcOffset, int length) {
+        if (output != null && length >= 2048) {
+            if (pos > 0) {
+                try {
+                    output.write(buf, 0, pos);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                offset += pos;
+                pos = 0;
+            }
+            try {
+                output.write(src, srcOffset, length);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            offset += length;
+            return;
+        }
+        flushOrGrow(length);
+        System.arraycopy(src, srcOffset, buf, pos, length);
+        pos += length;
+    }
+
+    /**
+     * Writes all bytes from the given {@link RandomAccessData}.
+     *
+     * @param src the source data
+     */
+    public void writeBytes(@NonNull RandomAccessData src) {
+        int len = (int) src.length();
+        if (len <= 0) return;
+        if (pos + len <= cap) {
+            src.getBytes(0, buf, pos, len);
+            pos += len;
+            return;
+        }
+        writeBytesRAInternal(src, len);
+    }
+
+    private void writeBytesRAInternal(RandomAccessData src, int len) {
+        if (output == null) {
+            flushOrGrow(len);
+            src.getBytes(0, buf, pos, len);
+            pos += len;
+        } else {
+            // Maybe the below can be improved. This path seems rare
+            int srcOffset = 0;
+            int remaining = len;
+            while (remaining > 0) {
+                if (pos == cap) {
+                    try {
+                        output.write(buf, 0, pos);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    offset += pos;
+                    pos = 0;
+                }
+                int chunk = Math.min(remaining, cap - pos);
+                src.getBytes(srcOffset, buf, pos, chunk);
+                pos += chunk;
+                srcOffset += chunk;
+                remaining -= chunk;
+            }
+        }
+    }
+
+    /**
+     * Writes a 32-bit integer in big-endian byte order. Alias for {@link #writeIntBE(int)}.
+     *
+     * @param value the integer to write
+     */
+    public void writeInt(int value) {
+        writeIntBE(value);
+    }
+
+    /**
+     * Writes a 32-bit integer in big-endian byte order (most significant byte first).
+     *
+     * @param value the integer to write
+     */
+    public void writeIntBE(int value) {
+        if (pos + 4 <= cap) {
+            buf[pos] = (byte) (value >>> 24);
+            buf[pos + 1] = (byte) (value >>> 16);
+            buf[pos + 2] = (byte) (value >>> 8);
+            buf[pos + 3] = (byte) value;
+            pos += 4;
+            return;
+        }
+        writeIntBEInternal(value);
+    }
+
+    private void writeIntBEInternal(int value) {
+        flushOrGrow(4);
+        buf[pos] = (byte) (value >>> 24);
+        buf[pos + 1] = (byte) (value >>> 16);
+        buf[pos + 2] = (byte) (value >>> 8);
+        buf[pos + 3] = (byte) value;
+        pos += 4;
+    }
+
+    /**
+     * Writes a 32-bit integer in little-endian byte order (least significant byte first).
+     *
+     * @param value the integer to write
+     */
+    public void writeIntLE(int value) {
+        if (pos + 4 <= cap) {
+            buf[pos] = (byte) value;
+            buf[pos + 1] = (byte) (value >>> 8);
+            buf[pos + 2] = (byte) (value >>> 16);
+            buf[pos + 3] = (byte) (value >>> 24);
+            pos += 4;
+            return;
+        }
+        writeIntLEInternal(value);
+    }
+
+    private void writeIntLEInternal(int value) {
+        flushOrGrow(4);
+        buf[pos] = (byte) value;
+        buf[pos + 1] = (byte) (value >>> 8);
+        buf[pos + 2] = (byte) (value >>> 16);
+        buf[pos + 3] = (byte) (value >>> 24);
+        pos += 4;
+    }
+
+    /**
+     * Writes a 64-bit integer in little-endian byte order (least significant byte first).
+     *
+     * @param value the long to write
+     */
+    public void writeLongLE(long value) {
+        if (pos + 8 <= cap) {
+            buf[pos] = (byte) value;
+            buf[pos + 1] = (byte) (value >>> 8);
+            buf[pos + 2] = (byte) (value >>> 16);
+            buf[pos + 3] = (byte) (value >>> 24);
+            buf[pos + 4] = (byte) (value >>> 32);
+            buf[pos + 5] = (byte) (value >>> 40);
+            buf[pos + 6] = (byte) (value >>> 48);
+            buf[pos + 7] = (byte) (value >>> 56);
+            pos += 8;
+            return;
+        }
+        writeLongLEInternal(value);
+    }
+
+    private void writeLongLEInternal(long value) {
+        flushOrGrow(8);
+        buf[pos] = (byte) value;
+        buf[pos + 1] = (byte) (value >>> 8);
+        buf[pos + 2] = (byte) (value >>> 16);
+        buf[pos + 3] = (byte) (value >>> 24);
+        buf[pos + 4] = (byte) (value >>> 32);
+        buf[pos + 5] = (byte) (value >>> 40);
+        buf[pos + 6] = (byte) (value >>> 48);
+        buf[pos + 7] = (byte) (value >>> 56);
+        pos += 8;
+    }
+
+    /**
+     * Writes a 32-bit float in big-endian byte order. Alias for {@link #writeFloatBE(float)}.
+     *
+     * @param value the float to write
+     */
+    public void writeFloat(float value) {
+        writeFloatBE(value);
+    }
+
+    /**
+     * Writes a 32-bit float in big-endian byte order using {@link Float#floatToRawIntBits}.
+     *
+     * @param value the float to write
+     */
+    public void writeFloatBE(float value) {
+        writeIntBE(Float.floatToRawIntBits(value));
+    }
+
+    /**
+     * Writes a 32-bit float in little-endian byte order using {@link Float#floatToRawIntBits}.
+     *
+     * @param value the float to write
+     */
+    public void writeFloatLE(float value) {
+        writeIntLE(Float.floatToRawIntBits(value));
+    }
+
+    /**
+     * Writes a 64-bit double in big-endian byte order. Alias for {@link #writeDoubleBE(double)}.
+     *
+     * @param value the double to write
+     */
+    public void writeDouble(double value) {
+        writeDoubleBE(value);
+    }
+
+    /**
+     * Writes a 64-bit double in big-endian byte order using {@link Double#doubleToRawLongBits}.
+     *
+     * @param value the double to write
+     */
+    public void writeDoubleBE(double value) {
+        writeLongBE(Double.doubleToRawLongBits(value));
+    }
+
+    /**
+     * Writes a 64-bit double in little-endian byte order using {@link Double#doubleToRawLongBits}.
+     *
+     * @param value the double to write
+     */
+    public void writeDoubleLE(double value) {
+        writeLongLE(Double.doubleToRawLongBits(value));
+    }
+
+    /**
+     * Writes a 64-bit integer in big-endian byte order. Alias for {@link #writeLongBE(long)}.
+     *
+     * @param value the long to write
+     */
+    public void writeLong(long value) {
+        writeLongBE(value);
+    }
+
+    /**
+     * Writes a 64-bit integer in big-endian byte order (most significant byte first).
+     *
+     * @param value the long to write
+     */
+    public void writeLongBE(long value) {
+        if (pos + 8 <= cap) {
+            buf[pos] = (byte) (value >>> 56);
+            buf[pos + 1] = (byte) (value >>> 48);
+            buf[pos + 2] = (byte) (value >>> 40);
+            buf[pos + 3] = (byte) (value >>> 32);
+            buf[pos + 4] = (byte) (value >>> 24);
+            buf[pos + 5] = (byte) (value >>> 16);
+            buf[pos + 6] = (byte) (value >>> 8);
+            buf[pos + 7] = (byte) value;
+            pos += 8;
+            return;
+        }
+        writeLongBEInternal(value);
+    }
+
+    private void writeLongBEInternal(long value) {
+        flushOrGrow(8);
+        buf[pos] = (byte) (value >>> 56);
+        buf[pos + 1] = (byte) (value >>> 48);
+        buf[pos + 2] = (byte) (value >>> 40);
+        buf[pos + 3] = (byte) (value >>> 32);
+        buf[pos + 4] = (byte) (value >>> 24);
+        buf[pos + 5] = (byte) (value >>> 16);
+        buf[pos + 6] = (byte) (value >>> 8);
+        buf[pos + 7] = (byte) value;
+        pos += 8;
+    }
+
+    /**
+     * Writes an {@code int} as a zigzag-encoded varint. Negative values are sign-extended to
+     * 64 bits before encoding, producing the 10-byte wire format required by the protobuf spec.
+     *
+     * @param value the signed int to encode
+     */
+    public void writeVarIntZZ(int value) {
+        writeVarLongZZ(value);
+    }
+
+    /**
+     * Writes a {@code long} as a zigzag-encoded varint. The value is mapped via
+     * {@code (value << 1) ^ (value >> 63)} before varint encoding so that small negative
+     * numbers require few bytes.
+     *
+     * @param value the signed long to encode
+     */
+    public void writeVarLongZZ(long value) {
+        writeVarLongNoZZ((value << 1) ^ (value >> 63));
+    }
+
+    /**
+     * Writes an {@code int} as a base-128 varint with optional zigzag encoding.
+     *
+     * @param value  the value to encode
+     * @param zigZag if {@code true}, applies zigzag encoding before varint encoding
+     */
+    public void writeVarInt(int value, boolean zigZag) {
+        long v = zigZag ? ((long) value << 1) ^ ((long) value >> 63) : value;
+        writeVarLongNoZZ(v);
+    }
+
+    /**
+     * Writes a {@code long} as a base-128 varint with optional zigzag encoding.
+     *
+     * @param value  the value to encode
+     * @param zigZag if {@code true}, applies zigzag encoding before varint encoding
+     */
+    public void writeVarLong(long value, boolean zigZag) {
+        long v = zigZag ? (value << 1) ^ (value >> 63) : value;
+        writeVarLongNoZZ(v);
+    }
+
+    private void writeVarLongInternal(long v) {
+        flushOrGrow(10);
+        while ((v & ~0x7FL) != 0) {
+            buf[pos++] = (byte) (((int) v & 0x7F) | 0x80);
+            v >>>= 7;
+        }
+        buf[pos++] = (byte) v;
+    }
+
+    /**
+     * Writes an {@code int} as a base-128 varint without zigzag encoding.
+     * The value is zero-extended to 64 bits before encoding.
+     *
+     * @param value the value to encode
+     */
+    public void writeVarIntNoZZ(int value) {
+        writeVarLongNoZZ(value);
+    }
+
+    /**
+     * Writes a {@code long} as a base-128 varint without zigzag encoding.
+     * Each 7-bit group is written as a byte with the high bit set if more bytes follow.
+     *
+     * @param v the value to encode
+     */
+    public void writeVarLongNoZZ(long v) {
+        if (pos + 10 <= cap) {
+            while ((v & ~0x7FL) != 0) {
+                buf[pos++] = (byte) (((int) v & 0x7F) | 0x80);
+                v >>>= 7;
+            }
+            buf[pos++] = (byte) v;
+            return;
+        }
+        writeVarLongInternal(v);
+    }
+
+    /**
+     * Flushes all buffered bytes to the underlying output stream and resets the internal buffer.
+     *
+     * <p>After the flush the internal write position is reset to zero, and the absolute byte
+     * offset is advanced by the number of bytes written. This is a no-op when no output stream
+     * is attached (standalone writers). Any pending error is surfaced before writing.
+     *
+     * @throws RuntimeException     if a prior error was recorded on this writer
+     * @throws UncheckedIOException if the underlying stream throws an {@link java.io.IOException}
+     */
+    public void flush() {
+        throwOnError();
+        if (output == null) return;
+        try {
+            output.write(buf, 0, pos);
+            output.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        offset += pos;
+        pos = 0;
+    }
+
+    /**
+     * Flushes any remaining bytes to the underlying output stream and closes it.
+     * If no output stream is attached this method does nothing.
+     */
+    @Override
+    public void close() {
+        if (output == null) return;
+        flush();
+        try {
+            output.close();
+        } catch (IOException ex) {
+            setError(IO_ERROR, ex.getMessage());
+        }
+        if (err == 0) {
+            err = CLOSED;
+        }
+    }
+
+    private void flushOrGrow(int minLength) {
+        if (output != null) {
+            if (minLength > cap) {
+                setError(IO_ERROR, "minLength is greater than capacity");
+                return;
+            }
+            try {
+                output.write(buf, 0, pos);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            offset += pos;
+            pos = 0;
+        } else if (reuseable && mayGrow) {
+            int power2Capacity = (int) 2L << (63 - Long.numberOfLeadingZeros(Math.max(buf.length, pos + minLength)));
+            byte[] newBuf = new byte[power2Capacity];
+            System.arraycopy(buf, 0, newBuf, 0, pos);
+            buf = newBuf;
+            cap = buf.length;
+        }
+        // A possible else case is using a byte array and trying to reserve (or grow) past the length of it
+        // reserving shouldn't cause a throw so this else is ignored
+    }
+
+    /**
+     * Flushes any buffered output and resets this writer's position, offset, and error state,
+     * leaving it ready for reuse while keeping the same output destination.
+     */
+    public void reset() {
+        flush();
+        pos = 0;
+        offset = 0;
+        err = 0;
+        cause = null;
+    }
+
+    /**
+     * Resets this writer and detaches it from any output stream, allowing subsequent use as
+     * a standalone in-memory writer.
+     */
+    public void resetWithNull() {
+        resetWith((OutputStream) null);
+    }
+
+    /**
+     * Resets this writer and redirects output to a new {@link OutputStream}.
+     * Only valid on writers that were originally created with an output stream.
+     * Sets the error code to {@link #USAGE_ERROR} if called on a non-reuseable writer.
+     *
+     * @param out the new output stream
+     */
+    public void resetWith(OutputStream out) {
+        reset();
+        if (!reuseable) {
+            setError(USAGE_ERROR, "resetWith on non-reuseable PbjWriter");
+            return;
+        }
+        output = out;
+    }
+
+    /**
+     * Resets this writer and redirects output to a new {@link WritableSequentialData}.
+     * Only valid on writers that were originally created with an output stream.
+     *
+     * @param out the new writable sequential data target
+     */
+    public void resetWith(@NonNull WritableSequentialData out) {
+        resetWith(new OutputStream() {
+            @Override
+            public void write(int b) {
+                out.writeByte((byte) b);
+            }
+
+            @Override
+            public void write(@NonNull byte[] b, int off, int len) {
+                out.writeBytes(b, off, len);
+            }
+        });
+    }
+
+    /**
+     * Returns the raw internal byte array. The valid data occupies indices {@code [0, position())}.
+     * Intended for low-level inspection; prefer {@link #toByteArray()} for a correctly sized copy
+     *
+     * @return the internal buffer array
+     */
+    public byte[] internalArray() {
+        return buf;
+    }
+
+    /**
+     * Returns a zero-copy {@link Bytes} view wrapping the internal buffer from index 0 up to
+     * the current position. The backing array is shared, so the returned {@code Bytes} must
+     * not be retained beyond the next write operation.
+     *
+     * @return a {@code Bytes} view of the current contents
+     */
+    public Bytes internalArrayWrapped() {
+        return Bytes.wrap(buf, 0, pos);
+    }
+
+    /**
+     * Returns a {@link Bytes} wrapping a fresh copy of the written bytes.
+     * Only valid on standalone (non-streaming) writers; sets {@link #USAGE_ERROR} and returns
+     * {@link Bytes#EMPTY} if called on a streaming writer.
+     *
+     * @return the written bytes wrapped in a {@code Bytes} instance
+     */
+    public Bytes toByteArrayWrapped() {
+        if (output != null) {
+            setError(USAGE_ERROR, "toByteArrayWrapped used on a streaming object");
+            return Bytes.EMPTY;
+        }
+        return Bytes.wrap(toByteArray());
+    }
+
+    /**
+     * Returns a newly allocated byte array containing exactly the bytes written so far.
+     * Only valid on standalone (non-streaming) writers; sets {@link #USAGE_ERROR} and returns
+     * {@code null} if called on a streaming writer.
+     *
+     * @return a copy of the written bytes, or {@code null} on error
+     */
+    public byte[] toByteArray() {
+        if (output != null) {
+            setError(USAGE_ERROR, "toByteArray used on a streaming object");
+            return null;
+        }
+        byte[] bytes = new byte[pos];
+        System.arraycopy(buf, 0, bytes, 0, pos);
+        return bytes;
+    }
+
+    /**
+     * Creates a {@link PbjReader} backed by the current internal buffer contents.
+     * Useful for reading back data written to a standalone writer without copying.
+     * Only valid on standalone (non-streaming) writers; sets {@link #USAGE_ERROR} and returns
+     * {@code null} if called on a streaming writer.
+     *
+     * @return a new {@code PbjReader} positioned at the start of the written bytes, or {@code null} on error
+     */
+    public PbjReader toPbjReader() {
+        if (output != null) {
+            setError(USAGE_ERROR, "toPbjReader on a streaming object");
+            return null;
+        }
+        return new PbjReader(buf, 0, pos);
+    }
+
+    /**
+     * Records an error on this writer if no previous error is set. Once an error is recorded
+     * subsequent writes become no-ops.
+     *
+     * @param errorKind one of the error-code constants ({@link #IO_ERROR}, {@link #USAGE_ERROR}, etc.)
+     * @param message   a message returned with an exception
+     */
+    public void setError(int errorKind, String message) {
+        if (err > 0) return;
+        err = errorKind;
+        if (useStacktrace) {
+            cause = new RuntimeException(message);
+        } else {
+            cause = premadeRuntimeException;
+        }
+    }
+
+    /**
+     * Returns the current error code, or {@code 0} if no error has occurred.
+     *
+     * @return a positive error-code constant, or {@code 0} for no error
+     */
+    public int error() {
+        return err > 0 ? err : 0;
+    }
+
+    /**
+     * Throws the recorded error as a {@link RuntimeException} if an error is set.
+     *
+     * @throws RuntimeException if {@link #error()} is non-zero
+     */
+    public void throwOnError() {
+        if (err > 0) {
+            throw cause;
+        }
+    }
+
+    /**
+     * Returns the exception that was recorded when the current error was set, or {@code null}
+     * if no error has occurred.
+     *
+     * @return the recorded exception, or {@code null}
+     */
+    public RuntimeException getCause() {
+        return cause;
+    }
+
+    /**
+     * Writes a UTF-8 encoded string without a preceding length varint.
+     * Surrogate pairs are encoded as a 4-byte UTF-8 sequence. An unpaired surrogate sets
+     * the error code to {@link #MALFORM_STRING}.
+     *
+     * @param str the string to encode
+     */
+    public void writeStringNoTag(String str) {
+        int inLength = str.length();
+        for (int i = 0; i < inLength; ++i) {
+            char c = str.charAt(i);
+            if (c < 0x80) {
+                writeByte((byte) c);
+            } else if (c < 0x800) {
+                writeByte2((byte) (0xC0 | (c >>> 6)), (byte) (0x80 | (0x3F & c)));
+            } else if (c < MIN_SURROGATE || MAX_SURROGATE < c) {
+                writeByte3((byte) (0xE0 | (c >>> 12)), (byte) (0x80 | (0x3F & (c >>> 6))), (byte) (0x80 | (0x3F & c)));
+            } else {
+                char low;
+                if (i + 1 == inLength || !isSurrogatePair(c, (low = str.charAt(++i)))) {
+                    setError(MALFORM_STRING, "Unpaired surrogate at index " + i + " of " + inLength);
+                    return;
+                }
+                int codePoint = toCodePoint(c, low);
+                writeByte4(
+                        (byte) ((0xF << 4) | (codePoint >>> 18)),
+                        (byte) (0x80 | (0x3F & (codePoint >>> 12))),
+                        (byte) (0x80 | (0x3F & (codePoint >>> 6))),
+                        (byte) (0x80 | (0x3F & codePoint)));
+            }
+        }
+    }
+
+    /**
+     * Writes a UTF-8 encoded string preceded by its length as a base-128 varint, as required
+     * by the protobuf wire format for {@code TYPE_STRING} fields.
+     *
+     * @param str the string to encode
+     */
+    public void writeStringWithTag(String str) {
+        int inLength = str.length();
+        if (inLength > 0x7F) {
+            writeUTF8_2byte(str);
+            return;
+        }
+        // fast path 1 byte tag case
+        reserveRel(0x7F * 4 + 2); // worse case size
+        int pos = position();
+        placehold(1);
+        writeStringNoTag(str);
+        int endPos = position();
+        int utf8Len = endPos - pos - 1;
+        if (utf8Len <= 0x7F) {
+            writeAtUnsafe(pos, (byte) utf8Len);
+        } else {
+            reinsertVarInt(pos);
+        }
+    }
+
+    private void writeUTF8_2byte(String str) {
+        // buffer is 16k, string is UTF16, so worst case is len*3.
+        // 5460 was picked bc its (16k - 2byte tag) / 3 byte worse case
+        if (str.length() > 5460) {
+            // Can't fit in buffer, todo check if we'll grow anyways
+            // I don't think anything hits this case?
+            // These two lines counts the length then write the length, making this 2 pass
+            writeVarIntNoZZ(ProtoWriterTools.sizeOfStringNoTag(str));
+            writeStringNoTag(str);
+            return;
+        }
+        reserveRel(str.length() * 3 + 2);
+        int pos = position();
+        placehold(2);
+        writeStringNoTag(str);
+        int utf8Len = position() - pos - 2;
+        writeAtUnsafe(pos, (byte) ((utf8Len & 0x7F) | 0x80));
+        writeAtUnsafe(pos + 1, (byte) (utf8Len >>> 7));
+    }
+
+    /**
+     * Advances the write position by {@code count} bytes without writing any data.
+     *
+     * @param count the number of bytes to skip
+     */
+    public void skip(int count) {
+        pos += count;
+    }
+}

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjWriter.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjWriter.java
@@ -29,14 +29,17 @@ import java.nio.ByteBuffer;
  * <p>Implements {@link AutoCloseable}: closing flushes pending bytes to the underlying stream.
  */
 public class PbjWriter implements AutoCloseable {
-    private byte[] buf;
+    private byte[] buf, ownedBuf;
     private int pos, cap;
     private int offset, err;
     private RuntimeException cause;
     private OutputStream output;
-    private boolean reuseable;
     private boolean mayGrow = true;
 
+    /*
+     * If a project doesn't care about stacktraces, setting pbj.ReaderWriter.useStackTrace to false
+     * will throw a premade exception that doesn't have the correct stacktrace. It's fast and good against DOS attacks
+     */
     private static final boolean useStacktrace =
             !"false".equalsIgnoreCase(System.getProperty("pbj.ReaderWriter.useStackTrace"));
     public static final int EOF = PbjReader.EOF,
@@ -56,6 +59,10 @@ public class PbjWriter implements AutoCloseable {
 
     private static final RuntimeException premadeRuntimeException;
 
+    /*
+     * Some projects may not want exceptions, but their test expects them.
+     * Here are premade exceptions that are created once and thrown potentially many times
+     */
     static {
         premadeRuntimeException = new RuntimeException("Stacktrace not enabled in PbjWriter");
     }
@@ -68,16 +75,16 @@ public class PbjWriter implements AutoCloseable {
      */
     public PbjWriter(@NonNull OutputStream output) {
         this.output = output;
-        buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        ownedBuf = buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
         cap = buf.length;
-        reuseable = true;
     }
 
     /**
      * Creates a writer backed by a {@link ByteBuffer}.
      *
-     * <p>If the buffer has a backing array it is used directly. Otherwise an internal 16 KB
-     * streaming buffer is used and bytes are forwarded to the {@link ByteBuffer} on flush.
+     * <p>If the buffer has a backing array it is used directly and this will not grow beyond
+     * it. Otherwise an internal 16 KB streaming buffer is used and bytes are forwarded to the
+     * {@link ByteBuffer} on flush.
      *
      * @param buffer the target byte buffer
      */
@@ -86,6 +93,7 @@ public class PbjWriter implements AutoCloseable {
             buf = buffer.array();
             pos = buffer.arrayOffset() + buffer.position();
             cap = buffer.arrayOffset() + buffer.limit();
+            mayGrow = false;
         } else {
             this.output = new OutputStream() {
                 @Override
@@ -98,9 +106,8 @@ public class PbjWriter implements AutoCloseable {
                     buffer.put(b, off, len);
                 }
             };
-            buf = new byte[16 << 10];
+            ownedBuf = buf = new byte[16 << 10];
             cap = buf.length;
-            reuseable = true;
         }
     }
 
@@ -115,6 +122,7 @@ public class PbjWriter implements AutoCloseable {
         this.buf = buffer;
         this.pos = pos;
         this.cap = buffer.length;
+        mayGrow = false;
     }
 
     /**
@@ -142,9 +150,8 @@ public class PbjWriter implements AutoCloseable {
      * No backing output stream is attached; use {@link #toByteArray()} to retrieve the written bytes.
      */
     public PbjWriter() {
-        buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+        ownedBuf = buf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
         cap = buf.length;
-        reuseable = true;
     }
 
     /**
@@ -156,12 +163,12 @@ public class PbjWriter implements AutoCloseable {
      *                    {@code false} to keep the buffer fixed at {@code reserveSize} bytes
      */
     public PbjWriter(int reserveSize, boolean mayGrow) {
-        if (mayGrow) buf = new byte[Math.max(reserveSize, 16 << 10)]; // 16k is friendly to x86-64 L1 cache
+        if (mayGrow) ownedBuf = new byte[Math.max(reserveSize, 16 << 10)]; // 16k is friendly to x86-64 L1 cache
         else {
-            buf = new byte[reserveSize];
+            ownedBuf = new byte[reserveSize];
         }
+        buf = ownedBuf;
         cap = buf.length;
-        reuseable = true;
         this.mayGrow = mayGrow;
     }
 
@@ -242,10 +249,11 @@ public class PbjWriter implements AutoCloseable {
             buf[pos++] = b;
             return;
         }
-        writeByteInternal(b);
+        // seperated so the above is likely to inline
+        writeByte_cold(b);
     }
 
-    private void writeByteInternal(byte b) {
+    private void writeByte_cold(byte b) {
         flushOrGrow(1);
         buf[pos++] = b;
     }
@@ -263,10 +271,10 @@ public class PbjWriter implements AutoCloseable {
             pos += 2;
             return;
         }
-        writeByte2Internal(b1, b2);
+        writeByte2_cold(b1, b2);
     }
 
-    private void writeByte2Internal(byte b1, byte b2) {
+    private void writeByte2_cold(byte b1, byte b2) {
         flushOrGrow(2);
         buf[pos] = b1;
         buf[pos + 1] = b2;
@@ -288,10 +296,10 @@ public class PbjWriter implements AutoCloseable {
             pos += 3;
             return;
         }
-        writeByte3Internal(b1, b2, b3);
+        writeByte3_cold(b1, b2, b3);
     }
 
-    private void writeByte3Internal(byte b1, byte b2, byte b3) {
+    private void writeByte3_cold(byte b1, byte b2, byte b3) {
         flushOrGrow(3);
         buf[pos] = b1;
         buf[pos + 1] = b2;
@@ -316,10 +324,10 @@ public class PbjWriter implements AutoCloseable {
             pos += 4;
             return;
         }
-        writeByte4Internal(b1, b2, b3, b4);
+        writeByte4_cold(b1, b2, b3, b4);
     }
 
-    private void writeByte4Internal(byte b1, byte b2, byte b3, byte b4) {
+    private void writeByte4_cold(byte b1, byte b2, byte b3, byte b4) {
         flushOrGrow(4);
         buf[pos] = b1;
         buf[pos + 1] = b2;
@@ -343,10 +351,10 @@ public class PbjWriter implements AutoCloseable {
             pos += len;
             return;
         }
-        writeBytesBDInternal(src, len, srcPos);
+        writeBytesBD_cold(src, len, srcPos);
     }
 
-    private void writeBytesBDInternal(BufferedData src, int len, long srcPos) {
+    private void writeBytesBD_cold(BufferedData src, int len, long srcPos) {
         if (output == null) {
             flushOrGrow(len); // to grow at least to pos + len
             src.getBytes(srcPos, buf, pos, len);
@@ -397,10 +405,11 @@ public class PbjWriter implements AutoCloseable {
             pos += length;
             return;
         }
-        writeBytesInternal(src, offset, length);
+        writeBytes_cold(src, offset, length);
     }
 
-    private void writeBytesInternal(byte[] src, int srcOffset, int length) {
+    private void writeBytes_cold(byte[] src, int srcOffset, int length) {
+        // the 2048 was picked out of the air, it's 1/8th of the buffer size
         if (output != null && length >= 2048) {
             if (pos > 0) {
                 try {
@@ -437,10 +446,10 @@ public class PbjWriter implements AutoCloseable {
             pos += len;
             return;
         }
-        writeBytesRAInternal(src, len);
+        writeBytesRA_cold(src, len);
     }
 
-    private void writeBytesRAInternal(RandomAccessData src, int len) {
+    private void writeBytesRA_cold(RandomAccessData src, int len) {
         if (output == null) {
             flushOrGrow(len);
             src.getBytes(0, buf, pos, len);
@@ -491,10 +500,12 @@ public class PbjWriter implements AutoCloseable {
             pos += 4;
             return;
         }
-        writeIntBEInternal(value);
+        // Don't inline the below. The above is very likely to inline
+        // while the below is not (and calls large methods like flushOrGrow())
+        writeIntBE_cold(value);
     }
 
-    private void writeIntBEInternal(int value) {
+    private void writeIntBE_cold(int value) {
         flushOrGrow(4);
         buf[pos] = (byte) (value >>> 24);
         buf[pos + 1] = (byte) (value >>> 16);
@@ -517,10 +528,12 @@ public class PbjWriter implements AutoCloseable {
             pos += 4;
             return;
         }
-        writeIntLEInternal(value);
+        // Don't inline the below. The above is very likely to inline
+        // while the below is not (and calls large methods like flushOrGrow())
+        writeIntLE_cold(value);
     }
 
-    private void writeIntLEInternal(int value) {
+    private void writeIntLE_cold(int value) {
         flushOrGrow(4);
         buf[pos] = (byte) value;
         buf[pos + 1] = (byte) (value >>> 8);
@@ -547,10 +560,12 @@ public class PbjWriter implements AutoCloseable {
             pos += 8;
             return;
         }
-        writeLongLEInternal(value);
+        // Don't inline the below. The above is very likely to inline
+        // while the below is not (and calls large methods like flushOrGrow())
+        writeLongLE_cold(value);
     }
 
-    private void writeLongLEInternal(long value) {
+    private void writeLongLE_cold(long value) {
         flushOrGrow(8);
         buf[pos] = (byte) value;
         buf[pos + 1] = (byte) (value >>> 8);
@@ -644,10 +659,12 @@ public class PbjWriter implements AutoCloseable {
             pos += 8;
             return;
         }
-        writeLongBEInternal(value);
+        // Don't inline the below. The above is very likely to inline
+        // while the below is not (and calls large methods like flushOrGrow())
+        writeLongBE_cold(value);
     }
 
-    private void writeLongBEInternal(long value) {
+    private void writeLongBE_cold(long value) {
         flushOrGrow(8);
         buf[pos] = (byte) (value >>> 56);
         buf[pos + 1] = (byte) (value >>> 48);
@@ -703,7 +720,7 @@ public class PbjWriter implements AutoCloseable {
         writeVarLongNoZZ(v);
     }
 
-    private void writeVarLongInternal(long v) {
+    private void writeVarLong_cold(long v) {
         flushOrGrow(10);
         while ((v & ~0x7FL) != 0) {
             buf[pos++] = (byte) (((int) v & 0x7F) | 0x80);
@@ -737,7 +754,7 @@ public class PbjWriter implements AutoCloseable {
             buf[pos++] = (byte) v;
             return;
         }
-        writeVarLongInternal(v);
+        writeVarLong_cold(v);
     }
 
     /**
@@ -781,6 +798,11 @@ public class PbjWriter implements AutoCloseable {
         }
     }
 
+    /*
+     * called from every *_cold path when the buffer doesn't have enough room for minLength bytes.
+     * If streaming, flushes buf to the output stream; otherwise grows buf to the next power of two
+     * that fits minLength, but only if mayGrow is true
+     */
     private void flushOrGrow(int minLength) {
         if (output != null) {
             if (minLength > cap) {
@@ -794,11 +816,11 @@ public class PbjWriter implements AutoCloseable {
             }
             offset += pos;
             pos = 0;
-        } else if (reuseable && mayGrow) {
+        } else if (mayGrow) {
             int power2Capacity = (int) 2L << (63 - Long.numberOfLeadingZeros(Math.max(buf.length, pos + minLength)));
             byte[] newBuf = new byte[power2Capacity];
             System.arraycopy(buf, 0, newBuf, 0, pos);
-            buf = newBuf;
+            ownedBuf = buf = newBuf;
             cap = buf.length;
         }
         // A possible else case is using a byte array and trying to reserve (or grow) past the length of it
@@ -827,17 +849,21 @@ public class PbjWriter implements AutoCloseable {
 
     /**
      * Resets this writer and redirects output to a new {@link OutputStream}.
-     * Only valid on writers that were originally created with an output stream.
-     * Sets the error code to {@link #USAGE_ERROR} if called on a non-reuseable writer.
+     *
+     * <p>If this writer was backed by a caller-supplied array or {@link ByteBuffer}, that memory
+     * is abandoned in favor of a freshly (or previously) owned internal buffer, which becomes
+     * growable going forward.
      *
      * @param out the new output stream
      */
     public void resetWith(OutputStream out) {
         reset();
-        if (!reuseable) {
-            setError(USAGE_ERROR, "resetWith on non-reuseable PbjWriter");
-            return;
+        if (ownedBuf == null) {
+            ownedBuf = new byte[16 << 10]; // 16k is friendly to x86-64 L1 cache
+            mayGrow = true;
         }
+        buf = ownedBuf;
+        cap = buf.length;
         output = out;
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
@@ -114,12 +114,12 @@ class CodecParseMethodTest {
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
-                final int maxSize)
-                throws ParseException {
+                final int maxSize) {
             final int length = input.readInt();
             final byte[] payload = new byte[length];
             if (input.readBytes(payload) != length) {
-                throw new ParseException("Failed to read payload bytes");
+                input.setError(PbjReader.PARSE, "Failed to read payload bytes");
+                return null;
             }
             return new LengthPrefixed(payload);
         }

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecParseMethodTest.java
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link Codec#parse(com.hedera.pbj.runtime.io.ReadableSequentialData, boolean, boolean, int, int)},
+ * {@link Codec#measure(com.hedera.pbj.runtime.io.ReadableSequentialData)}, and
+ * {@link Codec#fastEquals(Object, com.hedera.pbj.runtime.io.ReadableSequentialData)}.
+ * <p>
+ * These methods wrap the caller's input in a {@link PbjReader}, which buffers up to 16KB ahead of what has
+ * actually been consumed. The tests here use a buffer with more than 16KB of trailing data after the
+ * encoded message, to confirm that buffering does not leak into the reported message length or the
+ * original input's position.
+ */
+class CodecParseMethodTest {
+
+    private static final LengthPrefixedCodec CODEC = new LengthPrefixedCodec();
+
+    private static BufferedData messageWithTrailingFiller(final byte[] payload, final byte[] filler) {
+        final byte[] backing = new byte[4 + payload.length + filler.length];
+        final BufferedData writable = BufferedData.wrap(backing);
+        writable.writeInt(payload.length);
+        writable.writeBytes(payload);
+        writable.writeBytes(filler);
+        return BufferedData.wrap(backing);
+    }
+
+    private static byte[] filler(final int size) {
+        final byte[] filler = new byte[size];
+        Arrays.fill(filler, (byte) 0x7F);
+        return filler;
+    }
+
+    @Test
+    void measureIsNotInflatedByTrailingData() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000); // larger than PbjReader's 16KB internal buffer
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        final int measured = CODEC.measure(data);
+
+        assertEquals(4 + payload.length, measured);
+    }
+
+    @Test
+    void measureLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        CODEC.measure(data);
+
+        assertEquals(4 + payload.length, data.position());
+        final byte[] remaining = new byte[filler.length];
+        data.readBytes(remaining);
+        assertArrayEquals(filler, remaining);
+    }
+
+    @Test
+    void parseLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        final LengthPrefixed parsed = CODEC.parse(data);
+
+        assertArrayEquals(payload, parsed.payload());
+        assertEquals(4 + payload.length, data.position());
+        final byte[] remaining = new byte[filler.length];
+        data.readBytes(remaining);
+        assertArrayEquals(filler, remaining);
+    }
+
+    @Test
+    void fastEqualsLeavesInputPositionedAtEndOfMessage() throws ParseException {
+        final byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        final byte[] filler = filler(20_000);
+        final BufferedData data = messageWithTrailingFiller(payload, filler);
+
+        assertTrue(CODEC.fastEquals(new LengthPrefixed(payload), data));
+
+        assertEquals(4 + payload.length, data.position());
+    }
+
+    private record LengthPrefixed(byte[] payload) {
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof LengthPrefixed other && Arrays.equals(payload, other.payload);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(payload);
+        }
+    }
+
+    private static final class LengthPrefixedCodec extends Codec<LengthPrefixed> {
+
+        @NonNull
+        @Override
+        protected LengthPrefixed parseImpl(
+                @NonNull final PbjReader input,
+                final boolean strictMode,
+                final boolean parseUnknownFields,
+                final int maxDepth,
+                final int maxSize)
+                throws ParseException {
+            final int length = input.readInt();
+            final byte[] payload = new byte[length];
+            if (input.readBytes(payload) != length) {
+                throw new ParseException("Failed to read payload bytes");
+            }
+            return new LengthPrefixed(payload);
+        }
+
+        @Override
+        protected void writeImpl(@NonNull final LengthPrefixed item, @NonNull final PbjWriter output) {
+            output.writeInt(item.payload().length);
+            output.writeBytes(item.payload());
+        }
+
+        @Override
+        public int measure(@NonNull final PbjReader input) throws ParseException {
+            final long start = input.position();
+            parse(input);
+            return (int) (input.position() - start);
+        }
+
+        @Override
+        public int measureRecord(final LengthPrefixed item) {
+            return 4 + item.payload().length;
+        }
+
+        @Override
+        public boolean fastEquals(@NonNull final LengthPrefixed item, @NonNull final PbjReader input)
+                throws ParseException {
+            return item.equals(parse(input));
+        }
+
+        @Override
+        public LengthPrefixed getDefaultInstance() {
+            return new LengthPrefixed(new byte[0]);
+        }
+    }
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
@@ -24,8 +24,7 @@ class CodecWrapper<T> extends Codec<T> {
     @NonNull
     @Override
     protected T parseImpl(
-            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
-            throws ParseException {
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
         throw new UnsupportedOperationException();
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/CodecWrapper.java
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.pbj.runtime;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.util.function.ToIntFunction;
 
 /**
@@ -25,22 +24,18 @@ class CodecWrapper<T> extends Codec<T> {
     @NonNull
     @Override
     protected T parseImpl(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void writeImpl(@NonNull T item, @NonNull WritableSequentialData output) throws IOException {
+    protected void writeImpl(@NonNull T item, @NonNull PbjWriter output) {
         writer.write(item, output);
     }
 
     @Override
-    public int measure(@NonNull ReadableSequentialData input) throws ParseException {
+    public int measure(@NonNull PbjReader input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 
@@ -50,7 +45,7 @@ class CodecWrapper<T> extends Codec<T> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull T item, @NonNull ReadableSequentialData input) throws ParseException {
+    public boolean fastEquals(@NonNull T item, @NonNull PbjReader input) throws ParseException {
         throw new UnsupportedOperationException();
     }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.buffer.PbjReader;
+import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
@@ -359,7 +359,9 @@ class ProtoParserToolsTest {
     @Test
     void testExtractBytesNullInput() {
         final FieldDefinition field = createFieldDefinition(BYTES);
-        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes((PbjReader) null, field));
+        assertThrows(
+                NullPointerException.class,
+                () -> ProtoParserTools.extractFieldBytes((ReadableSequentialData) null, field));
     }
 
     @Test
@@ -543,7 +545,7 @@ class ProtoParserToolsTest {
         @NonNull
         @Override
         protected final TestMessage parseImpl(
-                @NonNull final ReadableSequentialData in,
+                @NonNull final PbjReader in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
@@ -570,8 +572,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        protected final void writeImpl(@NonNull final TestMessage item, @NonNull final WritableSequentialData out)
-                throws IOException {
+        protected final void writeImpl(@NonNull final TestMessage item, @NonNull final PbjWriter out) {
             final String value = item.getValue();
             if (value != null) {
                 ProtoWriterTools.writeString(out, VALUE_FIELD, value);
@@ -579,7 +580,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public int measure(@NonNull ReadableSequentialData input) throws ParseException {
+        public int measure(@NonNull PbjReader input) throws ParseException {
             throw new UnsupportedOperationException();
         }
 
@@ -593,8 +594,7 @@ class ProtoParserToolsTest {
         }
 
         @Override
-        public boolean fastEquals(@NonNull TestMessage item, @NonNull ReadableSequentialData input)
-                throws ParseException {
+        public boolean fastEquals(@NonNull TestMessage item, @NonNull PbjReader input) throws ParseException {
             throw new UnsupportedOperationException();
         }
 

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -549,8 +549,7 @@ class ProtoParserToolsTest {
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
-                final int maxSize)
-                throws ParseException {
+                final int maxSize) {
             String value = null;
             while (in.hasRemaining()) {
                 final int tag = in.readVarInt(false);
@@ -561,11 +560,13 @@ class ProtoParserToolsTest {
                     final int length = in.readVarInt(false);
                     final byte[] valueBytes = new byte[length];
                     if (in.readBytes(valueBytes) != length) {
-                        throw new ParseException("Failed to read value bytes");
+                        in.setError(PbjReader.PARSE, "Failed to read value bytes");
+                        return null;
                     }
                     value = new String(valueBytes, StandardCharsets.UTF_8);
                 } else {
-                    throw new ParseException("Unknown field: " + tag);
+                    in.setError(PbjReader.PARSE, "Unknown field: " + tag);
+                    return null;
                 }
             }
             return new TestMessage(value);

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -33,6 +33,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
@@ -358,7 +359,7 @@ class ProtoParserToolsTest {
     @Test
     void testExtractBytesNullInput() {
         final FieldDefinition field = createFieldDefinition(BYTES);
-        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes(null, field));
+        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes((PbjReader) null, field));
     }
 
     @Test

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/ProtoParserToolsTest.java
@@ -29,17 +29,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.buffer.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.PbjWriter;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hedera.pbj.runtime.test.UncheckedThrowingFunction;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteOrder;
@@ -359,20 +356,18 @@ class ProtoParserToolsTest {
     @Test
     void testExtractBytesNullInput() {
         final FieldDefinition field = createFieldDefinition(BYTES);
-        assertThrows(
-                NullPointerException.class,
-                () -> ProtoParserTools.extractFieldBytes((ReadableSequentialData) null, field));
+        assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes((PbjReader) null, field));
     }
 
     @Test
     void testExtractBytesNullField() {
-        final ReadableSequentialData input = Bytes.EMPTY.toReadableSequentialData();
+        final PbjReader input = Bytes.EMPTY.toPbjReader();
         assertThrows(NullPointerException.class, () -> ProtoParserTools.extractFieldBytes(input, null));
     }
 
     @Test
     void testExtractBytesRepeatedField() {
-        final ReadableSequentialData input = Bytes.EMPTY.toReadableSequentialData();
+        final PbjReader input = Bytes.EMPTY.toPbjReader();
         final FieldDefinition field = new FieldDefinition("field", FieldType.BYTES, true, true, false, 1);
         assertThrows(IllegalArgumentException.class, () -> ProtoParserTools.extractFieldBytes(input, field));
     }
@@ -407,22 +402,20 @@ class ProtoParserToolsTest {
     private static final FieldDefinition BOOL_F = new FieldDefinition("boolfield", BOOL, false, true, false, 11);
     private static final boolean BOOL_V = true;
 
-    private static Bytes prepareExtractBytesTestInput() throws IOException {
-        try (final ByteArrayOutputStream bout = new ByteArrayOutputStream();
-                final WritableStreamingData out = new WritableStreamingData(bout)) {
-            ProtoWriterTools.writeInteger(out, INT32_F, INT32_V);
-            ProtoWriterTools.writeInteger(out, FIXED_F, FIXED32_V);
-            ProtoWriterTools.writeString(out, STRING_F, STRING_V);
-            ProtoWriterTools.writeBytes(out, BYTES_F, BYTES_V);
-            ProtoWriterTools.writeMessage(out, MESSAGE_F, MESSAGE_V, TestMessageCodec.INSTANCE);
-            ProtoWriterTools.writeDouble(out, DOUBLE_F, DOUBLE32_V);
-            return Bytes.wrap(bout.toByteArray());
-        }
+    private static PbjReader prepareExtractBytesTestInput() throws IOException {
+        PbjWriter out = new PbjWriter();
+        ProtoWriterTools.writeInteger(out, INT32_F, INT32_V);
+        ProtoWriterTools.writeInteger(out, FIXED_F, FIXED32_V);
+        ProtoWriterTools.writeString(out, STRING_F, STRING_V);
+        ProtoWriterTools.writeBytes(out, BYTES_F, BYTES_V);
+        ProtoWriterTools.writeMessage(out, MESSAGE_F, MESSAGE_V, TestMessageCodec.INSTANCE);
+        ProtoWriterTools.writeDouble(out, DOUBLE_F, DOUBLE32_V);
+        return out.toPbjReader();
     }
 
     @Test
     void testExtractBytesStringField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, STRING_F);
         assertNotNull(bytes);
         assertEquals(STRING_V, new String(bytes.toByteArray(), StandardCharsets.UTF_8));
@@ -430,14 +423,14 @@ class ProtoParserToolsTest {
 
     @Test
     void testExtractFieldBytesInvalidType() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         // should throw because INT32 is not a delimited type
         assertThrows(IllegalArgumentException.class, () -> ProtoParserTools.extractFieldBytes(input, INT32_F));
     }
 
     @Test
     void testExtractBytesBytesField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, BYTES_F);
         assertNotNull(bytes);
         assertEquals(BYTES_V, bytes);
@@ -445,52 +438,58 @@ class ProtoParserToolsTest {
 
     @Test
     void testExtractBytesMessageField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, MESSAGE_F);
         assertNotNull(bytes);
-        final TestMessage value = TestMessageCodec.INSTANCE.parse(bytes.toReadableSequentialData());
+        final TestMessage value = TestMessageCodec.INSTANCE.parse(bytes);
         assertNotNull(value);
         assertEquals(MESSAGE_V, value);
     }
 
     @Test
     void testExtractBytesUnknownField() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final Bytes bytes = ProtoParserTools.extractFieldBytes(input, UNKNOWN_F);
         assertNull(bytes);
     }
 
     @Test
     void testExtractField32Bit() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final var res = ProtoParserTools.extractField(input, WIRE_TYPE_FIXED_32_BIT, 32);
         assertNotNull(res);
     }
 
     @Test
     void testExtractField64Bit() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final var res = ProtoParserTools.extractField(input, WIRE_TYPE_FIXED_64_BIT, 32);
         assertNotNull(res);
     }
 
     @Test
     void testExtractFieldVarInt() throws IOException, ParseException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
+        final PbjReader input = prepareExtractBytesTestInput();
         final var res = ProtoParserTools.extractField(input, WIRE_TYPE_VARINT_OR_ZIGZAG, 32);
         assertNotNull(res);
     }
 
     @Test
     void testExtractFieldGroupStartUnsupported() throws IOException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
-        assertThrows(IOException.class, () -> ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_START, 32));
+        final PbjReader input = prepareExtractBytesTestInput();
+        assertThrows(IOException.class, () -> {
+            ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_START, 32);
+            input.throwOnError2();
+        });
     }
 
     @Test
     void testExtractFieldGroupEndUnsupported() throws IOException {
-        final ReadableSequentialData input = prepareExtractBytesTestInput().toReadableSequentialData();
-        assertThrows(IOException.class, () -> ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_END, 32));
+        final PbjReader input = prepareExtractBytesTestInput();
+        assertThrows(IOException.class, () -> {
+            ProtoParserTools.extractField(input, WIRE_TYPE_GROUP_END, 32);
+            input.throwOnError2();
+        });
     }
 
     private static void skipTag(BufferedData data) {

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
@@ -1,0 +1,1561 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.pbj.runtime.io.buffer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class PbjReaderWriterTest {
+
+    @Test
+    void WriteConstructorBufferSizeConsistent() {
+        final int expectedSize = new PbjWriter().internalArray().length;
+        assertEquals(expectedSize, new PbjWriter((OutputStream) null).internalArray().length);
+        assertEquals(expectedSize, new PbjWriter((WritableSequentialData) null).internalArray().length);
+        assertEquals(expectedSize, new PbjWriter(128, true).internalArray().length);
+        // Does not apply to ByteBuffer, byte[], or reserve when large, or the below
+        assertEquals(128, new PbjWriter(128, false).internalArray().length);
+    }
+
+    @Test
+    void writerConstructorCanReserveLarge() {
+        PbjWriter writer = new PbjWriter(2 << 20, true);
+        assertEquals(2 << 20, writer.internalArray().length);
+    }
+
+    @Test
+    void writeByteBufferConstructorHeap() {
+        ByteBuffer bb = ByteBuffer.allocate(32);
+        PbjWriter writer = new PbjWriter(bb);
+        writer.writeByte3((byte) 11, (byte) 22, (byte) 33);
+        assertEquals(11, bb.array()[bb.arrayOffset()]);
+        assertEquals(22, bb.array()[bb.arrayOffset() + 1]);
+        assertEquals(33, bb.array()[bb.arrayOffset() + 2]);
+        assertEquals(3, writer.position());
+    }
+
+    @Test
+    void writeByteBufferConstructorDirect() {
+        ByteBuffer bb = ByteBuffer.allocateDirect(32);
+        PbjWriter writer = new PbjWriter(bb);
+        writer.writeByte3((byte) 11, (byte) 22, (byte) 33);
+        writer.flush();
+        bb.flip();
+        assertEquals(11, bb.get());
+        assertEquals(22, bb.get());
+        assertEquals(33, bb.get());
+    }
+
+    @Test
+    void writeBytesFromRandomAccessData() {
+        Bytes src = Bytes.wrap(new byte[] {10, 20, 30, 40});
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(src);
+        assertArrayEquals(new byte[] {10, 20, 30, 40}, writer.toByteArray());
+    }
+
+    @Test
+    void writeBytesFromBufferedData() {
+        BufferedData src = BufferedData.wrap(new byte[] {10, 20, 30, 40});
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(src);
+        assertArrayEquals(new byte[] {10, 20, 30, 40}, writer.toByteArray());
+    }
+
+    @Test
+    void closeFlushesDataToOutputStream() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        writer.writeByte2((byte) 55, (byte) 66);
+        assertArrayEquals(new byte[] {}, baos.toByteArray());
+        writer.close();
+        assertArrayEquals(new byte[] {55, 66}, baos.toByteArray());
+    }
+
+    @Test
+    void closeIsNoopWithoutOutputStream() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeByte((byte) 1);
+        writer.close();
+        assertEquals(1, writer.position());
+    }
+
+    @Test
+    void toByteArrayWrappedErrorsOnStreamingWriter() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        assertEquals(Bytes.EMPTY, writer.internalArrayWrapped());
+        assertEquals(Bytes.EMPTY, writer.toByteArrayWrapped());
+        assertEquals(PbjWriter.USAGE_ERROR, writer.error());
+        assertThrows(RuntimeException.class, () -> writer.throwOnError());
+    }
+
+    @Test
+    void toByteArrayErrorsOnStreamingWriter() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        assertEquals(null, writer.toByteArray());
+        assertEquals(PbjWriter.USAGE_ERROR, writer.error());
+        assertThrows(RuntimeException.class, () -> writer.throwOnError());
+    }
+
+    @Test
+    void writerRelativeReserve() {
+        PbjWriter writer = new PbjWriter();
+        byte[] origArray = writer.internalArray();
+        writer.reserveRel(origArray.length);
+        byte[] arr2 = writer.internalArray();
+        assertEquals(origArray, arr2); // same object
+
+        writer.reserveRel(origArray.length + 1);
+        byte[] arr3 = writer.internalArray();
+        assertNotEquals(origArray, arr3); // diff object
+
+        writer.skip(arr3.length - 1);
+        writer.reserveRel(1);
+        byte[] arr4 = writer.internalArray();
+        assertEquals(arr3, arr4);
+
+        writer.skip(1);
+        writer.reserveRel(0);
+        byte[] arr5 = writer.internalArray();
+        assertEquals(arr4, arr5);
+
+        writer.reserveRel(1);
+        byte[] arr6 = writer.internalArray();
+        assertNotEquals(arr4, arr6);
+    }
+
+    @Test
+    void writerUsesByteArray() {
+        byte[] bytes = new byte[128];
+        PbjWriter writer = new PbjWriter(bytes, 0);
+        writer.writeByte3((byte) 10, (byte) 20, (byte) 30);
+        assertEquals(bytes[0], 10);
+        assertEquals(bytes[1], 20);
+        assertEquals(bytes[2], 30);
+    }
+
+    @Test
+    void manyStringRoundtrip() {
+        byte[] bytes = new byte[128];
+        PbjWriter writer = new PbjWriter(bytes, 0);
+        String strings[] = {
+            "a",
+            "\u0100",
+            "\u2603",
+            "\uD800\uDC00",
+            "\uE000",
+            "a\u0100\u2603\uE000\uD800\uDC00",
+            "\uD800\uDC00\uE000\u2603\u0100a",
+            "\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uE000\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100\uD800\uDC00\u2603\u0100a"
+        };
+        for (String str : strings) {
+            writer.reset();
+            writer.writeStringWithTag(str);
+            String res = writer.toPbjReader().readString(128);
+            assertEquals(str, res);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "Test Ascii",
+                "UTF16 ☃",
+                "Hangul Syllable Hwen 휀",
+                "Private Use E000 \uE000",
+                "Linear B Syllable \uD800\uDC00",
+                "4 byte char \uDB40\uDDEF",
+                "☃ UTF16",
+                "휀Hangul Syllable Hwen",
+                "\uE000Private Use E000",
+                "\uD800\uDC00Linear B Syllable",
+                "\uDB40\uDDEF4 byte char",
+                "\u007F",
+                "\u013F"
+            })
+    void testReadString_readString_unicode(final String expected) {
+        byte[] utf8 = expected.getBytes(StandardCharsets.UTF_8);
+        BufferedData data = BufferedData.allocate(utf8.length + 5);
+        data.writeVarInt(utf8.length, false);
+        data.writeBytes(utf8);
+        data.flip();
+        PbjReader reader = new PbjReader(data.toInputStream());
+        assertEquals(expected, reader.readString(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void testReadString_readString_malformed_utf8() {
+        BufferedData data = BufferedData.allocate(128);
+        byte[][] manyBadEncoding = {
+            {(byte) 0xED, (byte) 0xA0, (byte) 0x80},
+            {(byte) 0xED, (byte) 0x9F, (byte) 0xC0},
+            {(byte) 0xE2, (byte) 0x98, (byte) 0x03},
+            {(byte) 0xE2, (byte) 0x18, (byte) 0x83},
+            {(byte) 0x82, (byte) 0x98, (byte) 0x83},
+            {(byte) 0xC4, (byte) 0x3F},
+            {(byte) 0x84, (byte) 0x3F},
+            {(byte) 0x3F, (byte) 0x84, 32},
+            {(byte) 0xF0, (byte) 0x90, (byte) 0x84, (byte) 0x3F},
+            {(byte) 0xF0, (byte) 0x90, (byte) 0x04, (byte) 0xBF},
+            {(byte) 0xF0, (byte) 0x10, (byte) 0x84, (byte) 0xBF},
+            {(byte) 0x70, (byte) 0x90, (byte) 0x84, (byte) 0xBF},
+
+            // Largest Legal Value is 10FFFF (F4 8F BF BF)
+            {(byte) 0xF4, (byte) 0x90, (byte) 0x80, (byte) 0x80},
+            {(byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xC0},
+            {(byte) 0xF5, (byte) 0x80, (byte) 0x80, (byte) 0x80},
+            {(byte) 0xF5, (byte) 0xBF, (byte) 0x80, (byte) 0x80},
+            {(byte) 0xF6, (byte) 0xBF, (byte) 0x80, (byte) 0x80},
+            {(byte) 0xF7, (byte) 0xBF, (byte) 0x80, (byte) 0x80},
+            {(byte) 0xF8, (byte) 0xBF, (byte) 0x80, (byte) 0x80},
+
+            // Check if the non tail codepath checks for these
+            {(byte) 0xF4, (byte) 0x90, (byte) 0x80, (byte) 0x80, 65},
+            {(byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xC0, 65},
+            {(byte) 0xF5, (byte) 0x80, (byte) 0x80, (byte) 0x80, 65},
+            {(byte) 0xF5, (byte) 0xBF, (byte) 0x80, (byte) 0x80, 65},
+            {(byte) 0xF6, (byte) 0xBF, (byte) 0x80, (byte) 0x80, 65},
+            {(byte) 0xF7, (byte) 0xBF, (byte) 0x80, (byte) 0x80, 65},
+            {(byte) 0xF8, (byte) 0xBF, (byte) 0x80, (byte) 0x80, 65},
+        };
+
+        // First check the code is encoding correctly
+        {
+            byte[] ok = {(byte) 0xED, (byte) 0x9F, (byte) 0xBF};
+            data.reset();
+            data.writeVarInt(ok.length, false);
+            data.writeBytes(ok);
+            data.flip();
+            PbjReader reader = new PbjReader(data.toInputStream());
+            String oksz = reader.readString(Integer.MAX_VALUE);
+            assertEquals("\uD7FF", oksz);
+            assert (reader.error() <= 0);
+        }
+
+        for (var bad : manyBadEncoding) {
+            data.reset();
+            data.writeVarInt(bad.length, false);
+            data.writeBytes(bad);
+            data.flip();
+            PbjReader reader = new PbjReader(data.toInputStream());
+            String badsz = reader.readString(Integer.MAX_VALUE);
+            assertEquals("", badsz);
+            assertEquals(reader.error(), PbjReader.PARSE);
+        }
+    }
+
+    @Test
+    void toByteArrayDoesAClone() {
+        byte[] bytes = new byte[128];
+        PbjWriter writer = new PbjWriter(bytes, 0);
+        for (int i = 0; i < 128; i++) {
+            writer.writeVarIntNoZZ(i);
+        }
+        assertEquals(128, writer.position());
+        assertEquals(bytes, writer.internalArray());
+        byte[] arr1 = writer.toByteArray();
+        assertNotEquals(bytes, arr1);
+        Bytes arr2 = writer.toByteArrayWrapped();
+        for (int i = 0; i < 128; i++) {
+            assertEquals(i, arr1[i]);
+            assertEquals(i, arr2.getByte(i));
+        }
+    }
+
+    @Test
+    void writeResetCheck() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeByte((byte) 10);
+        assertEquals(1, writer.position());
+        writer.reset();
+        assertEquals(0, writer.position());
+        writer.writeByte2((byte) 99, (byte) 88);
+        assertEquals(2, writer.position());
+        assertEquals(99, writer.internalArray()[0]);
+        assertEquals(88, writer.internalArray()[1]);
+        assertArrayEquals(new byte[] {99, 88}, writer.toByteArray());
+    }
+
+    @Test
+    void throwOnErrorThrows_NoPrevOverwrite() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag("\uD800"); // lone surrogate sets MalformString
+        assertEquals(PbjWriter.MALFORM_STRING, writer.error());
+        assertThrows(RuntimeException.class, writer::throwOnError);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer2 = new PbjWriter(baos);
+        writer2.writeStringWithTag("\uD800"); // lone surrogate sets MalformString
+        assertEquals(PbjWriter.MALFORM_STRING, writer2.error());
+        assertThrows(RuntimeException.class, writer2::throwOnError);
+        // Confirm error didn't change
+        assertEquals(Bytes.EMPTY, writer2.toByteArrayWrapped()); // if no error, this would set usage error
+        assertEquals(PbjWriter.MALFORM_STRING, writer2.error());
+
+        baos = new ByteArrayOutputStream();
+        PbjWriter writer3 = new PbjWriter(baos);
+        assertEquals(Bytes.EMPTY, writer3.toByteArrayWrapped());
+        assertEquals(PbjWriter.USAGE_ERROR, writer3.error());
+    }
+
+    @Test
+    void encodeUtf8HighSurrogateFollowedByHighSurrogate() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringNoTag("\uD800\uD801");
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void doesntThrowOnNoError() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4});
+        assertEquals(0x04030201, reader.readIntLE());
+        assertEquals(0, reader.error());
+        assertDoesNotThrow(() -> reader.throwOnError()); // must not throw
+
+        PbjWriter writer = new PbjWriter();
+        writer.writeByte((byte) 1);
+        assertEquals(0, writer.error());
+        writer.throwOnError(); // must not throw
+    }
+
+    @Test
+    void manyRoundtrip() {
+        PbjWriter w = new PbjWriter();
+
+        w.writeInt(0x01020304);
+        w.writeIntBE(0x05060708);
+        w.writeIntLE(0x090A0B0C);
+
+        w.writeLong(0x0102030405060708L);
+        w.writeLongBE(0x090A0B0C0D0E0F10L);
+        w.writeLongLE(0x1112131415161718L);
+
+        w.writeFloat(1.5f);
+        w.writeFloatBE(2.5f);
+        w.writeFloatLE(3.5f);
+
+        w.writeDouble(1.25);
+        w.writeDoubleBE(2.25);
+        w.writeDoubleLE(3.25);
+
+        w.writeBoolean(true);
+        w.writeBoolean(false);
+        w.writeByte((byte) 127);
+
+        byte[] arr1 = {10, 20, 30, 40, 50};
+        w.writeBytes(arr1);
+        w.writeBytes(arr1, 1, 3);
+        w.writeBytes(Bytes.wrap(new byte[] {60, 70}));
+        BufferedData bd = BufferedData.allocate(2);
+        bd.writeByte((byte) 80);
+        bd.writeByte((byte) 90);
+        bd.flip();
+        w.writeBytes(bd);
+
+        w.writeStringWithTag("hello");
+        w.writeStringWithTag("Ā☃");
+
+        PbjReader reader = w.toPbjReader();
+
+        assertEquals(0x01020304, reader.readInt());
+        assertEquals(0x05060708, reader.readIntBE());
+        assertEquals(0x090A0B0C, reader.readIntLE());
+
+        assertEquals(0x0102030405060708L, reader.readLong());
+        assertEquals(0x090A0B0C0D0E0F10L, reader.readLongBE());
+        assertEquals(0x1112131415161718L, reader.readLongLE());
+
+        assertEquals(1.5f, reader.readFloat(), 0f);
+        assertEquals(2.5f, reader.readFloat(), 0f);
+        assertEquals(3.5f, reader.readFloatLE(), 0f);
+
+        assertEquals(1.25, reader.readDouble(), 0.0);
+        assertEquals(2.25, reader.readDouble(), 0.0);
+        assertEquals(3.25, reader.readDoubleLE(), 0.0);
+
+        assertEquals(true, reader.readBoolean());
+        assertEquals(false, reader.readBoolean());
+        assertEquals(127, reader.readByte());
+
+        byte[] dst1 = new byte[5];
+        reader.readBytes(dst1);
+        assertArrayEquals(arr1, dst1);
+
+        byte[] dst2 = new byte[3];
+        reader.readBytes(dst2);
+        assertArrayEquals(new byte[] {20, 30, 40}, dst2);
+
+        byte[] dst3 = new byte[2];
+        reader.readBytes(dst3);
+        assertArrayEquals(new byte[] {60, 70}, dst3);
+
+        byte[] dst4 = new byte[2];
+        reader.readBytes(dst4);
+        assertArrayEquals(new byte[] {80, 90}, dst4);
+
+        assertEquals("hello", reader.readString(100));
+        assertEquals("Ā☃", reader.readString(100));
+
+        assertFalse(reader.hasRemaining());
+        assertEquals(0, w.error());
+    }
+
+    @Test
+    void writeVarIntZigZagRoundtrip() {
+        int[] values = {0, 1, -1, Integer.MAX_VALUE, Integer.MIN_VALUE, 100, -100};
+        PbjWriter writer = new PbjWriter();
+        for (int v : values) {
+            writer.reset();
+            writer.writeVarInt(v, true);
+            assertEquals(v, writer.toPbjReader().readVarIntZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarInt(v, false);
+            assertEquals(v, writer.toPbjReader().readVarIntNoZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarIntZZ(v);
+            assertEquals(v, writer.toPbjReader().readVarIntZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarIntNoZZ(v);
+            assertEquals(v, writer.toPbjReader().readVarIntNoZZ(), "Failed for value " + v);
+        }
+    }
+
+    @Test
+    void writeVarLongZigZagRoundtrip() {
+        long[] values = {0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE, 1_000_000_000L, -1_000_000_000L};
+        PbjWriter writer = new PbjWriter();
+        for (long v : values) {
+            writer.reset();
+            writer.writeVarLong(v, true);
+            assertEquals(v, writer.toPbjReader().readVarLongZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarLong(v, false);
+            assertEquals(v, writer.toPbjReader().readVarLongNoZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarLongZZ(v);
+            assertEquals(v, writer.toPbjReader().readVarLongZZ(), "Failed for value " + v);
+
+            writer.reset();
+            writer.writeVarLongNoZZ(v);
+            int noZZLen = writer.position();
+            assertEquals(v, writer.toPbjReader().readVarLongNoZZ(), "Failed for value " + v);
+
+            // edge test
+            writer.reset();
+            int len = writer.internalArray().length;
+            writer.skip(len);
+            writer.writeVarLongNoZZ(v);
+            byte[] buf = writer.internalArray();
+            for (int i = 0; i < noZZLen; i++) {
+                assertEquals(buf[i], buf[i + len]);
+            }
+        }
+    }
+
+    @Test
+    void testWriteByteAtEdge() {
+        PbjWriter writer = new PbjWriter();
+        int defaultLen = writer.internalArray().length;
+        writer.skip(defaultLen - 1);
+        writer.writeByte((byte) 1);
+        byte[] internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 1]);
+        writer.writeByte((byte) 1);
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 1]);
+        assertEquals((byte) 1, internalArray[defaultLen]);
+
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 2);
+        writer.writeByte2((byte) 1, (byte) 2);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 2]);
+        assertEquals((byte) 2, internalArray[defaultLen - 1]);
+        writer.skip(-1);
+        writer.writeByte2((byte) 1, (byte) 2);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 1]);
+        assertEquals((byte) 2, internalArray[defaultLen]);
+
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 3);
+        writer.writeByte3((byte) 1, (byte) 2, (byte) 3);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 3]);
+        assertEquals((byte) 2, internalArray[defaultLen - 2]);
+        assertEquals((byte) 3, internalArray[defaultLen - 1]);
+        writer.skip(-2);
+        writer.writeByte3((byte) 1, (byte) 2, (byte) 3);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 2]);
+        assertEquals((byte) 2, internalArray[defaultLen - 1]);
+        assertEquals((byte) 3, internalArray[defaultLen]);
+
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeByte4((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 4]);
+        assertEquals((byte) 2, internalArray[defaultLen - 3]);
+        assertEquals((byte) 3, internalArray[defaultLen - 2]);
+        assertEquals((byte) 4, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeByte4((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 1, internalArray[defaultLen - 3]);
+        assertEquals((byte) 2, internalArray[defaultLen - 2]);
+        assertEquals((byte) 3, internalArray[defaultLen - 1]);
+        assertEquals((byte) 4, internalArray[defaultLen]);
+
+        // writeInt writes big-endian: 4 = {0, 0, 0, 4}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeInt(4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0, internalArray[defaultLen - 4]);
+        assertEquals((byte) 0, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 4, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeInt(4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        assertEquals((byte) 4, internalArray[defaultLen]);
+
+        // writeIntLE writes little-endian: 4 = {4, 0, 0, 0}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeIntLE(4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 4, internalArray[defaultLen - 4]);
+        assertEquals((byte) 0, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeIntLE(4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 4, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        assertEquals((byte) 0, internalArray[defaultLen]);
+
+        // writeLong writes big-endian: 8 = {0, 0, 0, 0, 0, 0, 0, 8}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 8);
+        writer.writeLong(8);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 8, internalArray[defaultLen - 1]);
+        writer.skip(-7);
+        writer.writeLong(8);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0, internalArray[defaultLen - 1]);
+        assertEquals((byte) 8, internalArray[defaultLen]);
+
+        // writeFloatLE writes little-endian: 4.0f = 0x40800000 = {0x00, 0x00, 0x80, 0x40}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeFloatLE(4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 4]);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0x80, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0x40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeFloatLE(4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 3]);
+        assertEquals((byte) 0x00, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0x80, internalArray[defaultLen - 1]);
+        assertEquals((byte) 0x40, internalArray[defaultLen]);
+
+        // writeDoubleLE writes little-endian: 8.0 = 0x4020000000000000 = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20,
+        // 0x40}
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 8);
+        writer.writeDoubleLE(8);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 0x40, internalArray[defaultLen - 1]);
+        writer.skip(-7);
+        writer.writeDoubleLE(8);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 0x20, internalArray[defaultLen - 1]);
+        assertEquals((byte) 0x40, internalArray[defaultLen]);
+
+        byte[] array4 = new byte[] {10, 20, 30, 40};
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(array4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 4]);
+        assertEquals((byte) 20, internalArray[defaultLen - 3]);
+        assertEquals((byte) 30, internalArray[defaultLen - 2]);
+        assertEquals((byte) 40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeBytes(array4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 3]);
+        assertEquals((byte) 20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 30, internalArray[defaultLen - 1]);
+        assertEquals((byte) 40, internalArray[defaultLen]);
+
+        Bytes bytes4 = Bytes.wrap(new byte[] {10, 20, 30, 40});
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(bytes4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 4]);
+        assertEquals((byte) 20, internalArray[defaultLen - 3]);
+        assertEquals((byte) 30, internalArray[defaultLen - 2]);
+        assertEquals((byte) 40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        writer.writeBytes(bytes4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 3]);
+        assertEquals((byte) 20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 30, internalArray[defaultLen - 1]);
+        assertEquals((byte) 40, internalArray[defaultLen]);
+
+        BufferedData bb4 = BufferedData.wrap(new byte[] {10, 20, 30, 40});
+        writer = new PbjWriter();
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(bb4);
+        internalArray = writer.internalArray();
+        assertEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 4]);
+        assertEquals((byte) 20, internalArray[defaultLen - 3]);
+        assertEquals((byte) 30, internalArray[defaultLen - 2]);
+        assertEquals((byte) 40, internalArray[defaultLen - 1]);
+        writer.skip(-3);
+        bb4.resetPosition();
+        writer.writeBytes(bb4);
+        assertEquals(defaultLen + 1, writer.position());
+        internalArray = writer.internalArray();
+        assertNotEquals(defaultLen, internalArray.length);
+        assertEquals((byte) 10, internalArray[defaultLen - 3]);
+        assertEquals((byte) 20, internalArray[defaultLen - 2]);
+        assertEquals((byte) 30, internalArray[defaultLen - 1]);
+        assertEquals((byte) 40, internalArray[defaultLen]);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        writer = new PbjWriter(baos);
+        writer.skip(defaultLen - 4);
+        bb4.resetPosition();
+        writer.writeBytes(bb4);
+        assertEquals(0, baos.size());
+
+        writer.skip(-3);
+        bb4.resetPosition();
+        writer.writeBytes(bb4);
+        assertEquals(defaultLen + 1, writer.position());
+
+        assertEquals(defaultLen, baos.size());
+        byte[] data = baos.toByteArray();
+        assertEquals(defaultLen, data.length);
+        assertEquals((byte) 10, data[defaultLen - 4]);
+
+        assertEquals((byte) 10, data[defaultLen - 3]);
+        assertEquals((byte) 20, data[defaultLen - 2]);
+        assertEquals((byte) 30, data[defaultLen - 1]);
+        // last byte inside internal buffer
+
+        // Again but the Bytes path
+        baos = new ByteArrayOutputStream();
+        writer = new PbjWriter(baos);
+        writer.skip(defaultLen - 4);
+        writer.writeBytes(bytes4);
+        assertEquals(0, baos.size());
+
+        writer.skip(-3);
+        writer.writeBytes(bytes4);
+        assertEquals(defaultLen + 1, writer.position());
+
+        assertEquals(defaultLen, baos.size());
+        data = baos.toByteArray();
+        assertEquals(defaultLen, data.length);
+        assertEquals((byte) 10, data[defaultLen - 4]);
+
+        assertEquals((byte) 10, data[defaultLen - 3]);
+        assertEquals((byte) 20, data[defaultLen - 2]);
+        assertEquals((byte) 30, data[defaultLen - 1]);
+        // last byte inside internal buffer
+    }
+
+    @Test
+    void utf8EncodingTest() {
+        PbjWriter writer = new PbjWriter();
+        char arr[] = new char[6 << 10];
+        for (int i = 0; i < 127; i++) {
+            arr[i] = 'a';
+        }
+
+        writer.writeStringWithTag(new String(arr, 0, 127));
+        assertEquals(128, writer.position());
+
+        arr[50] = 'Ā';
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 127));
+        assertEquals(130, writer.position());
+
+        for (int i = 0; i < 127; i++) {
+            arr[i] = 'Ā';
+        }
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 127));
+        assertEquals(127 * 2 + 2, writer.position());
+
+        for (int i = 0; i < 5460; i++) {
+            arr[i] = 'b';
+        }
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 5460));
+        assertEquals(5460 + 2, writer.position());
+
+        for (int i = 0; i < 5460; i++) {
+            arr[i] = 'ā';
+        }
+
+        writer.reset();
+        writer.writeStringWithTag(new String(arr, 0, 5460));
+        assertEquals(5460 * 2 + 2, writer.position());
+
+        for (int i = 0; i < 6 << 10; i++) {
+            arr[i] = (char) (32 + i);
+        }
+
+        writer.reset();
+        String str = new String(arr);
+        writer.writeStringWithTag(str);
+        String res = writer.toPbjReader().readString(1 << 20);
+        assertEquals(str, res);
+    }
+
+    @Test
+    void readerLimit() {
+        byte[] data = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+        PbjReader reader = new PbjReader(data);
+
+        assertTrue(reader.hasRemaining());
+        assertEquals(0, reader.position());
+        assertEquals(data.length, reader.limit());
+        reader.limit(0);
+        assertTrue(!reader.hasRemaining());
+        assertEquals(0, reader.position());
+
+        reader.limit(4);
+        assertTrue(reader.hasRemaining());
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        assertEquals(4, reader.position());
+        assertEquals(0, reader.readIntBE());
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void readerByteBufferConstructor() {
+        PbjReader reader = new PbjReader(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void readerResetWithByteBuffer() {
+        PbjReader reader = new PbjReader(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        reader.resetWith(ByteBuffer.wrap(new byte[] {5, 6, 7, 8}));
+        assertEquals(0, reader.position());
+        assertEquals(0x05060708, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readerBufferBytesConstructor() {
+        PbjReader reader = new PbjReader(Bytes.wrap(new byte[] {0x0A, 0x0B, 0x0C, 0x0D}));
+        assertEquals(0x0A0B0C0D, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void readerBufferInputStreamConstructor() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void readerSkipAdvancesPosition() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4, 5});
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertTrue(reader.hasRemaining());
+    }
+
+    @Test
+    void readerSkipBeyondDataSetsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4});
+        reader.skip(5);
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void readerResetAllowsReRead() {
+        byte[] data = {1, 2, 3, 4};
+        PbjReader reader = new PbjReader(data);
+        assertEquals(0x01020304, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+        reader.resetWith(data);
+        assertEquals(0, reader.position());
+        assertTrue(reader.hasRemaining());
+        assertEquals(0x01020304, reader.readIntBE());
+    }
+
+    @Test
+    void readerResetWithReplacesBuffer() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4});
+        assertEquals(0x01020304, reader.readIntBE());
+        reader.resetWith(new byte[] {5, 6, 7, 8});
+        assertEquals(0x05060708, reader.readIntBE());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void writeLargeBytesBypassInternalBuffer() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(baos);
+        writer.writeByte((byte) 7);
+        byte[] large = new byte[4096];
+        large[0] = 11;
+        large[4095] = 22;
+        writer.writeBytes(large);
+
+        byte[] result = baos.toByteArray();
+        assertEquals(4097, result.length);
+        assertEquals(7, result[0]);
+        assertEquals(11, result[1]);
+        assertEquals(22, result[4096]);
+
+        byte[] internalArray = writer.internalArray();
+        assertEquals(7, internalArray[0]);
+        assertEquals(0, internalArray[1]);
+    }
+
+    @Test
+    void writeBytesRandomAccessDataZeroLengthWritesNothing() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(Bytes.wrap(new byte[0]));
+        assertEquals(0, writer.position());
+        writer.writeBytes(Bytes.EMPTY);
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void writeBytesBufferedDataZeroRemainingWritesNothing() {
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(BufferedData.wrap(new byte[0]));
+        assertEquals(0, writer.position());
+
+        BufferedData bd = BufferedData.wrap(new byte[] {1, 2, 3});
+        bd.skip(3);
+        writer.writeBytes(bd);
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void writeBytesArrayZeroAndNegativeLengthWritesNothing() {
+        byte[] src = new byte[] {1, 2, 3, 4};
+        PbjWriter writer = new PbjWriter();
+        writer.writeBytes(src, 0, 0);
+        assertEquals(0, writer.position());
+        writer.writeBytes(src, 0, -2);
+        assertEquals(0, writer.position());
+    }
+
+    @Test
+    void quickTest() {
+        byte[] a = {2, 3};
+        var by = Bytes.wrap(a);
+        var adap = by.toReadableSequentialData();
+        var r = new PbjReader(adap);
+        var w = new PbjWriter();
+        w.setError(4, "");
+        int q = 0;
+    }
+
+    @Test
+    void largeWriteBypassCorrectness() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(out);
+
+        byte[] fewBytes = {1, 2, 3, 4, 5};
+        byte[] manyBytes = new byte[8_000];
+        Arrays.fill(manyBytes, (byte) 0x7F);
+
+        writer.writeBytes(fewBytes);
+        writer.writeBytes(manyBytes);
+        writer.flush();
+
+        byte[] expected = new byte[fewBytes.length + manyBytes.length];
+        System.arraycopy(fewBytes, 0, expected, 0, fewBytes.length);
+        System.arraycopy(manyBytes, 0, expected, fewBytes.length, manyBytes.length);
+
+        assertArrayEquals(
+                expected,
+                out.toByteArray(),
+                "Buffered prefix bytes must not be dropped when a large payload bypasses the buffer");
+    }
+
+    @Test
+    void writeBytesArrayFastPathBoundaryWithOutputStream() {
+
+        {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PbjWriter writer = new PbjWriter(baos);
+            byte[] src = new byte[2047];
+            src[0] = 11;
+            src[2046] = 22;
+            writer.writeBytes(src, 0, 2047);
+            assertEquals(11, writer.internalArray()[0]);
+            assertEquals(0, baos.toByteArray().length);
+            writer.reset();
+            baos.reset();
+            int internalLen = writer.internalArray().length;
+            writer.skip(internalLen - 1);
+            writer.writeBytes(src, 0, 2047);
+            assertEquals(internalLen - 1, baos.toByteArray().length);
+        }
+        {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PbjWriter writer = new PbjWriter(baos);
+            byte[] src = new byte[2048];
+            src[0] = 11;
+            src[2047] = 22;
+            writer.writeBytes(src, 0, 2048);
+            writer.flush();
+            assertEquals(0, writer.internalArray()[0]); // this length bypasses buffer
+            byte[] result = baos.toByteArray();
+            assertEquals(2048, result.length);
+            assertEquals((byte) 11, result[0]);
+            assertEquals((byte) 22, result[2047]);
+            byte[] internalArray = writer.internalArray();
+            assertEquals(0, internalArray[0]);
+            assertEquals(0, internalArray[2047]);
+        }
+    }
+
+    @Test
+    void writeBytesBufferedDataFlushThrowsPropagated() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("Called write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        byte[] chunk = new byte[1024]; // 2k is a fastpath
+        for (int i = 0; i < 16; i++) writer.writeBytes(chunk);
+        UncheckedIOException ex =
+                assertThrows(UncheckedIOException.class, () -> writer.writeBytes(BufferedData.wrap(new byte[] {1})));
+        assertEquals("java.io.IOException: Called write", ex.getMessage());
+    }
+
+    @Test
+    void writeLargeByteArrayFlushThrowsPropagated() {
+        OutputStream failOnLarge = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                if (len == 1) return;
+                if (len >= 2048) throw new IOException("2k write alt path");
+                throw new RuntimeException("Called write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failOnLarge);
+        writer.writeBoolean(true);
+        UncheckedIOException ex = assertThrows(UncheckedIOException.class, () -> writer.writeBytes(new byte[2048]));
+        assertEquals("java.io.IOException: 2k write alt path", ex.getMessage());
+    }
+
+    @Test
+    void writeBytesRandomAccessDataFlushThrowsPropagated() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("writeBytesRAInternal write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        byte[] chunk = new byte[1024];
+        for (int i = 0; i < 16; i++) writer.writeBytes(chunk); // fill 16k internal buffer
+        UncheckedIOException ex =
+                assertThrows(UncheckedIOException.class, () -> writer.writeBytes(Bytes.wrap(new byte[] {1})));
+        assertEquals("java.io.IOException: writeBytesRAInternal write", ex.getMessage());
+    }
+
+    @Test
+    void flushOrGrowFlushThrowsPropagated() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("Called write");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        byte[] chunk = new byte[1024];
+        for (int i = 0; i < 16; i++) writer.writeBytes(chunk); // fill 16k internal buffer
+        UncheckedIOException ex = assertThrows(UncheckedIOException.class, () -> writer.writeByte((byte) 1));
+        assertEquals("java.io.IOException: Called write", ex.getMessage());
+    }
+
+    @Test
+    void flushPropagatesIOExceptionAsUnchecked() {
+        OutputStream failing = new OutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("fake disk full");
+            }
+        };
+        PbjWriter writer = new PbjWriter(failing);
+        writer.writeByte((byte) 1);
+        UncheckedIOException ex = assertThrows(UncheckedIOException.class, writer::flush);
+        assertEquals("java.io.IOException: fake disk full", ex.getMessage());
+    }
+
+    @Test
+    void constructorWithWritableSequentialDataFlushesThrough() {
+        BufferedData bd = BufferedData.allocate(16);
+        PbjWriter writer = new PbjWriter(bd);
+        writer.writeByte2((byte) 10, (byte) 20);
+        writer.flush();
+        assertEquals(10, bd.getByte(0));
+        assertEquals(20, bd.getByte(1));
+        assertEquals(2, bd.position());
+    }
+
+    @Test
+    void resetWithWritableSequentialDataSwitchesOutput() {
+        ByteArrayOutputStream out1 = new ByteArrayOutputStream();
+        BufferedData bd = BufferedData.allocate(16);
+        PbjWriter writer = new PbjWriter(out1);
+        writer.writeByte((byte) 5);
+        writer.resetWith(bd);
+        writer.writeByte((byte) 7);
+        writer.flush();
+        assertArrayEquals(new byte[] {5}, out1.toByteArray()); // flushed to out1 during reset
+        assertEquals(7, bd.getByte(0));
+        assertEquals(1, bd.position());
+    }
+
+    @Test
+    void resetWithFlushesAndSwitchesOutput() {
+        ByteArrayOutputStream out1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+        PbjWriter writer = new PbjWriter(out1);
+        writer.writeByte((byte) 10);
+        assertEquals(0, out1.size());
+        writer.resetWith(out2); // flushes before reset
+        assertArrayEquals(new byte[] {10}, out1.toByteArray());
+
+        assertEquals(0, writer.position());
+        writer.writeByte((byte) 20);
+        writer.flush();
+        assertArrayEquals(new byte[] {20}, out2.toByteArray());
+        writer.writeByte((byte) 5);
+        writer.resetWithNull();
+        assertArrayEquals(new byte[] {20, 5}, out2.toByteArray());
+        writer.writeByte((byte) 7);
+        assertArrayEquals(new byte[] {7}, writer.toByteArray());
+        assertArrayEquals(new byte[] {20, 5}, out2.toByteArray());
+    }
+
+    @Test
+    void resetWithOnNonReuseableWriterSetsError() {
+        byte[] buf = new byte[64];
+        PbjWriter writer = new PbjWriter(buf, 0);
+        writer.resetWith(new ByteArrayOutputStream());
+        assertEquals(PbjWriter.USAGE_ERROR, writer.error());
+    }
+
+    @Test
+    void bufferMoreBeyondAbsoluteLimitSetsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5}));
+        reader.limit(3);
+        assertEquals(1, reader.readByte());
+        assertEquals(2, reader.readByte());
+        assertEquals(3, reader.readByte());
+        assertEquals(false, reader.hasRemaining());
+        reader.readByte();
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void limitPropagatedToUnderlyingReadableSequentialData() {
+        BufferedData bd = BufferedData.allocate(8);
+        for (byte b = 0; b < 8; b++) bd.writeByte(b);
+        bd.flip();
+        PbjReader reader = new PbjReader(bd);
+        reader.limit(4);
+        reader.readByte();
+        assertEquals(4, bd.position());
+        assertEquals(1, reader.readByte());
+        assertEquals(2, reader.readByte());
+        assertEquals(3, reader.readByte());
+        assertFalse(reader.hasRemaining());
+    }
+
+    @Test
+    void skipTriggersUnderflow() {
+        byte[] data = {1, 2, 3, 4, 5};
+        PbjReader reader = new PbjReader(data);
+        assertEquals(1, reader.readByte());
+        reader.skip(5);
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void skipInternalAccountsForBytesRemainingInBuffer() {
+        byte[] data = {1, 2, 3, 4, 5};
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(data));
+        assertEquals(1, reader.readByte());
+        reader.skip(5);
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void readVarLongWithMoreThanTenBytesSetsDataEncoding() {
+        byte[] malformed = new byte[16];
+        for (int i = 0; i < 16; i++) malformed[i] = (byte) 0xFF;
+        PbjReader reader = new PbjReader(malformed);
+        reader.readVarLongNoZZ();
+        assertEquals(PbjReader.DATA_ENCODING, reader.error());
+        reader.resetWith(malformed);
+        reader.readVarLongBytes();
+        assertEquals(PbjReader.DATA_ENCODING, reader.error());
+    }
+
+    @Test
+    void skipInternalSuccessfullySkipsFromInputStream() {
+        InputStream in = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
+        PbjReader reader = new PbjReader(in);
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertEquals(4, reader.readByte());
+    }
+
+    @Test
+    void skipInternalSuccessfullySkipsFromReadableSequentialData() {
+        BufferedData bd = BufferedData.allocate(8);
+        for (int i = 0; i < 5; i++) {
+            bd.writeByte((byte) i);
+        }
+        bd.flip();
+        PbjReader reader = new PbjReader(bd);
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertEquals(3, reader.readByte());
+    }
+
+    @Test
+    void skipInternalSetsIOErrorWhenInputStreamSkipThrows() {
+        InputStream in = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public long skip(long n) throws IOException {
+                throw new IOException("skip failed");
+            }
+        };
+        PbjReader reader = new PbjReader(in);
+        reader.skip(5);
+        assertEquals(PbjReader.IO_ERROR, reader.error());
+    }
+
+    @Test
+    void skipInternalCallsUnderlyingInputSkipForReadableSequentialData() {
+        BufferedData bd = BufferedData.allocate(8);
+        for (byte b = 0; b < 8; b++) bd.writeByte(b);
+        bd.flip();
+        PbjReader reader = new PbjReader(bd);
+        reader.skip(3);
+        assertEquals(3, reader.position());
+        assertEquals(3, bd.position());
+        assertEquals(3, reader.readByte());
+    }
+
+    @Test
+    void readVarLongBytesReturnsWrappedBytesForValidVarint() {
+        PbjReader reader = new PbjReader(new byte[] {(byte) 0xAC, 0x02});
+        Bytes result = reader.readVarLongBytes();
+        assertEquals(2, result.length());
+        assertEquals((byte) 0xAC, result.getByte(0));
+        assertEquals((byte) 0x02, result.getByte(1));
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readLargeStringCantBeBuffered() {
+        int len = (16 << 10) + 1;
+        String str = "a".repeat(len);
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag(str);
+        PbjReader reader = writer.toPbjReader();
+        assertEquals(len, reader.readVarIntNoZZ());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readStringBufferedInternalSuccessPath() {
+        String str = "a".repeat(16384);
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag(str);
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(writer.toByteArray()));
+        assertEquals(str, reader.readString(16384 + 10));
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readStringBufferedInternalSuccessPathLarger() {
+        String str = "a".repeat(16385);
+        PbjWriter writer = new PbjWriter();
+        writer.writeStringWithTag(str);
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(writer.toByteArray()));
+        assertEquals(str, reader.readString(16385 + 10));
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readFromInputSetsIOErrorWhenInputStreamReadThrows() {
+        InputStream failingOnSecondRead = new InputStream() {
+            private boolean doThrow = false;
+
+            @Override
+            public int read() {
+                return 1;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                if (doThrow) throw new IOException("io error");
+                doThrow = true;
+                b[off] = 25;
+                return 1;
+            }
+        };
+        PbjReader reader = new PbjReader(failingOnSecondRead);
+        reader.readByte();
+        assertEquals(PbjReader.IO_ERROR, reader.error());
+    }
+
+    @Test
+    void readStringLengthExceedsMaxSize() {
+        var reader = new PbjReader(new byte[] {5, 'h', 'e', 'l', 'l', 'o'});
+        assertEquals("", reader.readString(2));
+        assertEquals(PbjReader.PARSE, reader.error());
+    }
+
+    @Test
+    void readStringNegativeLengthSetsParseError() {
+        var reader = new PbjReader(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x0F});
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.PARSE, reader.error());
+    }
+
+    @Test
+    void readStringInvalidUtf8SetParseError() {
+        var reader = new PbjReader(new byte[] {1, (byte) 0x80});
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.PARSE, reader.error());
+    }
+
+    @Test
+    void readStringReturnsEmptyOnInsufficientData() {
+        var reader = new PbjReader(new byte[] {5, 'a', 'b'}); // length=5 but only 2 bytes follow
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    ///// Reset /////
+
+    private static final byte[] DATA = {1, 2, 3, 4, 5};
+
+    @Test
+    void resetWithByteArraySequentialData_readsCorrectBytes() throws ParseException {
+        ReadableSequentialData byteArraySeq = Bytes.wrap(DATA).toReadableSequentialData();
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+
+        reader.resetWith(byteArraySeq);
+
+        for (byte expected : DATA) {
+            assertEquals(expected, reader.readByte());
+        }
+        reader.throwOnError();
+    }
+
+    @Test
+    void resetWithNonByteArraySequentialData_readsCorrectBytes() throws ParseException {
+        ReadableSequentialData buffered = BufferedData.wrap(DATA);
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+
+        reader.resetWith(buffered);
+
+        for (byte expected : DATA) {
+            assertEquals(expected, reader.readByte());
+        }
+        reader.throwOnError();
+    }
+
+    @Test
+    void resetWithInputStream_readsCorrectBytes() throws ParseException {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+
+        reader.resetWith(new ByteArrayInputStream(DATA));
+
+        for (byte expected : DATA) {
+            assertEquals(expected, reader.readByte());
+        }
+        reader.throwOnError();
+    }
+
+    @Test
+    void resetWithNull_throwsOnError() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[0]));
+        reader.resetWith((ReadableSequentialData) null);
+        assertThrows(ParseException.class, reader::throwOnError);
+
+        PbjReader reader2 = new PbjReader(new ByteArrayInputStream(new byte[0]));
+        reader2.resetWith((ReadableSequentialData) null);
+        assertThrows(ParseException.class, reader2::throwOnError);
+    }
+
+    @Test
+    void resetFromBytesToStream() {
+        var reader = new PbjReader(new byte[] {1});
+        assertEquals((byte) 1, reader.readByte());
+        reader.resetWith(new ByteArrayInputStream(new byte[] {7, 8}));
+        assertEquals((byte) 7, reader.readByte());
+        assertEquals((byte) 8, reader.readByte());
+        assertEquals(0, reader.error());
+    }
+
+    //
+
+    @Test
+    void asInputStreamReturnsUnderlyingStreamIfNeverRead() {
+        var stream = new ByteArrayInputStream(new byte[] {1, 2, 3});
+        var reader = new PbjReader(stream);
+        assertSame(stream, reader.asInputStream());
+    }
+
+    @Test
+    void asInputStreamDelegatesToInputIfNeverRead() throws Exception {
+        var innerStream = new ByteArrayInputStream(new byte[] {21});
+        var reader = new PbjReader(new ReadableStreamingData(innerStream));
+        var is = reader.asInputStream();
+        assertNotNull(is);
+        assertEquals(21, is.read());
+    }
+
+    @Test
+    void asInputStreamForByteArrayReader() throws Exception {
+        var reader = new PbjReader(new byte[] {1, 2, 3});
+        var is = reader.asInputStream();
+        assertEquals(1, is.read());
+        assertEquals(2, is.read());
+        assertEquals(3, is.read());
+    }
+
+    @Test
+    void readIntLESlowPathSuccess() {
+        var reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4}));
+        assertEquals(0x04030201, reader.readIntLE());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readLongLESlowPathSuccess() {
+        var reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}));
+        assertEquals(0x0807060504030201L, reader.readLongLE());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readIntLEUnderflow() {
+        var reader = new PbjReader(new byte[] {1, 2, 3}); // only 3 bytes, need 4
+        assertEquals(0, reader.readIntLE());
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void readLongLEUnderflow() {
+        var reader = new PbjReader(new byte[] {1, 2, 3, 4, 5, 6, 7}); // only 7 bytes, need 8
+        assertEquals(0L, reader.readLongLE());
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    ///// readBytes /////
+
+    @Test
+    void readBytesArrayOffsetLen_writesIntoCorrectSlice() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4, 5});
+        byte[] dst = new byte[7];
+        long n = reader.readBytes(dst, 2, 3);
+        assertEquals(3, n);
+        assertArrayEquals(new byte[] {0, 0, 1, 2, 3, 0, 0}, dst);
+    }
+
+    @Test
+    void readBytesIntoByteBuffer_dataReadAndPositionAdvances() {
+        PbjReader reader = new PbjReader(new byte[] {10, 20, 30});
+        ByteBuffer bb = ByteBuffer.allocate(5);
+        long n = reader.readBytes(bb);
+        assertEquals(3, n);
+        assertEquals(3, bb.position());
+        assertArrayEquals(new byte[] {10, 20, 30, 0, 0}, bb.array());
+    }
+
+    @Test
+    void readBytesIntoByteBuffer_positionUnchangedWhenError() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2});
+        reader.skip(10);
+        assertTrue(reader.error() > 0);
+        ByteBuffer bb = ByteBuffer.allocate(5);
+        long n = reader.readBytes(bb);
+        assertEquals(-1, n);
+        assertEquals(0, bb.position());
+    }
+
+    @Test
+    void readBytesInt_fastPath_bytesBuffered() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3, 4, 5});
+        Bytes result = reader.readBytes(3);
+        assertEquals(3, result.length());
+        assertArrayEquals(new byte[] {1, 2, 3}, result.toByteArray());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readBytesInt_slowPath_triggersReadBytesInternal() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {7, 8, 9}));
+        Bytes result = reader.readBytes(3);
+        assertEquals(3, result.length());
+        assertArrayEquals(new byte[] {7, 8, 9}, result.toByteArray());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readBytesInternal_zeroLength_returnsEmpty() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2});
+        reader.skip(10);
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+        assertSame(Bytes.EMPTY, reader.readBytes(2));
+    }
+
+    @Test
+    void readBytesInternal_notEnoughData_setsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2}));
+        Bytes result = reader.readBytes(5);
+        assertSame(Bytes.EMPTY, result);
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void readLongBEInternal_streamingReaderSucceeds() {
+        byte[] bytes = {0, 0, 0, 0, 0, 0, 0, 7};
+        PbjReader reader = new PbjReader(new ByteArrayInputStream(bytes));
+        assertEquals(7L, reader.readLongBE());
+        assertEquals(0, reader.error());
+    }
+
+    @Test
+    void readLongBEInternal_notEnoughData_setsBufferUnderflow() {
+        PbjReader reader = new PbjReader(new byte[] {1, 2, 3});
+        reader.readLongBE();
+        assertEquals(PbjReader.BUFFER_UNDERFLOW, reader.error());
+    }
+
+    @Test
+    void readBytesNegativeLengthSetsIllegalArgument() {
+        var reader = new PbjReader(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5}));
+        reader.readByte();
+        reader.readByte();
+        reader.limit(0);
+        var result = reader.readBytes(-1);
+        assertEquals(Bytes.EMPTY, result);
+        assertEquals(PbjReader.ILLEGAL_ARGUMENT, reader.error());
+    }
+}

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
@@ -930,17 +930,6 @@ public class PbjReaderWriterTest {
     }
 
     @Test
-    void quickTest() {
-        byte[] a = {2, 3};
-        var by = Bytes.wrap(a);
-        var adap = by.toReadableSequentialData();
-        var r = new PbjReader(adap);
-        var w = new PbjWriter();
-        w.setError(4, "");
-        int q = 0;
-    }
-
-    @Test
     void largeWriteBypassCorrectness() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PbjWriter writer = new PbjWriter(out);

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
@@ -1351,6 +1351,27 @@ public class PbjReaderWriterTest {
     }
 
     @Test
+    void readStringRejectsOverlong2ByteEncoding() {
+        var reader = new PbjReader(new byte[] {2, (byte) 0xC0, (byte) 0xAF});
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.PARSE, reader.error());
+    }
+
+    @Test
+    void readStringRejectsOverlong3ByteEncoding() {
+        var reader = new PbjReader(new byte[] {3, (byte) 0xE0, (byte) 0x80, (byte) 0xAF});
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.PARSE, reader.error());
+    }
+
+    @Test
+    void readStringRejectsOverlong4ByteEncoding() {
+        var reader = new PbjReader(new byte[] {4, (byte) 0xF0, (byte) 0x80, (byte) 0x80, (byte) 0xAF});
+        assertEquals("", reader.readString(Long.MAX_VALUE));
+        assertEquals(PbjReader.PARSE, reader.error());
+    }
+
+    @Test
     void readStringReturnsEmptyOnInsufficientData() {
         var reader = new PbjReader(new byte[] {5, 'a', 'b'}); // length=5 but only 2 bytes follow
         assertEquals("", reader.readString(Long.MAX_VALUE));

--- a/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
+++ b/pbj-core/pbj-runtime/src/test/java/com/hedera/pbj/runtime/io/buffer/PbjReaderWriterTest.java
@@ -1141,11 +1141,19 @@ public class PbjReaderWriterTest {
     }
 
     @Test
-    void resetWithOnNonReuseableWriterSetsError() {
+    void resetWithOnFixedArrayWriterLazilyOwnsABuffer() {
         byte[] buf = new byte[64];
         PbjWriter writer = new PbjWriter(buf, 0);
-        writer.resetWith(new ByteArrayOutputStream());
-        assertEquals(PbjWriter.USAGE_ERROR, writer.error());
+        writer.writeByte((byte) 1);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writer.resetWith(out);
+        assertEquals(0, writer.error());
+        assertEquals(1, buf[0]);
+
+        writer.writeByte((byte) 9);
+        writer.flush();
+        assertArrayEquals(new byte[] {9}, out.toByteArray());
+        assertEquals(1, buf[0]);
     }
 
     @Test

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/MaxSizeTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/MaxSizeTest.java
@@ -88,32 +88,22 @@ public class MaxSizeTest {
         final Bytes bytes = Everything.PROTOBUF.toBytes(everything);
 
         // Try negative cases first:
-        assertThrows(ParseException.class, () -> Everything.PROTOBUF.parse(bytes.toReadableSequentialData()));
+        assertThrows(ParseException.class, () -> Everything.PROTOBUF.parse(bytes));
         assertThrows(
                 ParseException.class,
-                () -> Everything.PROTOBUF.parse(
-                        bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, 256));
+                () -> Everything.PROTOBUF.parse(bytes, false, false, Codec.DEFAULT_MAX_DEPTH, 256));
         assertThrows(
                 ParseException.class,
-                () -> Everything.PROTOBUF.parse(
-                        bytes.toReadableSequentialData(),
-                        false,
-                        false,
-                        Codec.DEFAULT_MAX_DEPTH,
-                        Codec.DEFAULT_MAX_SIZE));
+                () -> Everything.PROTOBUF.parse(bytes, false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE));
         // +1 still shouldn't work because the outer and the inner objects are still larger:
         assertThrows(
                 ParseException.class,
                 () -> Everything.PROTOBUF.parse(
-                        bytes.toReadableSequentialData(),
-                        false,
-                        false,
-                        Codec.DEFAULT_MAX_DEPTH,
-                        Codec.DEFAULT_MAX_SIZE + 1));
+                        bytes, false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE + 1));
 
         // Now try supplying a large enough maxSize to parse it:
-        final Everything parsedEverything = Everything.PROTOBUF.parse(
-                bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE * 2);
+        final Everything parsedEverything =
+                Everything.PROTOBUF.parse(bytes, false, false, Codec.DEFAULT_MAX_DEPTH, Codec.DEFAULT_MAX_SIZE * 2);
 
         assertEquals(everything, parsedEverything);
     }

--- a/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnknownFieldsTest.java
+++ b/pbj-integration-tests/src/test/java/com/hedera/pbj/integration/test/UnknownFieldsTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.integration.EverythingTestData;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.UnknownField;
@@ -58,8 +59,7 @@ public class UnknownFieldsTest {
         final Bytes bytes2 = MessageWithBytes.PROTOBUF.toBytes(msg2);
 
         // now read it as MessageWithBytesAndString, w/o even enabling unknown fields
-        final MessageWithBytesAndString msg3 =
-                MessageWithBytesAndString.PROTOBUF.parse(bytes2.toReadableSequentialData());
+        final MessageWithBytesAndString msg3 = MessageWithBytesAndString.PROTOBUF.parse(bytes2.toPbjReader());
 
         assertEquals(msg1, msg3);
     }
@@ -77,8 +77,8 @@ public class UnknownFieldsTest {
         assertEquals(0, msgWithUnknownFieldsDisabled.getUnknownFields().size());
 
         // Now let's enable parsing unknown fields:
-        final MessageWithEverythingUnknownFields msg = MessageWithEverythingUnknownFields.PROTOBUF.parse(
-                everythingBytes.toReadableSequentialData(), false, true, 16);
+        final MessageWithEverythingUnknownFields msg =
+                MessageWithEverythingUnknownFields.PROTOBUF.parse(everythingBytes.toPbjReader(), false, true, 16);
 
         assertEquals(0, msg.knownField());
         assertEquals(65, msg.getUnknownFields().size());
@@ -108,7 +108,7 @@ public class UnknownFieldsTest {
 
         // then read it as MessageWithBytes with unknown fields
         final MessageWithBytes messageWithBytes = MessageWithBytes.PROTOBUF.parse(
-                messageWithBytesAndStringBytes.toReadableSequentialData(), false, true, 16);
+                messageWithBytesAndStringBytes, false, true, 16, Codec.DEFAULT_MAX_SIZE);
 
         final MessageWithBytesWrapper messageWithBytesWrapper = new MessageWithBytesWrapper(
                 new OneOf<>(MessageWithBytesWrapper.MessageValidOneOfType.MESSAGE_WITH_BYTES, messageWithBytes));
@@ -122,7 +122,7 @@ public class UnknownFieldsTest {
 
         // parse bytes back as a receiving user would and confirm unknown fields exist in inner message
         final MessageWithBytesWrapper parsedWrapper = MessageWithBytesWrapper.PROTOBUF.parse(
-                messageWithBytesWrapperBytes.toReadableSequentialData(), false, true, 16);
+                messageWithBytesWrapperBytes, false, true, 16, Codec.DEFAULT_MAX_SIZE);
         MessageWithBytes parsedBytes = parsedWrapper.messageWithBytes();
         assertFalse(parsedBytes.getUnknownFields().isEmpty());
         assertEquals(1, parsedBytes.getUnknownFields().size());
@@ -130,7 +130,7 @@ public class UnknownFieldsTest {
         // now confirm that user can retrieve unknown fields when using expanded message MessageWithBytesAndString
         final Bytes messageWithBytesBytes = MessageWithBytes.PROTOBUF.toBytes(parsedBytes);
         final MessageWithBytesAndString messageWithBytesAndStringParsed =
-                MessageWithBytesAndString.PROTOBUF.parse(messageWithBytesBytes.toReadableSequentialData());
+                MessageWithBytesAndString.PROTOBUF.parse(messageWithBytesBytes);
         assertTrue(messageWithBytesAndStringParsed.getUnknownFields().isEmpty());
         assertEquals(messageWithBytesAndString, messageWithBytesAndStringParsed);
     }


### PR DESCRIPTION
**Description**:

Overview: PbjReader/PbjWriter are a leaner, buffer-reusing alternative to the existing ReadableSequentialData/WritableSequentialData read/write path used by Codec, ProtoParserTools/ProtoWriterTools, and the pbj-compiler generators. They reuse an internal ~16KB (L1-cache-sized) buffer across many parse/write calls instead of allocating per call, avoid checked-exception-based control flow by recording a sticky internal error code instead, and split hot-path operations (e.g. zigzag vs. non-zigzag varints, direct UTF-8 decode into a reusable char[]) into dedicated fast methods.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
