### PR TITLE
feat: Add pbj.useUtils to allow projects to customize their codec.parse bytes impl

### DIFF
--- a/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
+++ b/pbj-core/pbj-compiler/src/main/java/com/hedera/pbj/compiler/impl/generators/ServiceGenerator.java
@@ -621,6 +621,13 @@ public final class ServiceGenerator {
         writer.addImport("java.util.concurrent.Flow");
         writer.addImport("java.util.concurrent.atomic.AtomicReference");
 
+        // Some generated code uses Codec.Parse Bytes overload.
+        // Some projects may want to use an alternative impl (such as using thread-locals)
+        String pbjUseUtils = System.getProperty("pbj.useUtils");
+        if (pbjUseUtils != null) {
+            writer.addImport(pbjUseUtils);
+        }
+
         rpcList.forEach(rpc -> {
             writer.addImport(rpc.requestTypePackage + "." + rpc.requestType);
             writer.addImport(rpc.replyTypePackage + "." + rpc.replyType);
@@ -773,6 +780,10 @@ public final class ServiceGenerator {
     }
 
     private static String formatParseRequestMethod(final String requestType) {
+        String parseLine = System.getProperty("pbj.useUtils") != null
+                ? "return PbjUtils.parse(get$simpleRequestTypeCodec(options), message, false, false, 16, options.maxMessageSizeBytes());"
+                : "return get$simpleRequestTypeCodec(options).parse(message, false, false, 16, options.maxMessageSizeBytes());";
+
         // spotless:off
         return """
                 @NonNull
@@ -781,9 +792,10 @@ public final class ServiceGenerator {
                     Objects.requireNonNull(options);
 
                     // not strict, no unknown fields, hard-code maxDepth for now, and use custom maxSize:
-                    return get$simpleRequestTypeCodec(options).parse(message, false, false, 16, options.maxMessageSizeBytes());
+                    $parseLine
                 }
                 """
+                .replace("$parseLine", parseLine)
                 .replace("$requestType", requestType)
                 .replace("$simpleRequestType", requestType.replace(".", ""))
                 ;

--- a/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
+++ b/pbj-core/pbj-runtime/src/main/java/com/hedera/pbj/runtime/io/buffer/PbjReader.java
@@ -219,6 +219,10 @@ public class PbjReader implements AutoCloseable {
         int position = bb.arrayOffset() + bb.position();
         resetWith(bb.array(), position, position + bb.remaining());
     }
+    /** Resets this reader to read from the given {@link Bytes}. */
+    public void resetWith(Bytes bytes) {
+        bytes.resetPbjReader(this);
+    }
 
     /*
      * fills the buffer from the stream repecting the set limit


### PR DESCRIPTION
**Description**:
The codec generator will create calls to `parse(Bytes)` and some projects may want to use thread-local storage. This commit adds an option that will generate PbjUtils.parse instead so those projects can use thread-local storage

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
